### PR TITLE
Added shaclex report

### DIFF
--- a/data-shapes-test-suite/reports/SHACLEX_EarlReport_SHACL.ttl
+++ b/data-shapes-test-suite/reports/SHACLEX_EarlReport_SHACL.ttl
@@ -1,0 +1,1763 @@
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix doap:  <http://usefulinc.com/ns/doap#> .
+@prefix earl:  <http://www.w3.org/ns/earl#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix dc:    <http://purl.org/dc/terms/> .
+
+<>      dc:issued          "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+        foaf:maker         <http://labra.weso.es#me> ;
+        foaf:primaryTopic  <https://github.com/labra/shaclex/> .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/lessThan-001.test#InvalidResource3> failed as expected for shape <http://datashapes.org/sh/tests/core/property/lessThan-001.test#TestShape-property1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/lessThan-001> ;
+  foaf:name        "lessThan-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<a:b> failed as expected for shape <http://datashapes.org/sh/tests/core/node/minLength-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/minLength-001> ;
+  foaf:name        "minLength-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-complex-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-complex-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-complex-001> ;
+  foaf:name        "path-complex-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/in-001.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/in-001.test#ShapeClass-property>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/in-001> ;
+  foaf:name        "in-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/lessThan-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/lessThan-001.test#TestShape-property1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/lessThan-001> ;
+  foaf:name        "lessThan-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/minLength-001.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/minLength-001.test#TestShape-testProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/minLength-001> ;
+  foaf:name        "minLength-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/class-001.test#Typeless> failed as expected for shape <http://datashapes.org/sh/tests/core/node/class-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/class-001> ;
+  foaf:name        "class-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/and-001.test#InvalidResource3> failed as expected for shape <http://datashapes.org/sh/tests/core/property/and-001.test#AddressShape-address>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/and-001> ;
+  foaf:name        "and-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/maxCount-002.test#InvalidResource> failed as expected for shape <http://datashapes.org/sh/tests/core/property/maxCount-002.test#TestShape-versionInfo>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/maxCount-002> ;
+  foaf:name        "maxCount-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/class-001.test#Typeless> failed as expected for shape <http://datashapes.org/sh/tests/core/node/class-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/class-003> ;
+  foaf:name        "class-003.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/or-datatypes-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/or-datatypes-001.test#TestShape-comment>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/or-datatypes-001> ;
+  foaf:name        "or-datatypes-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/hasValue-001.test#InvalidMalePerson> failed as expected for shape <http://datashapes.org/sh/tests/core/property/hasValue-001.test#PersonShape-gender>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/hasValue-001> ;
+  foaf:name        "hasValue-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-zeroOrOne-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-zeroOrOne-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-zeroOrOne-001> ;
+  foaf:name        "path-zeroOrOne-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-sequence-002.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-sequence-002.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-sequence-002> ;
+  foaf:name        "path-sequence-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://example.org/shacl-test/i> failed as expected for shape <http://example.org/shacl-test/s>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/datatype-ill-formed> ;
+  foaf:name        "datatype-ill-formed.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/targets/multipleTargets-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/targets/multipleTargets-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/targets/multipleTargets-001> ;
+  foaf:name        "multipleTargets-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/pattern-002.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/pattern-002.test#TestShape-property>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/pattern-002> ;
+  foaf:name        "pattern-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/minExclusive-001.test#John> failed as expected for shape <http://datashapes.org/sh/tests/core/node/minExclusive-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/minExclusive-001> ;
+  foaf:name        "minExclusive-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-sequence-duplicate-001.test#A> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-sequence-duplicate-001.test#SP>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-sequence-duplicate-001> ;
+  foaf:name        "path-sequence-duplicate-001.ttl"
+] .
+
+<https://github.com/labra/shaclex/>
+        a                          earl:TestSubject , doap:Project , earl:Software ;
+        dc:creator                 <http://labra.weso.es#me> ;
+        dc:date                    "2018-08-04T12:12:02.244Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+        dc:description             "shaclex"@en ;
+        dc:title                   "shaclex" ;
+        doap:developer             <http://labra.weso.es#me> ;
+        doap:documenter            <http://labra.weso.es#me> ;
+        doap:download-page         "https://github.com/labra/shaclex/" ;
+        doap:homepage              "https://github.com/labra/shaclex/" ;
+        doap:implements            "https://www.w3.org/TR/shacl/" ;
+        doap:maintainer            <http://labra.weso.es#me> ;
+        doap:maker                 <http://labra.weso.es#me> ;
+        doap:name                  "shaclex" ;
+        doap:programming-language  "Scala" ;
+        doap:release               [ a             doap:Version ;
+                                     doap:created  "2018-08-04"^^<http://www.w3.org/2001/XMLSchema#date> ;
+                                     doap:name     "shaclex"
+                                   ] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/misc/severity-002.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/misc/severity-002.test#TestShape1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/misc/severity-002> ;
+  foaf:name        "severity-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/equals-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/equals-001.test#TestShape-property1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/equals-001> ;
+  foaf:name        "equals-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/complex/personexample.test#Calvin> failed as expected for shape <http://datashapes.org/sh/tests/core/complex/personexample.test#PersonShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/complex/personexample> ;
+  foaf:name        "personexample.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-sequence-001.test#InvalidResource2> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-sequence-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-sequence-001> ;
+  foaf:name        "path-sequence-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-inverse-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-inverse-001.test#TestShape-P>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-inverse-001> ;
+  foaf:name        "path-inverse-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/minCount-001.test#InvalidPerson> failed as expected for shape <http://datashapes.org/sh/tests/core/property/minCount-001.test#PersonShape-firstName>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/minCount-001> ;
+  foaf:name        "minCount-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/and-001.test#InvalidRectangle2> failed as expected for shape <http://datashapes.org/sh/tests/core/node/and-001.test#Rectangle>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/and-001> ;
+  foaf:name        "and-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-alternative-001.test#InvalidResource2> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-alternative-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-alternative-001> ;
+  foaf:name        "path-alternative-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://example.org/test#j> failed as expected for shape <http://example.org/test#s1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-strange-002> ;
+  foaf:name        "path-strange-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/class-001.test#John> failed as expected for shape <http://datashapes.org/sh/tests/core/node/class-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/class-003> ;
+  foaf:name        "class-003.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-zeroOrMore-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-zeroOrMore-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-zeroOrMore-001> ;
+  foaf:name        "path-zeroOrMore-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/datatype-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/datatype-001.test#TestShape-integerProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/datatype-001> ;
+  foaf:name        "datatype-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/not-001#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/node/not-001#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/not-001> ;
+  foaf:name        "not-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/pattern-001.test#InvalidInstance2> failed as expected for shape <http://datashapes.org/sh/tests/core/property/pattern-001.test#TestShape-property>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/pattern-001> ;
+  foaf:name        "pattern-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-complex-001.test#InvalidResource2> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-complex-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-complex-001> ;
+  foaf:name        "path-complex-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://example.org/test#j> failed as expected for shape <http://example.org/test#s1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-strange-001> ;
+  foaf:name        "path-strange-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/equals-001.test#InvalidResource4> failed as expected for shape <http://datashapes.org/sh/tests/core/property/equals-001.test#TestShape-property1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/equals-001> ;
+  foaf:name        "equals-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-001.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-001.test#TestShape-myProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/targets/targetSubjectsOf-001> ;
+  foaf:name        "targetSubjectsOf-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://example.org/shacl/tests/i> failed as expected for shape <http://example.org/shacl/tests/s1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-complex-002> ;
+  foaf:name        "path-complex-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/lessThan-002.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/lessThan-002.test#TestShape-first>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/lessThan-002> ;
+  foaf:name        "lessThan-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/uniqueLang-001.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/uniqueLang-001.test#TestShape-testProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/uniqueLang-001> ;
+  foaf:name        "uniqueLang-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/and-002.test#InvalidInstance2> failed as expected for shape <http://datashapes.org/sh/tests/core/node/and-002.test#AndShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/and-002> ;
+  foaf:name        "and-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/maxLength-001.test#John> failed as expected for shape <http://datashapes.org/sh/tests/core/node/maxLength-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/maxLength-001> ;
+  foaf:name        "maxLength-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/datatype-003.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/datatype-003.test#TestShape-value>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/datatype-003> ;
+  foaf:name        "datatype-003.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/minExclusive-001.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/minExclusive-001.test#TestShape-testProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/minExclusive-001> ;
+  foaf:name        "minExclusive-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://example.org/shacl-test/i> failed as expected for shape <http://example.org/shacl-test/s1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/qualified-001> ;
+  foaf:name        "qualified-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://example.org/shacl/tests/j> failed as expected for shape <http://example.org/shacl/tests/s1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-unused-001> ;
+  foaf:name        "path-unused-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://www.w3.org/2001/XMLSchema#integer> failed as expected for shape <http://datashapes.org/sh/tests/core/node/datatype-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/datatype-001> ;
+  foaf:name        "datatype-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/and-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/and-001.test#AddressShape-address>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/and-001> ;
+  foaf:name        "and-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/closed-001.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/node/closed-001.test#MyShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/closed-001> ;
+  foaf:name        "closed-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/equals-001.test#InvalidResource2> failed as expected for shape <http://datashapes.org/sh/tests/core/node/equals-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/equals-001> ;
+  foaf:name        "equals-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/disjoint-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/disjoint-001.test#TestShape-property1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/disjoint-001> ;
+  foaf:name        "disjoint-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/maxExclusive-001.test#John> failed as expected for shape <http://datashapes.org/sh/tests/core/node/maxExclusive-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/maxExclusive-001> ;
+  foaf:name        "maxExclusive-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://example.org/shacl-test/j> failed as expected for shape <http://example.org/shacl-test/s4>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/validation-reports/shared> ;
+  foaf:name        "shared.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/maxInclusive-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/maxInclusive-001.test#TestShape-property>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/maxInclusive-001> ;
+  foaf:name        "maxInclusive-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/or-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/or-001.test#AddressShape-address>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/or-001> ;
+  foaf:name        "or-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/in-001.test#InvalidInstance> failed as expected for shape <http://datashapes.org/sh/tests/core/node/in-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/in-001> ;
+  foaf:name        "in-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://www.w3.org/2000/01/rdf-schema#Resource> failed as expected for shape <http://datashapes.org/sh/tests/core/node/languageIn-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/languageIn-001> ;
+  foaf:name        "languageIn-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/disjoint-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/node/disjoint-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/disjoint-001> ;
+  foaf:name        "disjoint-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/or-datatypes-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/or-datatypes-001.test#TestShape-comment>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/or-datatypes-001> ;
+  foaf:name        "or-datatypes-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/targets/targetNode-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/targets/targetNode-001.test#TestShape-label>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/targets/targetNode-001> ;
+  foaf:name        "targetNode-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/or-001.test#InvalidRectangle2> failed as expected for shape <http://datashapes.org/sh/tests/core/node/or-001.test#RectangleWithArea>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/or-001> ;
+  foaf:name        "or-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/minExclusive-002.test#InvalidInstance2> failed as expected for shape <http://datashapes.org/sh/tests/core/property/minExclusive-002.test#TestShape-testProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/minExclusive-002> ;
+  foaf:name        "minExclusive-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/datatype-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/datatype-001.test#TestShape-dateProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/datatype-001> ;
+  foaf:name        "datatype-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://example.org/shacl-test/j> failed as expected for shape <http://example.org/shacl-test/s1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/xone-duplicate> ;
+  foaf:name        "xone-duplicate.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-002.test#InvalidInstance2> failed as expected for shape <http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-002.test#TestShape-myProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/targets/targetSubjectsOf-002> ;
+  foaf:name        "targetSubjectsOf-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-sequence-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-sequence-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-sequence-001> ;
+  foaf:name        "path-sequence-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-oneOrMore-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-oneOrMore-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-oneOrMore-001> ;
+  foaf:name        "path-oneOrMore-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/node-002.test#Reto> failed as expected for shape <http://datashapes.org/sh/tests/core/property/node-002.test#PersonShape-address>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/node-002> ;
+  foaf:name        "node-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/closed-001.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/node/closed-001.test#MyShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/closed-001> ;
+  foaf:name        "closed-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/qualifiedValueShapesDisjoint-001.test#InvalidHand1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/qualifiedValueShapesDisjoint-001.test#HandShape-digit4>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/qualifiedValueShapesDisjoint-001> ;
+  foaf:name        "qualifiedValueShapesDisjoint-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/languageIn-001.test#Berg> failed as expected for shape <http://datashapes.org/sh/tests/core/property/languageIn-001.test#NewZealandLanguagesShape-prefLabel>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/languageIn-001> ;
+  foaf:name        "languageIn-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/languageIn-001.test#Berg> failed as expected for shape <http://datashapes.org/sh/tests/core/property/languageIn-001.test#NewZealandLanguagesShape-prefLabel>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/languageIn-001> ;
+  foaf:name        "languageIn-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/languageIn-001.test#Berg> failed as expected for shape <http://datashapes.org/sh/tests/core/property/languageIn-001.test#NewZealandLanguagesShape-prefLabel>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/languageIn-001> ;
+  foaf:name        "languageIn-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://example.org/shacl-test/i> failed as expected for shape <http://example.org/shacl-test/s1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/xone-duplicate> ;
+  foaf:name        "xone-duplicate.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/qualifiedValueShapesDisjoint-001.test#InvalidHand1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/qualifiedValueShapesDisjoint-001.test#HandShape-digit1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/qualifiedValueShapesDisjoint-001> ;
+  foaf:name        "qualifiedValueShapesDisjoint-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/maxExclusive-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/maxExclusive-001.test#TestShape-property>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/maxExclusive-001> ;
+  foaf:name        "maxExclusive-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/property-001.test#InvalidAddress> failed as expected for shape <http://datashapes.org/sh/tests/core/property/property-001.test#PersonShape-address-city>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/property-001> ;
+  foaf:name        "property-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/equals-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/equals-001.test#TestShape-property1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/equals-001> ;
+  foaf:name        "equals-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/and-001.test#InvalidResource2> failed as expected for shape <http://datashapes.org/sh/tests/core/property/and-001.test#AddressShape-address>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/and-001> ;
+  foaf:name        "and-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/minExclusive-001.test#InvalidInstance2> failed as expected for shape <http://datashapes.org/sh/tests/core/property/minExclusive-001.test#TestShape-testProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/minExclusive-001> ;
+  foaf:name        "minExclusive-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://example.org/shacl-test/i> failed as expected for shape <http://example.org/shacl-test/s>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/datatype-ill-formed> ;
+  foaf:name        "datatype-ill-formed.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/equals-001.test#InvalidResource3> failed as expected for shape <http://datashapes.org/sh/tests/core/property/equals-001.test#TestShape-property1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/equals-001> ;
+  foaf:name        "equals-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/class-001.test#Quokki> failed as expected for shape <http://datashapes.org/sh/tests/core/node/class-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/class-001> ;
+  foaf:name        "class-001.ttl"
+] .
+
+<http://labra.weso.es#me>
+        foaf:homepage  "http://labra.weso.es" ;
+        foaf:name      "Jose Emilio Labra Gayo" .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/lessThanOrEquals-001.test#InvalidResource2> failed as expected for shape <http://datashapes.org/sh/tests/core/property/lessThanOrEquals-001.test#TestShape-property1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/lessThanOrEquals-001> ;
+  foaf:name        "lessThanOrEquals-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/maxExclusive-001.test#InvalidResource2> failed as expected for shape <http://datashapes.org/sh/tests/core/property/maxExclusive-001.test#TestShape-property>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/maxExclusive-001> ;
+  foaf:name        "maxExclusive-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/qualifiedMinCountDisjoint-001.test#InvalidHand1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/qualifiedMinCountDisjoint-001.test#HandShape-digit-minCount1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/qualifiedMinCountDisjoint-001> ;
+  foaf:name        "qualifiedMinCountDisjoint-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://example.org/shacl-test/i> failed as expected for shape <http://example.org/shacl-test/s>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/datatype-ill-formed> ;
+  foaf:name        "datatype-ill-formed.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/xone-001.test#Dory> failed as expected for shape <http://datashapes.org/sh/tests/core/node/xone-001.test#XoneConstraintExampleShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/xone-001> ;
+  foaf:name        "xone-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-inverse-001.test#InvalidResource2> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-inverse-001.test#TestShape-P>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-inverse-001> ;
+  foaf:name        "path-inverse-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/class-001.test#Quokki> failed as expected for shape <http://datashapes.org/sh/tests/core/node/class-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/class-003> ;
+  foaf:name        "class-003.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://www.w3.org/2000/01/rdf-schema#Resource> failed as expected for shape <http://datashapes.org/sh/tests/core/targets/targetObjectsOf-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/targets/targetObjectsOf-001> ;
+  foaf:name        "targetObjectsOf-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/equals-001.test#InvalidResource2> failed as expected for shape <http://datashapes.org/sh/tests/core/property/equals-001.test#TestShape-property1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/equals-001> ;
+  foaf:name        "equals-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/pattern-001.test#Test> failed as expected for shape <http://datashapes.org/sh/tests/core/node/pattern-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/pattern-001> ;
+  foaf:name        "pattern-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/minInclusive-001.test#TestShape> failed as expected for shape <http://datashapes.org/sh/tests/core/node/minInclusive-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/minInclusive-002> ;
+  foaf:name        "minInclusive-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/targets/targetClass-001.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/targets/targetClass-001.test#MyShape-myProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/targets/targetClass-001> ;
+  foaf:name        "targetClass-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/pattern-001.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/pattern-001.test#TestShape-property>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/pattern-001> ;
+  foaf:name        "pattern-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/node-001.test#Issue_1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/node-001.test#Issue-assignedTo>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/node-001> ;
+  foaf:name        "node-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/and-001.test#InvalidRectangle1> failed as expected for shape <http://datashapes.org/sh/tests/core/node/and-001.test#Rectangle>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/and-001> ;
+  foaf:name        "and-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/uniqueLang-001.test#InvalidInstance2> failed as expected for shape <http://datashapes.org/sh/tests/core/property/uniqueLang-001.test#TestShape-testProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/uniqueLang-001> ;
+  foaf:name        "uniqueLang-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/lessThanOrEquals-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/lessThanOrEquals-001.test#TestShape-property1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/lessThanOrEquals-001> ;
+  foaf:name        "lessThanOrEquals-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/class-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/class-001.test#TestShape-testProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/class-001> ;
+  foaf:name        "class-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/qualifiedValueShape-001.test#Observation1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/qualifiedValueShape-001.test#APGARObservationShape-related>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/qualifiedValueShape-001> ;
+  foaf:name        "qualifiedValueShape-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/or-datatypes-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/or-datatypes-001.test#TestShape-comment>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/or-datatypes-001> ;
+  foaf:name        "or-datatypes-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/and-002.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/node/and-002.test#AndShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/and-002> ;
+  foaf:name        "and-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/maxInclusive-001.test#John> failed as expected for shape <http://datashapes.org/sh/tests/core/node/maxInclusive-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/maxInclusive-001> ;
+  foaf:name        "maxInclusive-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-002.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-002.test#TestShape-myProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/targets/targetSubjectsOf-002> ;
+  foaf:name        "targetSubjectsOf-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/equals-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/node/equals-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/equals-001> ;
+  foaf:name        "equals-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/datatype-002.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/datatype-002.test#TestShape-value>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/datatype-002> ;
+  foaf:name        "datatype-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/disjoint-001.test#InvalidResource2> failed as expected for shape <http://datashapes.org/sh/tests/core/property/disjoint-001.test#TestShape-property1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/disjoint-001> ;
+  foaf:name        "disjoint-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/not-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/not-001.test#TestShape-property>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/not-001> ;
+  foaf:name        "not-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://example.org/shacl/tests/i> failed as expected for shape <http://example.org/shacl/tests/s1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-complex-002> ;
+  foaf:name        "path-complex-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/lessThan-002.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/lessThan-002.test#TestShape-first>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/lessThan-002> ;
+  foaf:name        "lessThan-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-alternative-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-alternative-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-alternative-001> ;
+  foaf:name        "path-alternative-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-sequence-002.test#InvalidResource2> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-sequence-002.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-sequence-002> ;
+  foaf:name        "path-sequence-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/maxLength-001.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/maxLength-001.test#TestShape-testProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/maxLength-001> ;
+  foaf:name        "maxLength-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/lessThan-001.test#InvalidResource2> failed as expected for shape <http://datashapes.org/sh/tests/core/property/lessThan-001.test#TestShape-property1>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/lessThan-001> ;
+  foaf:name        "lessThan-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/datatype-002.test#InvalidInstance2> failed as expected for shape <http://datashapes.org/sh/tests/core/property/datatype-002.test#TestShape-value>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/datatype-002> ;
+  foaf:name        "datatype-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/not-002.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/node/not-002.test#NotExampleShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/not-002> ;
+  foaf:name        "not-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/class-001.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/class-001.test#TestShape-testProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/class-001> ;
+  foaf:name        "class-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/minInclusive-001.test#TestShape> failed as expected for shape <http://datashapes.org/sh/tests/core/node/minInclusive-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/minInclusive-003> ;
+  foaf:name        "minInclusive-003.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/misc/message-001.test#InvalidNode> failed as expected for shape <http://datashapes.org/sh/tests/core/misc/message-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/misc/message-001> ;
+  foaf:name        "message-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://example.org/shacl/tests/i> failed as expected for shape <http://example.org/shacl/tests/s2>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-complex-002> ;
+  foaf:name        "path-complex-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://example.org/shacl/tests/i> failed as expected for shape <http://example.org/shacl/tests/s2>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-complex-002> ;
+  foaf:name        "path-complex-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/closed-002.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/node/closed-002.test#MyShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/closed-002> ;
+  foaf:name        "closed-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/maxExclusive-001.test#InvalidResource3> failed as expected for shape <http://datashapes.org/sh/tests/core/property/maxExclusive-001.test#TestShape-property>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/maxExclusive-001> ;
+  foaf:name        "maxExclusive-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/class-001.test#Quokkip> failed as expected for shape <http://datashapes.org/sh/tests/core/node/class-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/class-003> ;
+  foaf:name        "class-003.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/node/node-001.test#InvalidInstance> failed as expected for shape <http://datashapes.org/sh/tests/core/node/node-001.test#TestClass>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/node/node-001> ;
+  foaf:name        "node-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/misc/severity-002.test#InvalidResource1> failed as expected for shape <http://datashapes.org/sh/tests/core/misc/severity-002.test#TestShape2>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/misc/severity-002> ;
+  foaf:name        "severity-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/targets/targetClassImplicit-001.test#InvalidInstance> failed as expected for shape <http://datashapes.org/sh/tests/core/targets/targetClassImplicit-001.test#SuperClass>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/targets/targetClassImplicit-001> ;
+  foaf:name        "targetClassImplicit-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/path/path-oneOrMore-001.test#InvalidResource2> failed as expected for shape <http://datashapes.org/sh/tests/core/path/path-oneOrMore-001.test#TestShape>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/path/path-oneOrMore-001> ;
+  foaf:name        "path-oneOrMore-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/maxCount-001.test#InvalidPerson> failed as expected for shape <http://datashapes.org/sh/tests/core/property/maxCount-001.test#PersonShape-firstName>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/maxCount-001> ;
+  foaf:name        "maxCount-001.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/minExclusive-002.test#InvalidInstance1> failed as expected for shape <http://datashapes.org/sh/tests/core/property/minExclusive-002.test#TestShape-testProperty>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/minExclusive-002> ;
+  foaf:name        "minExclusive-002.ttl"
+] .
+
+[ a                earl:Assertion ;
+  earl:assertedBy  <http://labra.weso.es#me> ;
+  earl:result      [ a               earl:TestResult ;
+                     dc:date         "2018-08-04T14:12:02"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                     dc:description  "<http://datashapes.org/sh/tests/core/property/maxInclusive-001.test#InvalidResource2> failed as expected for shape <http://datashapes.org/sh/tests/core/property/maxInclusive-001.test#TestShape-property>" ;
+                     earl:mode       earl:automatic ;
+                     earl:outcome    earl:passed
+                   ] ;
+  earl:subject     <https://github.com/labra/shaclex/> ;
+  earl:test        <urn:x-shacl-test:/property/maxInclusive-001> ;
+  foaf:name        "maxInclusive-001.ttl"
+] .


### PR DESCRIPTION
Added implementation report about shaclex. 

File added: data-shapes-test-suite/reports/SHACLEX_EarlReport_SHACL.ttl

It passes all shacl core tests
It doesn't implement shacl sparql yet