### PR TITLE
Erratum clarifying sh:declare and owl:Ontology

### DIFF
--- a/shacl/index.html
+++ b/shacl/index.html
@@ -4132,7 +4132,7 @@ ex:
 					</p>
 					<p>
 						The recommended <a>subject</a> for values of <code>sh:declare</code> is the IRI of the named graph containing the shapes that use the prefixes.
-						These IRIs are often declared as an instance of <code>owl:Ontology</code>, but this is not required.
+						These IRIs are often declared as an instance of <code>owl:Ontology</code>, but this <code>rdf:type owl:Ontology</code> declaration is not required.
 					</p>
 					<p>
 						<a>Prefix declarations</a> can be used by <a>SPARQL-based constraints</a>,


### PR DESCRIPTION
addresses #130 and #131