### PR TITLE
Changes to domain/range of sh:prefixes/sh:declare to remove owl:Ontology

### DIFF
--- a/shacl/shacl.ttl
+++ b/shacl/shacl.ttl
@@ -3,11 +3,13 @@
 ## --------
 
 # W3C Shapes Constraint Language (SHACL) Vocabulary
-# Version from 2020-10-01
+# Version from 2021-01-19
 # Changes since original CR publication:
+# - Deleted sh:declare rdfs:domain owl:Ontology and sh:prefixes rdfs:range owl:Ontology, clarified comment of sh:prefixes
 # - Fixed sh:namespace of "sh" to use xsd:anyURI instead of string
 # - Changed rdfs:label of sh:nodeValidator from "shape validator" to "node validator"
 # - Fixed rdfs:label of sh:TripleRule, moved into comment
+# - Made rdfs:label of sh:LessThanOrEqualsConstraintComponent upper case
 
 @prefix owl:  <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -691,7 +693,7 @@ sh:lessThan
 
 sh:LessThanOrEqualsConstraintComponent
 	a sh:ConstraintComponent ;
-	rdfs:label "less-than-or-equals constraint component"@en ;
+	rdfs:label "Less-than-or-equals constraint component"@en ;
 	rdfs:comment "A constraint component that can be used to verify that every value node is smaller than all the nodes that have the focus node as subject and the value of a given property as predicate."@en ;
 	sh:parameter sh:LessThanOrEqualsConstraintComponent-lessThanOrEquals ;
 	rdfs:isDefinedBy sh: .
@@ -1219,9 +1221,8 @@ sh:update
 sh:prefixes
 	a rdf:Property ;
 	rdfs:label "prefixes"@en ;
-	rdfs:comment "The prefixes that shall be applied before parsing the associated SPARQL query."@en ;
+	rdfs:comment "The prefixes that shall be applied before parsing the associated SPARQL query. The objects should define those prefixes using sh:declare."@en ;
 	rdfs:domain sh:SPARQLExecutable ;
-	rdfs:range owl:Ontology ;
 	rdfs:isDefinedBy sh: .
 
 sh:PrefixDeclaration
@@ -1235,7 +1236,6 @@ sh:declare
 	a rdf:Property ;
 	rdfs:label "declare"@en ;
 	rdfs:comment "Links a resource with its namespace prefix declarations."@en ;
-	rdfs:domain owl:Ontology ;
 	rdfs:range sh:PrefixDeclaration ;
 	rdfs:isDefinedBy sh: .
 


### PR DESCRIPTION
Based on discussion in #130 and #131 this deletes the triples sh:declare rdfs:domain owl:Ontology and sh:prefixes rdfs:range owl:Ontology - the owl:Ontologies are merely a recommendation in the spec yet now cause no RDFS inferences.

This PR also includes an unrelated trivial change to a label.