### PR TITLE
validation filter ordering

### DIFF
--- a/shacl/index.html
+++ b/shacl/index.html
@@ -1385,8 +1385,11 @@ ex:MyInstance
 					Validation is the process of determining whether a <a>data graph</a>, or <a>nodes</a> in the <a>data graph</a>, validate against a <a>shapes graph</a>.
 					<ul>
 						<li>A <a>node</a> validates against a <a>shape</a> if and only if
-							either it does not validate against some <a>filter</a> of the shape
-							or none of the <a>constraints</a> in the shape produce a <a>validation result</a> or a <a>failure</a> for the node.
+							it does not validate against some <a>filter</a> of the shape
+							and then none of the <a>constraints</a> in the shape produce
+							a <a>validation result</a> or a <a>failure</a> for the node.
+							Thus, filter shapes are validated and valid nodes are passed on
+							for validation with respect to the associated shapes or constraints.
 						</li>
 						<li>A <a>data graph</a> validates against a <a>shape</a> if and only if
 							each node that is in any of the <a>targets</a> of the shape validates against the shape.


### PR DESCRIPTION
potential text, in explicit change to the proposal in
https://www.w3.org/2014/data-shapes/track/issues/185

please do not merge without explicit resolution 


I have reinserted explicit ordering of filter evaluation and constraint evaluation in validation

I have not used the word `ordering`.  I wonder if an extra statement with this word in would add clarity
`Thus, filter shapes are validated and valid nodes are passed on for validation with respect to the associated shapes or constraints: the processing is ordered.`

I have not included the explicit text removed in
https://github.com/w3c/data-shapes/commit/139f7de173b0ee6e054c4f250f33e18a6dac78fd#diff-69303a57193e6c2d7327c8de0fc977caL1069
```
Filter shapes MUST be validated before validating the associated shapes or constraints.
This includes scenarios such as <a href="#ShapeConstraintComponent">
<code>sh:shape</code></a> where a shape is explicitly referenced by another constraint.
However, during the validation of a shape referenced via <code>sh:shape</code>, the 
<a>targets</a> of these shapes are not used to limit the set of focus nodes.
-				</p>
```
I think I have captured the sense of it and I am not sure these examples belong in 
3. Validation Definition

maybe we add these somewhere else?