### PR TITLE
Update SHACL compact syntax link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Deliverables:
 * [SHACL](https://w3c.github.io/data-shapes/shacl/)
 * [SHACL Advanced Features](https://w3c.github.io/data-shapes/shacl-af/)
 * [SHACL JavaScript Extensions](https://w3c.github.io/data-shapes/shacl-js/)
-* [SHACL Compact-Syntax](https://w3c.github.io/data-shapes/shacl-compact-syntax/)
+* [SHACL Compact-Syntax](https://w3c.github.io/shacl/shacl-compact-syntax/)
 
 All of the above spec drafts are automatically rebuilt on pushes to this repository.


### PR DESCRIPTION
Hi w3c

The current link to `SHACL Compact-Syntax` on the `README.md` references a nonblank page with another link to the actual current draft. To remove a layer of indirection, I updated the link to reference the current draft.

Thanks for making this work available!