### PR TITLE
Issue 230: Update description of `sh:pattern` behavior with IRI nodes

### DIFF
--- a/data-shapes-test-suite/tests/core/node/pattern-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/pattern-001.ttl
@@ -40,7 +40,7 @@ ex:TestShape
           rdf:type sh:ValidationResult ;
           sh:focusNode ex:Test ;
           sh:resultSeverity sh:Violation ;
-          sh:sourceConstraintComponent sh:PatternConstraintComponent ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
           sh:sourceShape ex:TestShape ;
           sh:value ex:Test ;
         ] ;


### PR DESCRIPTION
This patch series will address update test results, and possibly other documentation, around `sh:pattern` and how it behaves against IRI nodes.  E.g., there will be clarification on what should happen with use cases like this:

```turtle
@prefix ex: <http://example.org/> .

ex:Shape-1
    a sh:NodeShape ;
    sh:pattern "^https" ;
    sh:targetNode ex:Node-1 ;
    .
```

I.e., should the `sh:sourceConstraintComponent` be `sh:PatternConstraintComponent` for violating the pattern (not starting with `https`)?  `sh:NodeKindConstraint` for being an IRI node, even though `sh:nodeKind` is not used in this shape?

The intent of this PR is to at least close #230 , and possibly generate editor's draft revisions to cover use case 1 in #228 .

I suspect the working group needs to confirm whether this will be a backwards-compatible change.

I could also see SHACL-SHACL being updated to further constrain where `sh:pattern` can be used.

Aside: This is also my first PR against this repo, so rules-of-the-road pointers would be appreciated, such as appropriate target branch.
ACKs are due to @afs, @tfrancart, and @tpluscode from conversation on #228 ; what's the appropriate `git log` tag to use?  `Cc:`?
I'll force-push the first patch for the benefit of `git log` and `git blame` after guidance on ACKs.