### PR TITLE
Submitting shaWell EARL validation report

### DIFF
--- a/data-shapes-test-suite/reports/shawell_report.ttl
+++ b/data-shapes-test-suite/reports/shawell_report.ttl
@@ -1,0 +1,1188 @@
+@prefix sht:   <http://www.w3.org/ns/shacl-test#> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix earl: <http://www.w3.org/ns/earl#>  .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<https://github.com/cem-okulmus/shawell> rdf:type doap:Project .
+<https://github.com/cem-okulmus/shawell> rdf:type earl:Software .
+<https://github.com/cem-okulmus/shawell> rdf:type earl:TextSubject .
+<https://github.com/cem-okulmus/shawell> doap:developer <https://github.com/cem-okulmus> .
+<https://github.com/cem-okulmus/shawell> doap:name "shaWell" .
+
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/complex/personexample> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/complex/shacl-shacl> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/misc/deactivated-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/misc/deactivated-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/misc/message-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/misc/severity-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/misc/severity-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/and-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/and-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/class-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/class-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/class-003> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/closed-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/closed-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/datatype-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/datatype-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/disjoint-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/equals-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/hasValue-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/in-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/languageIn-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/maxExclusive-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/maxInclusive-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/maxLength-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/minExclusive-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/minInclusive-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/minInclusive-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome sht:partial ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/minInclusive-003> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/minLength-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/node-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/nodeKind-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/not-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/not-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/or-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/pattern-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/pattern-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/xone-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/xone-duplicate> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/node/qualified-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/path/path-alternative-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/path/path-complex-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/path/path-complex-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/path/path-inverse-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/path/path-oneOrMore-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/path/path-sequence-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/path/path-sequence-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/path/path-sequence-duplicate-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/path/path-strange-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/path/path-strange-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/path/path-zeroOrMore-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/path/path-zeroOrOne-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/path/path-unused-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/and-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/class-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/datatype-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/datatype-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/datatype-003> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/datatype-ill-formed> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/disjoint-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/equals-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/hasValue-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/in-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/languageIn-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/lessThan-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/lessThan-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/lessThanOrEquals-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/maxCount-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/maxCount-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/maxExclusive-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/maxInclusive-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/maxLength-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/minCount-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/minCount-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/minExclusive-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/minExclusive-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/minLength-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/node-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/node-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/nodeKind-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/not-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/or-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/or-datatypes-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/pattern-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/pattern-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/property-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/qualifiedMinCountDisjoint-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/qualifiedValueShape-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/qualifiedValueShapesDisjoint-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/uniqueLang-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/property/uniqueLang-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/targets/multipleTargets-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/targets/targetClass-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/targets/targetClassImplicit-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/targets/targetNode-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/targets/targetObjectsOf-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/targets/targetSubjectsOf-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/targets/targetSubjectsOf-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://github.com/cem-okulmus> ;
+  earl:result [
+     rdf:type earl:TestResult ;
+     earl:info "Sparql engine being used: GraphDB 10.3.3" ;
+     earl:mode earl:automatic ;
+     earl:outcome earl:passed ;
+  ];
+  earl:subject <https://github.com/cem-okulmus/shawell> ;
+  earl:test <urn:x-shacl-test:/core/validation-reports/shared> ;
+].
+


### PR DESCRIPTION
Here is the validation report for the tool [shaWell](https://github.com/cem-okulmus/shawell). It uses a provided Sparql endpoint to perform validation. The provided validation report here is for the Shacl CORE subset only. Since the approach already uses a Sparql  endpoint, it should be fairly straight-forward to extend it to support Shacl Sparql as well, but this is not supported as of this moment. I might provide another PR in the future with an extended validation report if and once this functionality is available in a future version of shaWell. 

If there is an interest in recreating this validation report, please write me. It can be produced automatically via test functions, but there is some hard-coded stuff that one would need to manually adapt to run it locally on a different machine. The tool currently also only supports GraphDB (other systems would require more work, mostly around rights management as the test needs to use Sparql Update to add the data ad-hoc and many systems do not easily expose this). 