### PR TITLE
dotNetRDF implementation report

### DIFF
--- a/data-shapes-test-suite/reports/dotnetrdf-shacl-earl.ttl
+++ b/data-shapes-test-suite/reports/dotnetrdf-shacl-earl.ttl
@@ -1,0 +1,859 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix doap: <http://usefulinc.com/ns/doap#>.
+@prefix earl: <http://www.w3.org/ns/earl#>.
+
+_:autos1010 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/class-002>.
+_:autos1030 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/class-003>.
+_:autos1041 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/closed-001>.
+_:autos1049 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/closed-002>.
+_:autos1063 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/datatype-001>.
+_:autos1074 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/datatype-002>.
+_:autos1082 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/disjoint-001>.
+_:autos1093 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/equals-001>.
+_:autos1101 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/hasValue-001>.
+_:autos1109 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/in-001>.
+_:autos1123 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/languageIn-001>.
+_:autos1146 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/maxExclusive-001>.
+_:autos1163 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/maxInclusive-001>.
+_:autos1186 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/minExclusive-001>.
+_:autos1194 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/minInclusive-001>.
+_:autos1208 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/minInclusive-002>.
+_:autos1225 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/minInclusive-003>.
+_:autos1233 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/node-001>.
+_:autos1241 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/nodeKind-001>.
+_:autos1249 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/not-001>.
+_:autos1257 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/not-002>.
+_:autos1268 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/or-001>.
+_:autos1285 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/pattern-001>.
+_:autos1293 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/pattern-002>.
+_:autos1301 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/xone-001>.
+_:autos1314 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/xone-duplicate>.
+_:autos1322 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/qualified-001>.
+_:autos1345 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/path/path-alternative-001>.
+_:autos1368 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/path/path-complex-001>.
+_:autos1383 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/path/path-inverse-001>.
+_:autos1398 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/path/path-oneOrMore-001>.
+_:autos1417 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/path/path-sequence-001>.
+_:autos1440 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/path/path-sequence-002>.
+_:autos1452 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/path/path-sequence-duplicate-001>.
+_:autos1464 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/path/path-strange-001>.
+_:autos1476 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/path/path-strange-002>.
+_:autos1486 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/path/path-zeroOrMore-001>.
+_:autos1496 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/path/path-zeroOrOne-001>.
+_:autos1507 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/path/path-unused-001>.
+_:autos1521 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/and-001>.
+_:autos1532 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/class-001>.
+_:autos1543 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/datatype-001>.
+_:autos1554 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/datatype-002>.
+_:autos1562 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/datatype-003>.
+_:autos1576 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/datatype-ill-formed>.
+_:autos1587 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/disjoint-001>.
+_:autos1607 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/equals-001>.
+_:autos1615 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/hasValue-001>.
+_:autos1623 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/in-001>.
+_:autos1637 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/languageIn-001>.
+_:autos1651 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/lessThan-001>.
+_:autos1668 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/lessThan-002>.
+_:autos1679 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/lessThanOrEquals-001>.
+_:autos1687 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/maxCount-001>.
+_:autos1695 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/maxCount-002>.
+_:autos1709 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/maxExclusive-001>.
+_:autos1720 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/maxInclusive-001>.
+_:autos1728 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/maxLength-001>.
+_:autos1736 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/minCount-001>.
+_:autos1741 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/minCount-002>.
+_:autos1752 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/minExclusive-001>.
+_:autos1763 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/minExclusive-002>.
+_:autos1771 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/minLength-001>.
+_:autos1779 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/node-001>.
+_:autos1787 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/node-002>.
+_:autos1795 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/not-001>.
+_:autos1803 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/or-001>.
+_:autos1817 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/or-datatypes-001>.
+_:autos1828 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/pattern-001>.
+_:autos1836 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/pattern-002>.
+_:autos1847 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/property-001>.
+_:autos1855 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/qualifiedMinCountDisjoint-001>.
+_:autos1863 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/qualifiedValueShape-001>.
+_:autos1874 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/qualifiedValueShapesDisjoint-001>.
+_:autos1888 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/uniqueLang-001>.
+_:autos1893 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/uniqueLang-002>.
+_:autos1901 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/targets/multipleTargets-001>.
+_:autos1909 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/targets/targetClass-001>.
+_:autos1917 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/targets/targetClassImplicit-001>.
+_:autos1925 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/targets/targetNode-001>.
+_:autos1936 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/targets/targetObjectsOf-001>.
+_:autos1944 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/targets/targetSubjectsOf-001>.
+_:autos1955 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/targets/targetSubjectsOf-002>.
+_:autos1966 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/validation-reports/shared>.
+_:autos1983 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/component/optional-001>.
+_:autos1994 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/component/propertyValidator-select-001>.
+_:autos2002 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/component/validator-001>.
+_:autos2010 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/node/prefixes-001>.
+_:autos2024 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/node/sparql-001>.
+_:autos2032 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/node/sparql-002>.
+_:autos2040 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/node/sparql-003>.
+_:autos2048 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/property/sparql-001>.
+_:autos2056 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/pre-binding/pre-binding-001>.
+_:autos2064 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/pre-binding/pre-binding-002>.
+_:autos2072 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/pre-binding/pre-binding-003>.
+_:autos2080 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/pre-binding/pre-binding-004>.
+_:autos2088 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/pre-binding/pre-binding-005>.
+_:autos2093 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/pre-binding/pre-binding-006>.
+_:autos2101 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/pre-binding/pre-binding-007>.
+_:autos2109 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/pre-binding/shapesGraph-001>.
+_:autos2114 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/pre-binding/unsupported-sparql-001>.
+_:autos2119 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/pre-binding/unsupported-sparql-002>.
+_:autos2124 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/pre-binding/unsupported-sparql-003>.
+_:autos2129 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/pre-binding/unsupported-sparql-004>.
+_:autos2134 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/pre-binding/unsupported-sparql-005>.
+_:autos2139 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/pre-binding/unsupported-sparql-006>.
+_:autos2147 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:automatic ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/sparql/component/nodeValidator-001>.
+_:autos2151 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:semiAuto ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/path/path-complex-002>.
+_:autos2155 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:semiAuto ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/property/nodeKind-001>.
+_:autos2159 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:semiAuto ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/minLength-001>.
+_:autos2163 a earl:Assertion;
+            earl:assertedBy <https://github.com/langsamu>;
+            earl:result [a earl:TestResult ; 
+                         earl:mode earl:semiAuto ; 
+                         earl:outcome earl:passed];
+            earl:subject <https://www.dotnetrdf.org/>;
+            earl:test <urn:x-shacl-test:/core/node/maxLength-001>.
+_:autos792 a earl:Assertion;
+           earl:assertedBy <https://github.com/langsamu>;
+           earl:result [a earl:TestResult ; 
+                        earl:mode earl:automatic ; 
+                        earl:outcome earl:passed];
+           earl:subject <https://www.dotnetrdf.org/>;
+           earl:test <urn:x-shacl-test:/core/complex/personexample>.
+_:autos926 a earl:Assertion;
+           earl:assertedBy <https://github.com/langsamu>;
+           earl:result [a earl:TestResult ; 
+                        earl:mode earl:automatic ; 
+                        earl:outcome earl:passed];
+           earl:subject <https://www.dotnetrdf.org/>;
+           earl:test <urn:x-shacl-test:/core/complex/shacl-shacl>.
+_:autos931 a earl:Assertion;
+           earl:assertedBy <https://github.com/langsamu>;
+           earl:result [a earl:TestResult ; 
+                        earl:mode earl:automatic ; 
+                        earl:outcome earl:passed];
+           earl:subject <https://www.dotnetrdf.org/>;
+           earl:test <urn:x-shacl-test:/core/misc/deactivated-001>.
+_:autos939 a earl:Assertion;
+           earl:assertedBy <https://github.com/langsamu>;
+           earl:result [a earl:TestResult ; 
+                        earl:mode earl:automatic ; 
+                        earl:outcome earl:passed];
+           earl:subject <https://www.dotnetrdf.org/>;
+           earl:test <urn:x-shacl-test:/core/misc/deactivated-002>.
+_:autos947 a earl:Assertion;
+           earl:assertedBy <https://github.com/langsamu>;
+           earl:result [a earl:TestResult ; 
+                        earl:mode earl:automatic ; 
+                        earl:outcome earl:passed];
+           earl:subject <https://www.dotnetrdf.org/>;
+           earl:test <urn:x-shacl-test:/core/misc/message-001>.
+_:autos955 a earl:Assertion;
+           earl:assertedBy <https://github.com/langsamu>;
+           earl:result [a earl:TestResult ; 
+                        earl:mode earl:automatic ; 
+                        earl:outcome earl:passed];
+           earl:subject <https://www.dotnetrdf.org/>;
+           earl:test <urn:x-shacl-test:/core/misc/severity-001>.
+_:autos966 a earl:Assertion;
+           earl:assertedBy <https://github.com/langsamu>;
+           earl:result [a earl:TestResult ; 
+                        earl:mode earl:automatic ; 
+                        earl:outcome earl:passed];
+           earl:subject <https://www.dotnetrdf.org/>;
+           earl:test <urn:x-shacl-test:/core/misc/severity-002>.
+_:autos977 a earl:Assertion;
+           earl:assertedBy <https://github.com/langsamu>;
+           earl:result [a earl:TestResult ; 
+                        earl:mode earl:automatic ; 
+                        earl:outcome earl:passed];
+           earl:subject <https://www.dotnetrdf.org/>;
+           earl:test <urn:x-shacl-test:/core/node/and-001>.
+_:autos988 a earl:Assertion;
+           earl:assertedBy <https://github.com/langsamu>;
+           earl:result [a earl:TestResult ; 
+                        earl:mode earl:automatic ; 
+                        earl:outcome earl:passed];
+           earl:subject <https://www.dotnetrdf.org/>;
+           earl:test <urn:x-shacl-test:/core/node/and-002>.
+_:autos999 a earl:Assertion;
+           earl:assertedBy <https://github.com/langsamu>;
+           earl:result [a earl:TestResult ; 
+                        earl:mode earl:automatic ; 
+                        earl:outcome earl:passed];
+           earl:subject <https://www.dotnetrdf.org/>;
+           earl:test <urn:x-shacl-test:/core/node/class-001>.
+<https://www.dotnetrdf.org/> doap:date "2019-05-14T15:47:49.142280Z"^^xsd:dateTime;
+                             doap:developer <https://github.com/langsamu>;
+                             doap:name "dotNetRDF";
+                             a doap:Project,
+                               earl:Software,
+                               earl:TestSubject.


### PR DESCRIPTION
Implemented in dotnetrdf/dotnetrdf#236.

- [Test suite in dotNetRDF unit tests](https://github.com/dotnetrdf/dotnetrdf/blob/956364e5b1afa384364bd1cebc61d12f94b82b56/Testing/unittest/Shacl/TestSuite.cs)
- [CLI report generator](https://github.com/langsamu/SHACL-dotNetRDF-implementation-report-generator/)
- [SHACL service](http://langsamu.net/shacl) using this implementation ([OpenAPI](http://langsamu.net/shacl/openapi))