### PR TITLE
Update SHACL-AF to current reSpec.

### DIFF
--- a/shacl-af/index.html
+++ b/shacl-af/index.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
+<html lang="en-US">
   	<head>
-    	<title>SHACL Advanced Features</title>
+		<title>SHACL Advanced Features</title>
 		<meta charset="utf-8">
-    	<script src='https://www.w3.org/Tools/respec/respec-w3c-common' async="async" class='remove'></script>
-    	<script class='remove'>
-	
+ 	 	<script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
+	 	<script class='remove'>
 			var prepareSyntaxRules = function() {
 				$("[data-syntax-rule]").each(function(index, element) {
 					var ruleId = $(element).attr("data-syntax-rule");
@@ -28,11 +27,20 @@
 					}
 				},
 			
-				specStatus: "FPWD-NOTE",
-				preProcess : [ prepareSyntaxRules ],
-				edDraftURI: "https://w3c.github.io/data-shapes/shacl-af/",
-				shortName:  "shacl-af",
-				editors: [
+				specStatus:  	"NOTE",
+				group:       	"data-shapes",
+				//preProcess : [ prepareSyntaxRules ],
+				edDraftURI: 	"https://w3c.github.io/data-shapes/shacl-af/",
+				shortName:  	"shacl-af",
+        		github: 		"https://github.com/w3c/data-shapes/",
+        		//copyrightStart: "2025",
+        		editors:  [
+		          {	name: "Holger Knublauch",
+				    company:    "TopQuadrant, Inc.",
+				    companyURL: "http://topquadrant.com/",
+					 w3cid: "46500" }
+        		],
+				formerEditors: [
 					{
 						name:       "Holger Knublauch",
 						url:        "http://knublauch.com/",
@@ -48,17 +56,11 @@
 					},
 					{   
 						name:       "Simon Steyskal",
-			         	url:        "http://steyskal.info/",
-			         	company:    "WU Vienna/Siemens AG",
-			         	w3cid: 	73545 
+           				url:        "http://steyskal.info/",
+	         			company:    "WU Vienna/Siemens AG",
+	         			w3cid: 		73545 
 					}
-				],
-				publishDate: "2017-05-30",
-				wg: "RDF Data Shapes Working Group",
-				wgURI: "https://www.w3.org/2014/data-shapes/",
-				wgPublicList: "public-rdf-shapes",
-				wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/73865/status",
-				noHighlightCSS: true
+				]
 			};
 	    </script>
  		<style>
@@ -267,7 +269,7 @@
 	<body>
 
 		<section id='abstract'>
-			This document describes advanced features of the Shapes Constraint Language (SHACL) [[!shacl]]
+			This document describes advanced features of the Shapes Constraint Language (SHACL) [[shacl]]
 			including features to define custom targets, annotation properties, user-defined functions,
 			node expressions and rules.
 			While many of these features rely on SPARQL, they also define extension points
@@ -283,8 +285,8 @@
 		<section class="introductory">
 			<h2>Document Conventions</h2>
 			<p>
-				Some examples in this document use Turtle [[!turtle]].
-				The reader is expected to be familiar with SHACL [[!shacl]] and SPARQL [[!sparql11-query]].
+				Some examples in this document use Turtle [[turtle]].
+				The reader is expected to be familiar with SHACL [[shacl]] and SPARQL [[sparql-query]].
 			</p>
 			<p>
 				Within this document, the following namespace prefix bindings are used:
@@ -355,7 +357,7 @@
 			<h2>Terminology</h2>
 			<p>
 				The terminology used throughout this document is consistent with the definitions in the
-				main SHACL [[!shacl]] specification, which references terms from RDF [[!rdf11-concepts]].
+				main SHACL [[shacl]] specification, which references terms from RDF [[rdf11-concepts]].
 				This includes the terms
 				<dfn data-lt="bindings"><a href="https://www.w3.org/TR/shacl/#dfn-binding">binding</a></dfn>,
 				<dfn data-lt="blank nodes"><a href="https://www.w3.org/TR/shacl/#dfn-blank-node">blank node</a></dfn>,

--- a/shacl-af/index.html
+++ b/shacl-af/index.html
@@ -56,8 +56,9 @@
 					},
 					{   
 						name:       "Simon Steyskal",
-           				url:        "http://steyskal.info/",
-	         			company:    "WU Vienna/Siemens AG",
+           				url:        "http://steyskal.at/",
+	         			company:    "Siemens AG",
+						companyURL: "https://siemens.com"
 	         			w3cid: 		73545 
 					}
 				]


### PR DESCRIPTION
This is PR updates shacl-af from `respec-w3c-common`, which is out-of-date, to `respec-w3c`.

Fixes warnings about normative references in informative sections.
Tweaked`respecConfig`.

There are 2 errors causes by no recognized group name.
"data-shapes" is not listed in the group database https://respec.org/w3c/groups/
("shacl" is the CG).

7 warnings about definitions with no links to it. Ignored.

`prepareSyntaxRules` has a syntax error - the PR comments the preprocess step out.
 