### PR TITLE
fix core/property/datatype-ill-formed validation results

### DIFF
--- a/data-shapes-test-suite/tests/core/property/datatype-ill-formed.ttl
+++ b/data-shapes-test-suite/tests/core/property/datatype-ill-formed.ttl
@@ -14,11 +14,25 @@
     ) .
 
 <datatype-ill-formed> rdf:type sht:Validate;
-  rdfs:label "Test of validation report for shape shared by property constraints" ;
+  rdfs:label "Test of validation report for ill-formed literals" ;
   mf:action [ sht:dataGraph <datatype-ill-formed-data.ttl> ;
               sht:shapesGraph <datatype-ill-formed-shapes.ttl> ] ;
   mf:result [ rdf:type sh:ValidationReport ;
               sh:conforms "false"^^xsd:boolean ;
+	      sh:result [ rdf:type sh:ValidationResult ;
+ 	      		  sh:resultSeverity sh:Violation ;
+ 			  sh:focusNode ex:i ;
+ 			  sh:value "300"^^xsd:byte ;
+			  sh:resultPath ex:p ;
+ 			  sh:sourceShape ex:s ;
+ 			  sh:sourceConstraintComponent sh:DatatypeConstraintComponent ] ;
+	      sh:result [ rdf:type sh:ValidationResult ;
+ 	      		  sh:resultSeverity sh:Violation ;
+ 			  sh:focusNode ex:i ;
+ 			  sh:value "c"^^xsd:byte ;
+			  sh:resultPath ex:p ;
+ 			  sh:sourceShape ex:s ;
+ 			  sh:sourceConstraintComponent sh:DatatypeConstraintComponent ] ;
 	      sh:result [ rdf:type sh:ValidationResult ;
  	      		  sh:resultSeverity sh:Violation ;
  			  sh:focusNode ex:i ;


### PR DESCRIPTION
fix core/property/datatype-ill-formed validation results