### PR TITLE
Defined sh:minCount and sh:maxCount without mention of default values

### DIFF
--- a/shacl/index.html
+++ b/shacl/index.html
@@ -140,6 +140,7 @@
 				The detailed list of changes and their diffs can be found in the <a href="https://github.com/w3c/data-shapes/commits/gh-pages/shacl/index.html">Git repository</a>.
 			</p>
 			<ul>
+				<li><b>2015-10-15</b>: Define sh:minCount and sh:maxCount without reference to default values</li>
 				<li><b>2015-10-15</b>: Use real-world names in examples 3, 4 and 5</li>
 				<li><b>2015-10-15</b>: Changed SPARQL definition of sh:AllObjects, implementing resolution to ISSUE-90</li>
 				<li><b>2015-10-09</b>: Added sh:flags and sh:uniqueLang</li>
@@ -1104,29 +1105,27 @@ ex:HasValueExampleValidResource
 						<tr>
 							<td><code>sh:minCount</code></td>
 							<td><code>xsd:integer</code></td>
-							<td>The minimum cardinality. Default value is 0.</td>
+							<td>The minimum cardinality. If the value is 0 then this constraint is always satisfied and so may be ommitted.</td>
 						</tr>
 						<tr>
 							<td><code>sh:maxCount</code></td>
 							<td><code>xsd:integer</code></td>
-							<td>The maximum cardinality. Default interpretation is unlimited.</td>
+							<td>The maximum cardinality. If this constraint is omitted then there is no limit on the number of triples.</td>
 						</tr>
 					</table>
 					<div class="def def-text">
-						<div class="def-header">TEXTUAL DEFINITION</div>
+						<div class="def-header">TEXTUAL DEFINITION of sh:minCount</div>
 						<div class="def-text-body">
-							The default value of <code>sh:minCount</code> is 0.
 							Let <code>?count</code> be the number of triples that have the <span class="term">focus node</span> as
-							the <span class="term">subject</span> and the <code>sh:predicate</code> as the <span class="term">predicate</span>.
-							A <span class="term">validation result</span> must be produced in either of the following cases:
-							If <code>?count</code> is less than the value of <code>sh:minCount</code>, or
-							if <code>sh:maxCount</code> is present and <code>?count</code> is greater than the value of <code>sh:maxCount</code>.
+							the <span class="term">subject</span> and the value of <code>sh:predicate</code> as the <span class="term">predicate</span>.
+							A <span class="term">validation result</span> must be produced
+							if <code>?count</code> is less than the value of <code>sh:minCount</code>.
 							The produced <span class="term">validation result</span> must have the <span class="term">focus node</span> as its <code>sh:subject</code>,
 							and the predicate as its <code>sh:predicate</code>. 
 						</div>
 					</div>
 					<div class="def def-sparql">
-						<div class="def-header">SPARQL DEFINITION</div>
+						<div class="def-header">SPARQL DEFINITION of sh:minCount</div>
 <pre class="def-sparql-body">
 SELECT $this ($this AS ?subject) $predicate
 WHERE {
@@ -1136,7 +1135,32 @@ WHERE {
 			$this $predicate ?value .
 		}
 	}
-	FILTER (?count &lt; $minCount || (bound($maxCount) &amp;&amp; ?count &gt; $maxCount))
+	FILTER (?count &lt; $minCount)
+}</pre>
+					</div>
+					<div class="def def-text">
+						<div class="def-header">TEXTUAL DEFINITION of sh:maxCount</div>
+						<div class="def-text-body">
+							Let <code>?count</code> be the number of triples that have the <span class="term">focus node</span> as
+							the <span class="term">subject</span> and the value of <code>sh:predicate</code> as the <span class="term">predicate</span>.
+							A <span class="term">validation result</span> must be produced 
+							if <code>?count</code> is greater than the value of <code>sh:maxCount</code>.
+							The produced <span class="term">validation result</span> must have the <span class="term">focus node</span> as its <code>sh:subject</code>,
+							and the predicate as its <code>sh:predicate</code>. 
+						</div>
+					</div>
+					<div class="def def-sparql">
+						<div class="def-header">SPARQL DEFINITION of sh:maxCount</div>
+<pre class="def-sparql-body">
+SELECT $this ($this AS ?subject) $predicate
+WHERE {
+	{
+		SELECT (COUNT(?value) AS ?count)
+		WHERE {
+			$this $predicate ?value .
+		}
+	}
+	FILTER (?count &gt; $maxCount))
 }</pre>
 					</div>
 					<pre class="example" title="Shape with sh:minCount and sh:maxCount constraints">


### PR DESCRIPTION
Split definitions and SPARQL.
