### PR TITLE
Add results for proposed test to pySHACL report

### DIFF
--- a/data-shapes-test-suite/reports/pyshacl-earl.ttl
+++ b/data-shapes-test-suite/reports/pyshacl-earl.ttl
@@ -985,3 +985,11 @@ See https://github.com/w3c/data-shapes/issues/84."""@en ;
             earl:outcome earl:passed ] ;
     earl:subject <https://github.com/RDFLib/pySHACL> ;
     earl:test <urn:x-shacl-test:/core/property/maxCount-002> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/ashleysommer> ;
+    earl:result [ a earl:TestResult ;
+            earl:mode earl:automatic ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://github.com/RDFLib/pySHACL> ;
+    earl:test <urn:x-shacl-test:/sparql/component/nodeValidator-001> .


### PR DESCRIPTION
Missed the proposed test from the test suite. It is outcome:passed in pySHACL.