### PR TITLE
examples use tabular summary

### DIFF
--- a/shacl/index.html
+++ b/shacl/index.html
@@ -846,8 +846,11 @@ ex:PersonShape
 					<li>specified in any <a>constraint</a> that references a <a>shape</a>
 						in parameters of <a href="#constraints-shape">shape-based constraint components</a> (i.e. <code>sh:shape</code>) or
 						<a href="#constraints-shape">logical constraint components</a> (i.e. <code>sh:or</code>),</li>
-					<li>specified as input to the SHACL processor for validating specific nodes from the <a>data graph</a> against the shape</li>
+					<li>specified as input parameters to a validation function.</li>
 				</ul>
+        <p id="target-can-be-skipped">
+          In this document, target properties are indicated by the <span class="target-can-be-skipped">target-can-be-skipped</span> class indicating that they are not necessary for a validation function which accepts node and shape parameters.
+        </p>
 			</section>
 
 			<section id="targets">

--- a/shacl/index.html
+++ b/shacl/index.html
@@ -168,10 +168,10 @@
 			.example-results, .example-results:before, .example-results th, .example-results td { border: 1px solid #aca; }
 			pre.example-results:before { color: #797; content: "Example validation results"; width: 13em; }
 
-			div.example-results1 { background: #edb; }
+			div.example-results1 { background: #edb; margin-top:2.5ex; }
 			.example-results1, .example-results1:before, .example-results1 th, .example-results1 td { border: 1px solid #aca; }
 			.example-results1:before { color: #797; background-color: #fff; content: "Validation summary"; width: 13em; }
-			.example-results1:before { background: white; display: block; font-family: sans-serif; margin: -1em 0 0.4em -1em; padding: 0.2em 1em; }
+			.example-results1:before { background: white; display: block; font-family: sans-serif; font-size: 90%; margin: -.5em 0 0.4em -.25em; padding: 0.2em 1em; }
       .example-results1 table { border-collapse: collapse; }
       .example-results1 table td { padding: 0em .5em; }
       th.schema, .example-results1 td:nth-child(1) { background-color: #deb; }
@@ -1847,8 +1847,8 @@ ex:Alice ex:age "23"^^xsd:integer .
             <table>
               <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
               <tr class="pass"><td>ex:DatatypeExampleShape</td><td>ex:Alice</td><td>yes</td></tr>
-              <tr class="fail"><td>ex:DatatypeExampleShape</td><td>ex:Bob</td><td>no</td><td class="fail"><code>ex:age</code> has type xsd:string; expected xsd:integer.</td></tr>
-              <tr class="fail"><td>ex:DatatypeExampleShape</td><td>ex:Carol</td><td>no</td><td class="fail"><code>ex:age</code> has type xsd:int; expected xsd:integer.</td></tr>
+              <tr class="fail"><td>ex:DatatypeExampleShape</td><td>ex:Bob</td><td>no</td><td class="fail"><code>ex:age</code> has type xsd:string.</td></tr>
+              <tr class="fail"><td>ex:DatatypeExampleShape</td><td>ex:Carol</td><td>no</td><td class="fail"><code>ex:age</code> has type xsd:int.</td></tr>
             </table>
           </div>
 				</section>
@@ -2133,7 +2133,7 @@ ex:Bob ex:age 23 .
             <table>
               <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
               <tr class="pass"><td>ex:NumericRangeExampleShape</td><td>ex:Bob</td><td>yes</td></tr>
-              <tr class="fail"><td>ex:NumericRangeExampleShape</td><td>ex:Alice</td><td>no</td><td class="fail">expected <code>ex:age</code> to have a max value of 150.</td></tr>
+              <tr class="fail"><td>ex:NumericRangeExampleShape</td><td>ex:Alice</td><td>no</td><td class="fail">expected <code>ex:age</code> to have max value 150.</td></tr>
               <tr class="fail"><td>ex:NumericRangeExampleShape</td><td>ex:Ted</td><td>no</td><td class="fail">expected <code>ex:age</code> to be numeric.</td></tr>
             </table>
           </div>
@@ -2360,7 +2360,7 @@ ex:Alice ex:w3cHomepage &lt;https://www.w3.org/People/Alice&gt; .
               <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
               <tr class="pass"><td>ex:StemExampleShape</td><td>ex:Alice</td><td>yes</td></tr>
               <tr class="fail"><td>ex:StemExampleShape</td><td>ex:Bob</td><td>no</td><td class="fail"><code>ex:w3cHomepage</code> does not match stem.</td></tr>
-              <tr class="fail"><td>ex:StemExampleShape</td><td>ex:Carol</td><td>no</td><td class="fail"><code>ex:w3cHomepage</code> does not match stem.</td></tr>
+              <tr class="fail"><td>ex:StemExampleShape</td><td>ex:Carol</td><td>no</td><td class="fail"><code>ex:w3cHomepage</code> is not an IRI.</td></tr>
             </table>
           </div>
 				</section>
@@ -2514,7 +2514,7 @@ ex:Alice
             <table>
               <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
               <tr class="pass"><td>ex:UniqueLangExampleShape</td><td>ex:Alice</td><td>yes</td></tr>
-              <tr class="fail"><td>ex:UniqueLangExampleShape</td><td>ex:Bob</td><td>no</td><td class="fail">multiple <code>ex:label</code>s with the same language tag.</td></tr>
+              <tr class="fail"><td>ex:UniqueLangExampleShape</td><td>ex:Bob</td><td>no</td><td class="fail">multiple <code>ex:label</code>s with same language tag.</td></tr>
             </table>
           </div>
 				</section>
@@ -2884,7 +2884,6 @@ ex:SuperShape
 
 ex:ExampleAndShape
 	a sh:Shape ;
-	sh:targetNode ex:ValidInstance, ex:InvalidInstance ;
 	sh:and (
 		ex:SuperShape
 		[
@@ -2957,7 +2956,6 @@ ex:ValidInstance
 					<pre class="example-shapes">
 ex:OrConstraintExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:Bob ;
 	sh:or (
 		[
 			sh:property [
@@ -2973,7 +2971,19 @@ ex:OrConstraintExampleShape
 		]
 	) .</pre>
 					<pre class="example-data">
-ex:Bob ex:firstName "Robert" .</pre>
+ex:Alice ex:givenName "Alice" .
+ex:Bob ex:firstName "Robert" .
+<span class="focus-node-error">ex:Clair</span> ex:name "Clair" .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:OrConstraintExampleShape</td><td>ex:Alice</td><td>yes</td></tr>
+              <tr class="pass"><td>ex:OrConstraintExampleShape</td><td>ex:Bob</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:OrConstraintExampleShape</td><td>ex:Clair</td><td>no</td><td class="fail">must have a <code>ex:firstName</code> or <code>ex:givenName</code>.</td></tr>
+            </table>
+          </div>
+
 					<p>
 						The next example shows how <code>sh:or</code> can be used in a <a>property constraint</a> to state that the values of
 						the given property <code>ex:address</code> may be either literals with datatype <code>xsd:string</code>
@@ -2982,7 +2992,6 @@ ex:Bob ex:firstName "Robert" .</pre>
 					<pre class="example-shapes">
 ex:PersonAddressShape
 	a sh:Shape ;
-	sh:targetClass ex:Person ;
 	sh:property [
 		sh:predicate ex:address ;
 		sh:or (
@@ -2995,7 +3004,24 @@ ex:PersonAddressShape
 		)
 	] .</pre>
 					<pre class="example-data">
-ex:Bob ex:address "123 Prinzengasse, Vaduz, Liechtenstein" .</pre>
+ex:Alice ex:address [ a ex:Address ;
+  ex:street "1-14-19" ;
+  ex:city "湘南台" ;
+  ex:country "日本" ] .
+ex:Bob ex:address "123 Prinzengasse, Vaduz, Liechtenstein" .
+<span class="focus-node-error">ex:Claire</span> ex:address [
+  ex:street "улитса Декабристов, 55" ;
+  ex:city "Санкт-Петербург" ;
+  ex:country "Руссиа" ] .</pre>
+ 
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:PersonAddressShape</td><td>ex:Alice</td><td>yes</td></tr>
+              <tr class="pass"><td>ex:PersonAddressShape</td><td>ex:Bob</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:PersonAddressShape</td><td>ex:Clair</td><td>no</td><td class="fail"><code>ex:address</code> must be a string or an ex:Address.</td></tr>
+            </table>
+          </div>
 				</section>
 			</section>
 	
@@ -3056,12 +3082,25 @@ ex:ShapeExampleShape
 	] .</pre>
 
 					<pre class="example-data">
-ex:ShapeExampleValidResource
+ex:node1
 	ex:someProperty [
 		ex:nestedProperty 42 ;
+	] .
+
+<span class="focus-node-error">ex:node2</span>
+	ex:someProperty [
+		ex:otherProperty 43 ;
 	] .</pre>
+ 
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:ShapeExampleShape</td><td>ex:node1</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:ShapeExampleShape</td><td>ex:node2</td><td>no</td><td class="fail">expected 1 <code>ex:nestedProperty</code> property.</td></tr>
+            </table>
+          </div>
 				</section>
-				
+
 				<section id="QualifiedValueShapeConstraintComponent">
 					<h4>sh:qualifiedValueShape, sh:qualifiedMinCount, sh:qualifiedMaxCount</h4>
 					<div class="issue" data-number="92" title="Relationship of QCRs with Partitions">
@@ -3131,7 +3170,6 @@ ex:ShapeExampleValidResource
 					<pre class="example-shapes">
 ex:QualifiedValueShapeExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:QualifiedValueShapeExampleValidResource ;
 	sh:property [
 		sh:predicate ex:parent ;
 		sh:minCount 2 ;
@@ -3147,7 +3185,7 @@ ex:QualifiedValueShapeExampleShape
 	] .</pre>
 
 					<pre class="example-data">
-ex:QualifiedValueShapeExampleValidResource
+ex:node1
 	ex:parent ex:John ;
 	ex:parent ex:Jane .
 
@@ -3155,7 +3193,26 @@ ex:John
 	ex:gender ex:male .
 
 ex:Jane
-	ex:gender ex:female .</pre>
+	ex:gender ex:female .
+
+<span class="focus-node-error">ex:node2</span>
+	ex:parent ex:John .
+
+<span class="focus-node-error">ex:node3</span>
+	ex:parent ex:John ;
+	ex:parent ex:June .
+
+ex:June
+	ex:sex ex:male .</pre>
+ 
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:QualifiedValueShapeExampleShape</td><td>ex:node1</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:QualifiedValueShapeExampleShape</td><td>ex:node2</td><td>no</td><td class="fail"><code>ex:parent</code> fails min cardinality.</td></tr>
+              <tr class="fail"><td>ex:QualifiedValueShapeExampleShape</td><td>ex:node3</td><td>no</td><td class="fail">object of <code>ex:parent</code> not valid.</td></tr>
+            </table>
+          </div>
 				</section>
 				
 				<section id="PartitionConstraintComponent">
@@ -3340,7 +3397,6 @@ WHERE {
 					<pre class="example-shapes">
 ex:ClosedShapeExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:Alice, ex:Bob ;
 	sh:closed true ;
 	sh:ignoredProperties (rdf:type) ;
 	sh:property [
@@ -3357,6 +3413,14 @@ ex:Alice
 <span class="focus-node-error">ex:Bob</span>
 	ex:firstName "Bob" ;
 	ex:middleInitial "J" .</pre>
+ 
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:ClosedShapeExampleShape</td><td>ex:Alice</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:ClosedShapeExampleShape</td><td>ex:Bob</td><td>no</td><td class="fail">unexpected <code>ex:middleInitial</code> property.</td></tr>
+            </table>
+          </div>
 				</section>
 				
 				<section id="HasValueConstraintComponent">
@@ -3396,16 +3460,30 @@ WHERE {
 					<pre class="example-shapes">
 ex:StanfordGraduate
 	a sh:Shape ;
-	sh:targetNode ex:Alice ;
 	sh:property [
-		sh:predicate ex:alumniOf ;
+		sh:predicate ex:alumnusOf ;
 		sh:hasValue ex:Stanford ;
 	] .</pre>
 
 					<pre class="example-data">
 ex:Alice
-	ex:alumniOf ex:Harvard ;
-	ex:alumniOf ex:Stanford .</pre>
+	ex:alumnusOf ex:Stanford .
+
+ex:Bob
+	ex:alumnusOf ex:Harvard ;
+	ex:alumnusOf ex:Stanford .
+
+<span class="focus-node-error">ex:Claire</span>
+	ex:alumnusOf ex:Harvard .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:StanfordGraduate</td><td>ex:Alice</td><td>yes</td></tr>
+              <tr class="pass"><td>ex:StanfordGraduate</td><td>ex:Bob</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:StanfordGraduate</td><td>ex:Claire</td><td>no</td><td class="fail">expected 1 <code>ex:alumnusOf</code> ex:Stanford.</td></tr>
+            </table>
+          </div>
 				</section>
 				
 				<section id="InConstraintComponent">
@@ -3451,14 +3529,24 @@ ASK {
 					<pre class="example-shapes">
 ex:InExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:RainbowPony ;
 	sh:property [
 		sh:predicate ex:color ;
 		sh:in ( ex:Pink ex:Purple ) ;
 	] .</pre>
 
 					<pre class="example-data">
-ex:RainbowPony ex:color ex:Pink .</pre>
+ex:pony1 ex:color ex:Pink .
+<span class="focus-node-error">ex:pony2</span> ex:color ex:Blue .
+<span class="focus-node-error">ex:pony3</span> ex:color ex:Pink, ex:Blue .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:InExampleShape</td><td>ex:pony1</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:InExampleShape</td><td>ex:pony2</td><td>no</td><td class="fail">unrecognized <code>ex:color</code> ex:Blue.</td></tr>
+              <tr class="fail"><td>ex:InExampleShape</td><td>ex:pony3</td><td>no</td><td class="fail">unrecognized <code>ex:color</code> ex:Blue.</td></tr>
+            </table>
+          </div>
 				</section>
 			</section>
 				
@@ -3623,6 +3711,14 @@ ex:ValidCountry a ex:Country ;
   
 <span class="focus-node-error">ex:InvalidCountry</span> a ex:Country ;
 	ex:germanLabel "Spain"@en .</pre>
+
+        <div class="example-results1">
+          <table>
+            <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+            <tr class="pass"><td>ex:LanguageExampleShape</td><td>ex:ValidCountry</td><td>yes</td></tr>
+            <tr class="fail"><td>ex:LanguageExampleShape</td><td>ex:InvalidCountry</td><td>no</td><td class="fail">expected <code>ex:germanLabel</code> with "@de".</td></tr>
+          </table>
+        </div>
 				<pre class="example-shapes" id="example-sparql-constraint">
 ex:LanguageExampleShape
 	a sh:Shape ;
@@ -3914,6 +4010,14 @@ ex:ExampleRootResource
 ex:ExampleValueResource
 	ex:property2 ex:ExampleIntermediateResource .
 </pre>
+
+        <div class="example-results1">
+          <table>
+            <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+            <tr class="fail"><td>ex:ShapeWithPathViolationExample</td><td>ex:ExampleRootResource</td><td>yes</td><td class="fail">sh:sparql error.</td></tr>
+            <tr class="pass"><td>ex:ShapeWithPathViolationExample</td><td>ex:ExampleValueResource</td><td>no</td></tr>
+          </table>
+        </div>
 				<p>
 					Which produces the following validation result nodes:
 				</p>

--- a/shacl/index.html
+++ b/shacl/index.html
@@ -547,9 +547,9 @@
         </p>
         <div class="example-results1">
         <table>
-          <tr><th class="schema">shape</th><th class="data">node</th><th>result</th><th>reason</th></tr>
-          <tr class="pass"><td>&lt;Shape1&gt;</td><td>&lt;node1&gt;</td><td>pass</td></tr>
-          <tr class="fail"><td>&lt;Shape1&gt;</td><td>&lt;node2&gt;</td><td>fail</td><td class="fail">no <code>ex:state</code> supplied.</td></tr>
+          <tr><th class="schema">shape</th><th class="data">node</th><th>valid</th><th>reason</th></tr>
+          <tr class="pass"><td>&lt;Shape1&gt;</td><td>&lt;node1&gt;</td><td>yes</td></tr>
+          <tr class="fail"><td>&lt;Shape1&gt;</td><td>&lt;node2&gt;</td><td>no</td><td class="fail">no <code>ex:state</code> supplied.</td></tr>
         </table>
         </div>
         <p>
@@ -681,11 +681,11 @@ ex:PersonShape
 				</p>
         <div class="example-results1">
         <table>
-          <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-          <tr class="fail"><td>ex:PersonShape</td><td>&lt;Alice&gt;</td><td>fail</td><td class="fail"><code>ex:ssn</code> "987-65-432A" does not match pattern.</td></tr>
-          <tr class="fail"><td>ex:PersonShape</td><td>&lt;Bob&gt;</td><td>fail</td><td class="fail">cardinality of <code>ex:state</code> exceeds 1.</td></tr>
-          <tr class="fail"><td>ex:PersonShape</td><td>&lt;Calvin&gt;</td><td>fail</td><td class="fail">unexpected <code>ex:school</code> in closed shape.</td></tr>
-          <tr class="pass"><td>ex:PersonShape</td><td>&lt;Danielle&gt;</td><td>pass</td></tr>
+          <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+          <tr class="fail"><td>ex:PersonShape</td><td>&lt;Alice&gt;</td><td>no</td><td class="fail"><code>ex:ssn</code> "987-65-432A" does not match pattern.</td></tr>
+          <tr class="fail"><td>ex:PersonShape</td><td>&lt;Bob&gt;</td><td>no</td><td class="fail">cardinality of <code>ex:state</code> exceeds 1.</td></tr>
+          <tr class="fail"><td>ex:PersonShape</td><td>&lt;Calvin&gt;</td><td>no</td><td class="fail">unexpected <code>ex:school</code> in closed shape.</td></tr>
+          <tr class="pass"><td>ex:PersonShape</td><td>&lt;Danielle&gt;</td><td>yes</td></tr>
         </table>
         </div>
 				<p>
@@ -1084,10 +1084,10 @@ ex:Bob
 
         <div class="example-results1">
         <table>
-          <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-          <tr class="pass"><td>ex:ExampleFilteredShape</td><td>&lt;Alice&gt;</td><td>pass</td></tr>
-          <tr class="fail"><td>ex:ExampleFilteredShape</td><td>&lt;John&gt;</td><td>fail</td><td class="fail">cardinality of <code>ex:email</code> less than 1.</td></tr>
-          <tr class="pass"><td>ex:ExampleFilteredShape</td><td>&lt;Bob&gt;</td><td>pass</td></tr>
+          <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+          <tr class="pass"><td>ex:ExampleFilteredShape</td><td>&lt;Alice&gt;</td><td>yes</td></tr>
+          <tr class="fail"><td>ex:ExampleFilteredShape</td><td>&lt;John&gt;</td><td>no</td><td class="fail">cardinality of <code>ex:email</code> less than 1.</td></tr>
+          <tr class="pass"><td>ex:ExampleFilteredShape</td><td>&lt;Bob&gt;</td><td>yes</td></tr>
         </table>
         </div>
 				<pre class="example-results">
@@ -1388,8 +1388,8 @@ ex:MyInstance
 	ex:myProperty "http://toomanycharacters"^^xsd:anyURI .</pre>
         <div class="example-results1">
         <table>
-          <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-          <tr class="fail"><td>ex:MyShape</td><td>ex:MyInstance</td><td>fail</td><td class="fail">length of <code>ex:myProperty</code> exceeds maxLength 10.</td></tr>
+          <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+          <tr class="fail"><td>ex:MyShape</td><td>ex:MyInstance</td><td>no</td><td class="fail">length of <code>ex:myProperty</code> exceeds maxLength 10.</td></tr>
         </table>
         </div>
 					<pre class="example-results">
@@ -1786,10 +1786,10 @@ ex:Alice a ex:Person .
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="pass"><td>ex:ClassExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
-              <tr class="fail"><td>ex:ClassExampleShape</td><td>ex:Bob</td><td>fail</td><td class="fail">expected to be in class <code>ex:Person</code>.</td></tr>
-              <tr class="fail"><td>ex:ClassExampleShape</td><td>ex:Carol</td><td>fail</td><td class="fail">expected to be in class <code>ex:Person</code>.</td></tr>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:ClassExampleShape</td><td>ex:Alice</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:ClassExampleShape</td><td>ex:Bob</td><td>no</td><td class="fail">expected to be in class <code>ex:Person</code>.</td></tr>
+              <tr class="fail"><td>ex:ClassExampleShape</td><td>ex:Carol</td><td>no</td><td class="fail">expected to be in class <code>ex:Person</code>.</td></tr>
             </table>
           </div>
 				</section>
@@ -1845,10 +1845,10 @@ ex:Alice ex:age "23"^^xsd:integer .
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="pass"><td>ex:DatatypeExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
-              <tr class="fail"><td>ex:DatatypeExampleShape</td><td>ex:Bob</td><td>fail</td><td class="fail"><code>ex:age</code> has type xsd:string; expected xsd:integer.</td></tr>
-              <tr class="fail"><td>ex:DatatypeExampleShape</td><td>ex:Carol</td><td>fail</td><td class="fail"><code>ex:age</code> has type xsd:int; expected xsd:integer.</td></tr>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:DatatypeExampleShape</td><td>ex:Alice</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:DatatypeExampleShape</td><td>ex:Bob</td><td>no</td><td class="fail"><code>ex:age</code> has type xsd:string; expected xsd:integer.</td></tr>
+              <tr class="fail"><td>ex:DatatypeExampleShape</td><td>ex:Carol</td><td>no</td><td class="fail"><code>ex:age</code> has type xsd:int; expected xsd:integer.</td></tr>
             </table>
           </div>
 				</section>
@@ -1907,9 +1907,9 @@ ex:Bob ex:knows ex:Alice .
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="fail"><td>ex:NodeKindExampleShape</td><td>ex:Alice</td><td>fail</td><td class="fail"><code>ex:knows</code> expected to be an RDF IRI.</td></tr>
-              <tr class="pass"><td>ex:NodeKindExampleShape</td><td>ex:Bob</td><td>pass</td></tr>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="fail"><td>ex:NodeKindExampleShape</td><td>ex:Alice</td><td>no</td><td class="fail"><code>ex:knows</code> expected to be an RDF IRI.</td></tr>
+              <tr class="pass"><td>ex:NodeKindExampleShape</td><td>ex:Bob</td><td>yes</td></tr>
             </table>
           </div>
 				</section>
@@ -1978,9 +1978,9 @@ ex:Alice ex:name "Alice" .
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="pass"><td>ex:MinCountExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
-              <tr class="fail"><td>ex:MinCountExampleShape</td><td>ex:Bob</td><td>fail</td><td class="fail">expected 1 <code>ex:name</code>.</td></tr>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:MinCountExampleShape</td><td>ex:Alice</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:MinCountExampleShape</td><td>ex:Bob</td><td>no</td><td class="fail">expected 1 <code>ex:name</code>.</td></tr>
             </table>
           </div>
 				</section>
@@ -2039,9 +2039,9 @@ ex:Alice ex:birthDate "May 5th 1990" .
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="pass"><td>ex:MaxCountExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
-              <tr class="fail"><td>ex:MaxCountExampleShape</td><td>ex:Bob</td><td>fail</td><td class="fail">expected 1 <code>ex:birthDate</code>.</td></tr>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:MaxCountExampleShape</td><td>ex:Alice</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:MaxCountExampleShape</td><td>ex:Bob</td><td>no</td><td class="fail">expected 1 <code>ex:birthDate</code>.</td></tr>
             </table>
           </div>
 			</section>
@@ -2131,10 +2131,10 @@ ex:Bob ex:age 23 .
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="pass"><td>ex:NumericRangeExampleShape</td><td>ex:Bob</td><td>pass</td></tr>
-              <tr class="fail"><td>ex:NumericRangeExampleShape</td><td>ex:Alice</td><td>fail</td><td class="fail">expected <code>ex:age</code> to have a max value of 150.</td></tr>
-              <tr class="fail"><td>ex:NumericRangeExampleShape</td><td>ex:Ted</td><td>fail</td><td class="fail">expected <code>ex:age</code> to be numeric.</td></tr>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:NumericRangeExampleShape</td><td>ex:Bob</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:NumericRangeExampleShape</td><td>ex:Alice</td><td>no</td><td class="fail">expected <code>ex:age</code> to have a max value of 150.</td></tr>
+              <tr class="fail"><td>ex:NumericRangeExampleShape</td><td>ex:Ted</td><td>no</td><td class="fail">expected <code>ex:age</code> to be numeric.</td></tr>
             </table>
           </div>
 			</section>
@@ -2236,9 +2236,9 @@ ex:Bob ex:password "123456789" .
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="pass"><td>ex:PasswordExampleShape</td><td>ex:Bob</td><td>pass</td></tr>
-              <tr class="fail"><td>ex:PasswordExampleShape</td><td>ex:Alice</td><td>fail</td><td class="fail"><code>ex:password</code> more than 10 characters.</td></tr>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:PasswordExampleShape</td><td>ex:Bob</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:PasswordExampleShape</td><td>ex:Alice</td><td>no</td><td class="fail"><code>ex:password</code> more than 10 characters.</td></tr>
             </table>
           </div>
 				</section>
@@ -2300,10 +2300,10 @@ ex:Alice ex:bCode "B102" .
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="pass"><td>ex:PatternExampleShape</td><td>ex:Bob</td><td>pass</td></tr>
-              <tr class="pass"><td>ex:PatternExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
-              <tr class="fail"><td>ex:PatternExampleShape</td><td>ex:Carol</td><td>fail</td><td class="fail"><code>ex:bCode</code> does not match pattern.</td></tr>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:PatternExampleShape</td><td>ex:Bob</td><td>yes</td></tr>
+              <tr class="pass"><td>ex:PatternExampleShape</td><td>ex:Alice</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:PatternExampleShape</td><td>ex:Carol</td><td>no</td><td class="fail"><code>ex:bCode</code> does not match pattern.</td></tr>
             </table>
           </div>
 				</section>
@@ -2357,10 +2357,10 @@ ex:Alice ex:w3cHomepage &lt;https://www.w3.org/People/Alice&gt; .
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="pass"><td>ex:StemExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
-              <tr class="fail"><td>ex:StemExampleShape</td><td>ex:Bob</td><td>fail</td><td class="fail"><code>ex:w3cHomepage</code> does not match stem.</td></tr>
-              <tr class="fail"><td>ex:StemExampleShape</td><td>ex:Carol</td><td>fail</td><td class="fail"><code>ex:w3cHomepage</code> does not match stem.</td></tr>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:StemExampleShape</td><td>ex:Alice</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:StemExampleShape</td><td>ex:Bob</td><td>no</td><td class="fail"><code>ex:w3cHomepage</code> does not match stem.</td></tr>
+              <tr class="fail"><td>ex:StemExampleShape</td><td>ex:Carol</td><td>no</td><td class="fail"><code>ex:w3cHomepage</code> does not match stem.</td></tr>
             </table>
           </div>
 				</section>
@@ -2437,9 +2437,9 @@ ex:Mountain
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="pass"><td>ex:NewZealandLanguagesShape</td><td>ex:Mountain</td><td>pass</td></tr>
-              <tr class="fail"><td>ex:NewZealandLanguagesShape</td><td>ex:Berg</td><td>fail</td><td class="fail">"Berg" does not have a language tag.<br/>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:NewZealandLanguagesShape</td><td>ex:Mountain</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:NewZealandLanguagesShape</td><td>ex:Berg</td><td>no</td><td class="fail">"Berg" does not have a language tag.<br/>
               @de does not match language choice.<br/>
               ex:BergLabel is not a literal.</td></tr>
             </table>
@@ -2512,9 +2512,9 @@ ex:Alice
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="pass"><td>ex:UniqueLangExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
-              <tr class="fail"><td>ex:UniqueLangExampleShape</td><td>ex:Bob</td><td>fail</td><td class="fail">multiple <code>ex:label</code>s with the same language tag.</td></tr>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:UniqueLangExampleShape</td><td>ex:Alice</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:UniqueLangExampleShape</td><td>ex:Bob</td><td>no</td><td class="fail">multiple <code>ex:label</code>s with the same language tag.</td></tr>
             </table>
           </div>
 				</section>
@@ -2599,9 +2599,9 @@ ex:Bob
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="pass"><td>ex:EqualExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
-              <tr class="fail"><td>ex:EqualExampleShape</td><td>ex:Bob</td><td>fail</td><td class="fail"><code>ex:firstName</code> does not match <code>ex:givenName</code>.</td></tr>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:EqualExampleShape</td><td>ex:Alice</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:EqualExampleShape</td><td>ex:Bob</td><td>no</td><td class="fail"><code>ex:firstName</code> does not match <code>ex:givenName</code>.</td></tr>
             </table>
           </div>
 				</section>
@@ -2665,9 +2665,9 @@ ex:USA
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="pass"><td>ex:DisjointExampleShape</td><td>ex:USA</td><td>pass</td></tr>
-              <tr class="fail"><td>ex:DisjointExampleShape</td><td>ex:Germany</td><td>fail</td><td class="fail"><code>ex:prefLabel</code> must not equal <code>ex:altLabel</code>.</td></tr>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:DisjointExampleShape</td><td>ex:USA</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:DisjointExampleShape</td><td>ex:Germany</td><td>no</td><td class="fail"><code>ex:prefLabel</code> must not equal <code>ex:altLabel</code>.</td></tr>
             </table>
           </div>
 				</section>
@@ -2825,9 +2825,9 @@ ex:ValidInstance ex:property2 "Some value" .</pre>
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="fail"><td>ex:NotExampleShape</td><td>ex:InvalidInstance</td><td>fail</td><td class="fail">must not have a <code>ex:property1</code>.</td></tr>
-              <tr class="pass"><td>ex:NotExampleShape</td><td>ex:ValidInstance</td><td>pass</td></tr>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="fail"><td>ex:NotExampleShape</td><td>ex:InvalidInstance</td><td>no</td><td class="fail">must not have a <code>ex:property1</code>.</td></tr>
+              <tr class="pass"><td>ex:NotExampleShape</td><td>ex:ValidInstance</td><td>yes</td></tr>
             </table>
           </div>
 				</section>
@@ -2907,9 +2907,9 @@ ex:ValidInstance
 
           <div class="example-results1">
             <table>
-              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
-              <tr class="pass"><td>ex:ExampleAndShape</td><td>ex:ValidInstance</td><td>pass</td></tr>
-              <tr class="fail"><td>ex:ExampleAndShape</td><td>ex:InvalidInstance</td><td>fail</td><td class="fail">must have only 1 <code>ex:property</code>.</td></tr>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>valid</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:ExampleAndShape</td><td>ex:ValidInstance</td><td>yes</td></tr>
+              <tr class="fail"><td>ex:ExampleAndShape</td><td>ex:InvalidInstance</td><td>no</td><td class="fail">must have only 1 <code>ex:property</code>.</td></tr>
             </table>
           </div>
 				</section>

--- a/shacl/index.html
+++ b/shacl/index.html
@@ -543,7 +543,7 @@
 <span class="focus-node-error">ex:Alice</span> a ex:Person .</pre>
 
         <p>
-          Results of validation are summarized in a table associating node/shape pairs with a pass or fail and an informal explanation for failure:
+          In examples, the results of validation are summarized in a table associating node/shape pairs with a pass or fail and an informal explanation for failure:
         </p>
         <div class="example-results1">
         <table>

--- a/shacl/index.html
+++ b/shacl/index.html
@@ -168,6 +168,17 @@
 			.example-results, .example-results:before, .example-results th, .example-results td { border: 1px solid #aca; }
 			pre.example-results:before { color: #797; content: "Example validation results"; width: 13em; }
 
+			div.example-results1 { background: #edb; }
+			.example-results1, .example-results1:before, .example-results1 th, .example-results1 td { border: 1px solid #aca; }
+			.example-results1:before { color: #797; background-color: #fff; content: "Validation summary"; width: 13em; }
+			.example-results1:before { background: white; display: block; font-family: sans-serif; margin: -1em 0 0.4em -1em; padding: 0.2em 1em; }
+      .example-results1 table { border-collapse: collapse; }
+      .example-results1 table td { padding: 0em .5em; }
+      th.schema, .example-results1 td:nth-child(1) { background-color: #deb; }
+      th.data  , .example-results1 td:nth-child(2) { background-color: #eeb; }
+      .pass     { background-color: #cfc; }
+      .fail     { background-color: #fcc; }
+
 			/* our syntax menu for switching */
 			div.syntaxmenu {
 				border: 1px dotted black;
@@ -531,8 +542,28 @@
 # Elements highlighted in red are focus nodes that fail <a href="#validation">validation</a>
 <span class="focus-node-error">ex:Alice</span> a ex:Person .</pre>
 
+        <p>
+          Results of validation are summarized in a table associating node/shape pairs with a pass or fail and an informal explanation for failure:
+        </p>
+        <div class="example-results1">
+        <table>
+          <tr><th class="schema">shape</th><th class="data">node</th><th>result</th><th>reason</th></tr>
+          <tr class="pass"><td>&lt;Shape1&gt;</td><td>&lt;node1&gt;</td><td>pass</td></tr>
+          <tr class="fail"><td>&lt;Shape1&gt;</td><td>&lt;node2&gt;</td><td>fail</td><td class="fail">no <code>ex:state</code> supplied.</td></tr>
+        </table>
+        </div>
+        <p>
+          RDF output from validation is expressed in Turtle:
+        </p>
 				<pre class="example-results">
-# This box represents an output results graph</pre>
+[	a sh:ValidationResult ;
+	sh:sourceConstraintComponent sh:RegexConstraintComponent ;
+	sh:sourceShape ex:PersonShape ;
+	sh:focusNode ex:Alice ;
+	sh:path ex:ssn ;
+	sh:value "987-65-432A" ;
+	sh:severity sh:Violation ;
+] .</pre>
 
 				<p>
 					SHACL Definitions appear in blue boxes:
@@ -586,7 +617,12 @@ ex:Bob
   
 ex:Calvin
 	a ex:Person ;
-	ex:school ex:TrinityAnglicanSchool .</pre>
+	ex:school ex:TrinityAnglicanSchool .
+
+ex:Danielle
+  a ex:Person ;
+  ex:ssn "123-45-6789" .
+</pre>
 				<p>
 					SHACL can be used to define the following example <a>constraints</a>:
 				<p>
@@ -638,12 +674,20 @@ ex:PersonShape
 	sh:ignoredProperties ( rdf:type ) .</pre>
 				<p>
 					We can use the shape definition above to illustrate some of the key terminology used by SHACL.
-					The <a>focus nodes</a> for the <a>shape</a> <code>ex:PersonShape</code> are all <a>SHACL instances</a> of the <a>class</a> <code>ex:Person</code>.
-					These <a>focus nodes</a> are the <a>targets</a> of the <a>shape</a> and are defined using the property <code>sh:targetClass</code>.
 					The <a>shape</a> defines three <a>property constraints</a> with the property <code>sh:property</code>,
 					one of which uses a <a>path</a> expression.
 					The <a>shape</a> defines a further constraint on the <a>focus nodes</a> using the <a>parameters</a> <code>sh:closed</code> and <code>sh:ignoredProperties</code>.
+					Validation is performed on <a>focus nodes</a>; the results are summarized here:
 				</p>
+        <div class="example-results1">
+        <table>
+          <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+          <tr class="fail"><td>ex:PersonShape</td><td>&lt;Alice&gt;</td><td>fail</td><td class="fail"><code>ex:ssn</code> "987-65-432A" does not match pattern.</td></tr>
+          <tr class="fail"><td>ex:PersonShape</td><td>&lt;Bob&gt;</td><td>fail</td><td class="fail">cardinality of <code>ex:state</code> exceeds 1.</td></tr>
+          <tr class="fail"><td>ex:PersonShape</td><td>&lt;Calvin&gt;</td><td>fail</td><td class="fail">unexpected <code>ex:school</code> in closed shape.</td></tr>
+          <tr class="pass"><td>ex:PersonShape</td><td>&lt;Danielle&gt;</td><td>pass</td></tr>
+        </table>
+        </div>
 				<p>
 					Some of the <a>property constraints</a> specify parameters from multiple <a>constraint components</a> in order to
 					restrict multiple aspects of the <a>property values</a>.
@@ -1017,7 +1061,6 @@ WHERE {
 				<pre class="example-shapes">
 ex:ExampleFilteredShape
 	a sh:Shape ;
-	sh:targetClass ex:Person ;
 	sh:filterShape [
 		<span style="color: grey;">a sh:Shape ; # Optional triple</span>
 		sh:property [
@@ -1031,14 +1074,22 @@ ex:ExampleFilteredShape
 	] .</pre>
 
 <pre class="example-data">
-<span class="focus-node-selected">ex:Alice</span> a ex:Person ;
+<span class="focus-node-selected">ex:Alice</span>
 	ex:member ex:W3c ;
 	ex:email &lt;mailto:alice@example.org&gt; .
-<span class="focus-node-selected">ex:John</span> a ex:Person ;
+<span class="focus-node-selected">ex:John</span>
 	ex:member ex:W3c .
-ex:Bob a ex:Person ;
+ex:Bob
 	ex:member ex:Acme .</pre>
 
+        <div class="example-results1">
+        <table>
+          <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+          <tr class="pass"><td>ex:ExampleFilteredShape</td><td>&lt;Alice&gt;</td><td>pass</td></tr>
+          <tr class="fail"><td>ex:ExampleFilteredShape</td><td>&lt;John&gt;</td><td>fail</td><td class="fail">cardinality of <code>ex:email</code> less than 1.</td></tr>
+          <tr class="pass"><td>ex:ExampleFilteredShape</td><td>&lt;Bob&gt;</td><td>pass</td></tr>
+        </table>
+        </div>
 				<pre class="example-results">
 [  a sh:ValidationResult ;
 	sh:severity sh:Violation ;
@@ -1318,7 +1369,6 @@ ex:parent sh:alternativePath ( ex:father ex:mother  ) .</pre>
 					<pre class="example-shapes">
 ex:MyShape
 	a sh:Shape ;
-	sh:targetNode ex:MyInstance ;
 	sh:property [
 		# Violations of sh:minCount and sh:datatype are produced as warnings
 		sh:predicate ex:myProperty ;
@@ -1336,6 +1386,12 @@ ex:MyShape
 					<pre class="example-data">
 ex:MyInstance
 	ex:myProperty "http://toomanycharacters"^^xsd:anyURI .</pre>
+        <div class="example-results1">
+        <table>
+          <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+          <tr class="fail"><td>ex:MyShape</td><td>ex:MyInstance</td><td>fail</td><td class="fail">length of <code>ex:myProperty</code> exceeds maxLength 10.</td></tr>
+        </table>
+        </div>
 					<pre class="example-results">
 [
 	a sh:ValidationResult ;
@@ -1718,7 +1774,6 @@ ASK {
 					<pre class="example-shapes">
 ex:ClassExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:Bob, ex:Alice, ex:Carol ;
 	sh:property [
 		sh:predicate ex:knows ;
 		sh:class ex:Person ;
@@ -1726,8 +1781,17 @@ ex:ClassExampleShape
 
 					<pre class="example-data">
 ex:Alice a ex:Person .
-ex:Bob ex:knows ex:Alice .
+<span class="focus-node-error">ex:Bob</span> ex:knows ex:Alice .
 <span class="focus-node-error">ex:Carol</span> ex:knows ex:Bob .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:ClassExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
+              <tr class="fail"><td>ex:ClassExampleShape</td><td>ex:Bob</td><td>fail</td><td class="fail">expected to be in class <code>ex:Person</code>.</td></tr>
+              <tr class="fail"><td>ex:ClassExampleShape</td><td>ex:Carol</td><td>fail</td><td class="fail">expected to be in class <code>ex:Person</code>.</td></tr>
+            </table>
+          </div>
 				</section>
 				
 				<section id="DatatypeConstraintComponent">
@@ -1769,7 +1833,6 @@ ASK {
 					<pre class="example-shapes" title="Shape with sh:datatype property constraint">
 ex:DatatypeExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:Alice, ex:Bob, ex:Carol ;
 	sh:property [
 		sh:predicate ex:age ;
 		sh:datatype xsd:integer ;
@@ -1779,6 +1842,15 @@ ex:DatatypeExampleShape
 ex:Alice ex:age "23"^^xsd:integer .
 <span class="focus-node-error">ex:Bob</span> ex:age "twenty two" .
 <span class="focus-node-error">ex:Carol</span> ex:age "23"^^xsd:int .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:DatatypeExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
+              <tr class="fail"><td>ex:DatatypeExampleShape</td><td>ex:Bob</td><td>fail</td><td class="fail"><code>ex:age</code> has type xsd:string; expected xsd:integer.</td></tr>
+              <tr class="fail"><td>ex:DatatypeExampleShape</td><td>ex:Carol</td><td>fail</td><td class="fail"><code>ex:age</code> has type xsd:int; expected xsd:integer.</td></tr>
+            </table>
+          </div>
 				</section>
 				
 				<section id="NodeKindConstraintComponent">
@@ -1824,7 +1896,6 @@ ASK {
 					<pre class="example-shapes">
 ex:NodeKindExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:Bob, ex:Alice ;
 	sh:property [
 		sh:predicate ex:knows ;
 		sh:nodeKind ex:IRI ;
@@ -1833,6 +1904,14 @@ ex:NodeKindExampleShape
 					<pre class="example-data">
 ex:Bob ex:knows ex:Alice .
 <span class="focus-node-error">ex:Alice</span> ex:knows "Bob" .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="fail"><td>ex:NodeKindExampleShape</td><td>ex:Alice</td><td>fail</td><td class="fail"><code>ex:knows</code> expected to be an RDF IRI.</td></tr>
+              <tr class="pass"><td>ex:NodeKindExampleShape</td><td>ex:Bob</td><td>pass</td></tr>
+            </table>
+          </div>
 				</section>
 			</section>
 
@@ -1888,7 +1967,6 @@ HAVING (COUNT(DISTINCT ?value) &lt; $minCount)</pre>
 					<pre class="example-shapes">
 ex:MinCountExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:Alice, ex:Bob ;
 	sh:property [
 		sh:predicate ex:name ;
 		sh:minCount 1 ;
@@ -1897,6 +1975,14 @@ ex:MinCountExampleShape
 					<pre class="example-data">
 ex:Alice ex:name "Alice" .
 <span class="focus-node-error">ex:Bob</span> ex:givenName "Bob"@en .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:MinCountExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
+              <tr class="fail"><td>ex:MinCountExampleShape</td><td>ex:Bob</td><td>fail</td><td class="fail">expected 1 <code>ex:name</code>.</td></tr>
+            </table>
+          </div>
 				</section>
 				
 				<section id="MaxCountConstraintComponent">
@@ -1941,15 +2027,23 @@ HAVING (COUNT(DISTINCT ?value) > $maxCount)</pre>
 					<pre class="example-shapes">
 ex:MaxCountExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:Bob ;
 	sh:property [
 		sh:predicate ex:birthDate ;
 		sh:maxCount 1 ;
 	] .</pre>
 
 					<pre class="example-data">
-ex:Bob ex:birthDate "May 5th 1990" .</pre>
+ex:Alice ex:birthDate "May 5th 1990" .
+<span class="focus-node-error">ex:Bob</span> ex:birthDate "May 5th 1990", "1990-05-05"^^xsd:date .</pre>
 				</section>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:MaxCountExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
+              <tr class="fail"><td>ex:MaxCountExampleShape</td><td>ex:Bob</td><td>fail</td><td class="fail">expected 1 <code>ex:birthDate</code>.</td></tr>
+            </table>
+          </div>
 			</section>
 			
 			<section id="constraints-range">
@@ -2023,7 +2117,6 @@ ASK {
 					<pre class="example-shapes">
 ex:NumericRangeExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:Bob, ex:Alice, ex:Ted ;
 	sh:property [
 		sh:predicate ex:age ;
 		sh:minInclusive 0 ;
@@ -2035,6 +2128,15 @@ ex:Bob ex:age 23 .
 <span class="focus-node-error">ex:Alice</span> ex:age 220 .
 <span class="focus-node-error">ex:Ted</span> ex:age "twenty one" .</pre>
 				</section>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:NumericRangeExampleShape</td><td>ex:Bob</td><td>pass</td></tr>
+              <tr class="fail"><td>ex:NumericRangeExampleShape</td><td>ex:Alice</td><td>fail</td><td class="fail">expected <code>ex:age</code> to have a max value of 150.</td></tr>
+              <tr class="fail"><td>ex:NumericRangeExampleShape</td><td>ex:Ted</td><td>fail</td><td class="fail">expected <code>ex:age</code> to be numeric.</td></tr>
+            </table>
+          </div>
 			</section>
 
 			<section id="constraints-string">
@@ -2122,7 +2224,6 @@ ASK {
 					<pre class="example-shapes">
 ex:PasswordExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:Bob, ex:Alice ;
 	sh:property [
 		sh:predicate ex:password ;
 		sh:minLength 8 ;
@@ -2132,6 +2233,14 @@ ex:PasswordExampleShape
 					<pre class="example-data">
 ex:Bob ex:password "123456789" .
 <span class="focus-node-error">ex:Alice</span> ex:password "1234567890ABC" .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:PasswordExampleShape</td><td>ex:Bob</td><td>pass</td></tr>
+              <tr class="fail"><td>ex:PasswordExampleShape</td><td>ex:Alice</td><td>fail</td><td class="fail"><code>ex:password</code> more than 10 characters.</td></tr>
+            </table>
+          </div>
 				</section>
 				
 				<section id="PatternConstraintComponent">
@@ -2179,7 +2288,6 @@ ASK {
 					<pre class="example-shapes">
 ex:PatternExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:Bob, ex:Alice, ex:Carol ;
 	sh:property [
 		sh:predicate ex:bCode ;
 		sh:pattern "^B" ;    # starts with 'B'
@@ -2189,6 +2297,15 @@ ex:PatternExampleShape
 ex:Bob ex:bCode "b101" .
 ex:Alice ex:bCode "B102" .
 <span class="focus-node-error">ex:Carol</span> ex:bCode "C103" .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:PatternExampleShape</td><td>ex:Bob</td><td>pass</td></tr>
+              <tr class="pass"><td>ex:PatternExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
+              <tr class="fail"><td>ex:PatternExampleShape</td><td>ex:Carol</td><td>fail</td><td class="fail"><code>ex:bCode</code> does not match pattern.</td></tr>
+            </table>
+          </div>
 				</section>
 				
 				<section id="StemConstraintComponent">
@@ -2229,7 +2346,6 @@ ASK {
 					<pre class="example-shapes">
 ex:StemExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:Bob, ex:Alice, ex:Carol ;
 	sh:property [
 		sh:predicate ex:w3cHomepage ;
 		sh:stem "https://www.w3.org/People/" ;
@@ -2237,7 +2353,16 @@ ex:StemExampleShape
 					<pre class="example-data">
 ex:Alice ex:w3cHomepage &lt;https://www.w3.org/People/Alice&gt; .
 <span class="focus-node-error">ex:Bob</span> ex:w3cHomepage &lt;https://example.com/People/Bob&gt; .
-<span class="focus-node-error">ex:Carol</span> ex:w3cHomepage "https://www.w3.org/People/Carol" .</pre>
+<span class="focus-node-error">ex:Carol</span> ex:w3cHomepage "https://w3.org/People/Carol" .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:StemExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
+              <tr class="fail"><td>ex:StemExampleShape</td><td>ex:Bob</td><td>fail</td><td class="fail"><code>ex:w3cHomepage</code> does not match stem.</td></tr>
+              <tr class="fail"><td>ex:StemExampleShape</td><td>ex:Carol</td><td>fail</td><td class="fail"><code>ex:w3cHomepage</code> does not match stem.</td></tr>
+            </table>
+          </div>
 				</section>
 				
 				<section id="LanguageInConstraintComponent">
@@ -2291,7 +2416,6 @@ ASK {
 					<pre class="example-shapes">
 ex:NewZealandLanguagesShape
 	a sh:Shape ;
-	sh:targetNode ex:Mountain, ex:Berg ;
 	sh:property [
 		sh:predicate ex:prefLabel ;
 		sh:languageIn ( "en" "mi" ) ;
@@ -2310,6 +2434,16 @@ ex:Mountain
 	ex:prefLabel "Berg" ;
 	ex:prefLabel "Berg"@de ;
 	ex:prefLabel ex:BergLabel .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:NewZealandLanguagesShape</td><td>ex:Mountain</td><td>pass</td></tr>
+              <tr class="fail"><td>ex:NewZealandLanguagesShape</td><td>ex:Berg</td><td>fail</td><td class="fail">"Berg" does not have a language tag.<br/>
+              @de does not match language choice.<br/>
+              ex:BergLabel is not a literal.</td></tr>
+            </table>
+          </div>
 				</section>
 				
 				<section id="UniqueLangConstraintComponent">
@@ -2361,7 +2495,6 @@ WHERE {
 					<pre class="example-shapes">
 ex:UniqueLangExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:Alice, ex:Bob ;
 	sh:property [
 		sh:predicate ex:label ;
 		sh:uniqueLang true ;
@@ -2376,6 +2509,14 @@ ex:Alice
 <span class="focus-node-error">ex:Bob</span>
 	ex:label "Bob"@en ;
 	ex:label "Bobby"@en .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:UniqueLangExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
+              <tr class="fail"><td>ex:UniqueLangExampleShape</td><td>ex:Bob</td><td>fail</td><td class="fail">multiple <code>ex:label</code>s with the same language tag.</td></tr>
+            </table>
+          </div>
 				</section>
 			</section>
 			
@@ -2443,15 +2584,26 @@ WHERE {
 					<pre class="example-shapes">
 ex:EqualExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:Bob ;
 	sh:property [
 		sh:predicate ex:firstName ;
 		sh:equals ex:givenName ;
 	] .</pre>
 					<pre class="example-data">
+ex:Alice
+	ex:firstName "Alice" ;
+	ex:givenName "Alice" .
+
 ex:Bob
 	ex:firstName "Bob" ;
-	ex:givenName "Bob" .</pre>
+	ex:givenName "Robert" .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:EqualExampleShape</td><td>ex:Alice</td><td>pass</td></tr>
+              <tr class="fail"><td>ex:EqualExampleShape</td><td>ex:Bob</td><td>fail</td><td class="fail"><code>ex:firstName</code> does not match <code>ex:givenName</code>.</td></tr>
+            </table>
+          </div>
 				</section>
 				
 				<section id="DisjointConstraintComponent">
@@ -2498,7 +2650,6 @@ WHERE {
 					<pre class="example-shapes">
 ex:DisjointExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:USA, ex:Germany ;
 	sh:property [
 		sh:predicate ex:prefLabel ;
 		sh:disjoint ex:altLabel ;
@@ -2511,6 +2662,14 @@ ex:USA
 <span class="focus-node-error">ex:Germany</span>
 	ex:prefLabel "Germany" ;
 	ex:altLabel "Germany" .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:DisjointExampleShape</td><td>ex:USA</td><td>pass</td></tr>
+              <tr class="fail"><td>ex:DisjointExampleShape</td><td>ex:Germany</td><td>fail</td><td class="fail"><code>ex:prefLabel</code> must not equal <code>ex:altLabel</code>.</td></tr>
+            </table>
+          </div>
 				</section>
 				
 				<section id="LessThanConstraintComponent">
@@ -2653,16 +2812,24 @@ WHERE {
 					<pre class="example-shapes">
 ex:NotExampleShape
 	a sh:Shape ;
-	sh:targetNode ex:InvalidInstance1 ;
 	sh:not [
 		a sh:Shape ;
 		sh:property [
-			sh:predicate ex:property ;
+			sh:predicate ex:property1 ;
 			sh:minCount 1 ;
 		] ;
 	] .</pre>
 					<pre class="example-data">
-<span class="focus-node-error">ex:InvalidInstance1</span> ex:property "Some value" .</pre>
+<span class="focus-node-error">ex:InvalidInstance</span> ex:property1 "Some value" .
+ex:ValidInstance ex:property2 "Some value" .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="fail"><td>ex:NotExampleShape</td><td>ex:InvalidInstance</td><td>fail</td><td class="fail">must not have a <code>ex:property1</code>.</td></tr>
+              <tr class="pass"><td>ex:NotExampleShape</td><td>ex:ValidInstance</td><td>pass</td></tr>
+            </table>
+          </div>
 				</section>
 				
 				<section id="AndConstraintComponent">
@@ -2737,6 +2904,14 @@ ex:ValidInstance
 <span class="focus-node-error">ex:InvalidInstance</span>
 	ex:property "One" ;
 	ex:property "Two" .</pre>
+
+          <div class="example-results1">
+            <table>
+              <tr><th class="schema">shape</th><th class="data">focus node</th><th>result</th><th>reason</th></tr>
+              <tr class="pass"><td>ex:ExampleAndShape</td><td>ex:ValidInstance</td><td>pass</td></tr>
+              <tr class="fail"><td>ex:ExampleAndShape</td><td>ex:InvalidInstance</td><td>fail</td><td class="fail">must have only 1 <code>ex:property</code>.</td></tr>
+            </table>
+          </div>
 				</section>
 				
 				<section id="OrConstraintComponent">


### PR DESCRIPTION
This changes the examples to use a tabular summary of node/shape pairs and their validation results.
