### PR TITLE
#255 and #256: Core and SPARQL clean up - no more respec errors or warnings

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -120,12 +120,25 @@
 				],
 				testSuiteURI: "http://w3c.github.io/data-shapes/data-shapes-test-suite/",
 
+				lint: {
+					"no-unused-dfns": false,  // This should be removed near the end of the process
+  				},
+
 				previousPublishDate: "2017-07-20",
 				previousMaturity: "REC",
 				prevRecShortname: "shacl",
 				prevRecURI: "https://www.w3.org/TR/2017/REC-shacl-20170720/",
 
 				wgPublicList: "public-shacl",
+
+				localBiblio: {
+					"shacl12-sparql": {
+						title: "SHACL 1.2 SPARQL Extensions",
+						href: "https://w3c.github.io/data-shapes/shacl12-sparql/",
+						status: "ED",
+						publisher: "W3C",
+					}
+				}
 			};
 		</script>
 		<style>
@@ -213,6 +226,10 @@
 				border-top: 1px dashed #808080;
 				padding: 8px;
 			}
+
+			.example {
+				overflow-y: hidden !important;
+			}
 			
 			.focus-node-selected {
 				color: blue;
@@ -250,18 +267,6 @@
 
 			.part-header {
 				font-weight: bold;
-			}
-
-			.prediv {
-				background: var(--base, #fafafa);
-				border: 1px solid grey;
-				font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
-				font-size: 100%;
-				hyphens: none;
-				overflow-x: auto;
-				padding: .5em;
-				text-align: start;
-				white-space: pre;
 			}
 			
 			.syntax {
@@ -315,21 +320,53 @@
 				word-wrap: normal;
 			}
 
-			/* example pre taken / adapted from R2RML */
-			pre.shapes, pre.example-shapes, pre.example-data, pre.example-results, pre.example-other { margin-left: 0; padding: 0 2em; margin-top: 1.5em; padding: 1em; }
-			pre.example-shapes:before, pre.example-data:before, pre.example-results:before, pre.example-other:before { background: white; display: block; font-family: sans-serif; margin: -1em 0 0.4em -1em; padding: 0.2em 1em; }
-			pre.shapes, pre.example-shapes { background: #deb; }
-			pre.shapes, pre.example-shapes, pre.example-shapes:before { border: 1px solid #bbb; }
-			pre.example-shapes:before { color: #888; content: "Example shapes graph"; width: 13em; }
-			pre.example-data { background: #eeb; }
-			pre.example-data, pre.example-data:before { border: 1px solid #cc9; }
-			pre.example-data:before { color: #996; content: "Example data graph"; width: 13em; }
-			.example-results { background: #edb; }
-			.example-results, .example-results:before, .example-results th, .example-results td { border: 1px solid #cca; }
-			pre.example-results:before { color: #997; content: "Example validation results"; width: 13em; }
-			pre.example-other { background: #bed; }
-			pre.example-other, pre.example-other:before { border: 1px solid #ddd; }
-			pre.example-other:before { color: #888; content: "Example"; width: 13em; }
+			.turtle {
+				font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
+				font-size: 14.4px;
+				hyphens: none;
+				overflow-x: auto;
+				padding: .5em;
+				tab-size: 3;
+				-moz-tab-size: 3; /* Code for Firefox */
+				-o-tab-size: 3; /* Code for Opera */
+				text-align: start;
+				margin-bottom: -1.5em;
+				margin-top: -1.5em;
+				white-space: pre;
+			}
+			
+			.data-graph { 
+				background: #eeb; 
+				border: 1px solid #cc9;
+				margin-top: 0.3em;
+			}
+			.data-graph:before { 
+				color: #996; 
+				content: "Data graph"; 
+				padding-left: 0.4em;
+			}
+			
+			.results-graph { 
+				background: #edb; 
+				border: 1px solid #bbb;
+				margin-top: 0.3em;
+			}
+			.results-graph:before { 
+				color: #997; 
+				content: "Validation results"; 
+				padding-left: 0.4em;
+			}
+			
+			.shapes-graph { 
+				background: #deb; 
+				border: 1px solid #bbb;
+				margin-top: 0.3em;
+			}
+			.shapes-graph:before { 
+				color: #888; 
+				content: "Shapes graph"; 
+				padding-left: 0.4em;
+			}
 
 			/* our syntax menu for switching */
 			div.syntaxmenu {
@@ -369,13 +406,10 @@
 				The introduction includes a <a href="#terminology">Terminology</a> section.
 			</p>
 			<p>
-				The sections 2 - 4 cover the <a>SHACL Core</a> language.
-			</p>
-			<p>
 				The syntax of SHACL is RDF.
-				The examples in this document use Turtle [[!turtle]] and (in one instance) JSON-LD [[json-ld]].
+				The examples in this document use Turtle [[rdf12-turtle]] and (in one instance) JSON-LD [[json-ld]].
 				Other RDF serializations such as RDF/XML may be used in practice.
-				The reader should be familiar with basic RDF concepts [[!rdf11-concepts]] such as triples.
+				The reader should be familiar with basic RDF concepts [[rdf12-concepts]] such as triples.
 			</p>
 		</section>
 	
@@ -391,9 +425,9 @@
 					Throughout this document, the following terminology is used.
 				</p>
 				<p>
-					Terminology that is linked to portions of RDF 1.1 Concepts and Abstract
+					Terminology that is linked to portions of RDF 1.2 Concepts and Abstract
 					Syntax is used in SHACL as defined there. Terminology that is linked to
-					portions of SPARQL 1.1 Query Language is used in SHACL as defined there. A
+					portions of SPARQL 1.2 Query Language is used in SHACL as defined there. A
 					single linkage is sufficient to provide a definition for all occurences of a
 					particular term in this document.
 				</p>
@@ -405,19 +439,29 @@
 					<div class="term-def-header">Basic RDF Terminology</div>
 					<div>
 						This document uses the terms 
-						<a href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-graph"><dfn data-lt="graph|graphs|RDF graphs">RDF graph</dfn></a>,
-						<a href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple"><dfn data-lt="triple|triples">RDF triple</dfn></a>,
-						<a href="http://www.w3.org/TR/rdf11-concepts/#dfn-iri"><dfn data-lt="IRI|IRIs">IRI</dfn></a>,
-						<a href="http://www.w3.org/TR/rdf11-concepts/#dfn-literal"><dfn data-lt="literal|literals">literal</dfn></a>,
-						<a href="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node"><dfn data-lt="blank node|blank nodes">blank node</dfn></a>,
-						<a href="http://www.w3.org/TR/rdf11-concepts/#dfn-node"><dfn data-lt="node|nodes">node</dfn></a> of an RDF graph,
-						<a href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-term"><dfn>RDF term</dfn></a>, and
-						<a href="https://www.w3.org/TR/rdf11-concepts/#dfn-subject"><dfn data-lt="subject|subjects">subject</dfn></a>,
-						<a href="https://www.w3.org/TR/rdf11-concepts/#dfn-predicate"><dfn data-lt="predicate|predicates">predicate</dfn></a>, and
-						<a href="https://www.w3.org/TR/rdf11-concepts/#dfn-object"><dfn data-lt="object|objects">object</dfn></a> of RDF triples, and
-						<a href="https://www.w3.org/TR/rdf11-concepts/#dfn-datatype"><dfn data-lt="datatypes">datatype</dfn></a>
-						as defined in RDF 1.1 Concepts and Abstract Syntax [[!rdf11-concepts]].
+						<dfn data-cite="rdf12-concepts#dfn-rdf-graph" data-lt="graph|graphs|RDF graphs">RDF graph</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-rdf-triple" data-lt="triple|triples">RDF triple</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-iri" data-lt="IRI|IRIs">IRI</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-literal" data-lt="literal|literals">literal</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-datatype" data-lt="datatype">datatype</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-blank-node" data-lt="blank node|blank nodes">blank node</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-node" data-lt="node|nodes">node</dfn> of an RDF graph,
+						<dfn data-cite="rdf12-concepts#dfn-rdf-term" data-lt="term|terms">RDF term</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-subject" data-lt="subject|subjects">subject</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-predicate" data-lt="predicate|predicates">predicate</dfn>, and
+						<dfn data-cite="rdf12-concepts#dfn-object" data-lt="object|objects">object</dfn> of RDF triples
+						as defined in RDF 1.2 Concepts and Abstract Syntax [[!rdf12-concepts]].
 						<dfn data-lt="language tag">Language tags</dfn> are defined as in [[!BCP47]].
+					</div>
+				</div>
+				<div class="def" id="shacl-terminology">
+					<div class="term-def-header">SHACL-SPARQL Terminology</div>
+					<div>
+						This document uses the terms
+						<dfn data-cite="shacl12-sparql#dfn-parameter-names" data-lt="parameter names">parameter name</dfn>,
+						<dfn data-cite="shacl12-sparql#dfn-pre-binding" data-lt="pre-bind|pre-binding|pre-bound">pre-binding</dfn>, and
+						<dfn data-cite="shacl12-sparql#dfn-substituted" data-lt="substitution|substituted">substitution</dfn>
+						as defined in the SHACL 1.2 SPARQL Extensions specification [[!shacl12-sparql]].
 					</div>
 				</div>
 				<div class="def">
@@ -430,7 +474,7 @@
 						The phrase "Every value of P in graph G ..." means "Every object of a triple in G with predicate P ...".
 						(In this document, the verbs <em>specify</em> or <em>declare</em> are sometimes used to express the fact that an RDF term has values for a given predicate in a graph.)
 						<br />
-						<dfn data-lt="SPARQL property path">SPARQL property paths</dfn> are defined as in <a href="https://www.w3.org/TR/sparql11-query/#pp-language">SPARQL 1.1</a>.
+						<dfn data-lt="SPARQL property path">SPARQL property paths</dfn> are defined as in <a href="https://www.w3.org/TR/sparql12-query/#pp-language">SPARQL 1.2</a>.
 						An RDF term <code>n</code> has value <code>v</code> for <a>SPARQL property path</a> expression
 						<code>p</code> in an RDF graph <code>G</code> if there is a solution mapping in the result of the SPARQL query
 						<code>SELECT ?s ?o WHERE { ?s p' ?o }</code> on <code>G</code> that binds <code>?s</code> to
@@ -491,16 +535,6 @@
 						if one of the <a>SHACL types</a> of <code>n</code> in <code>G</code> is <code>C</code>.
 					</div>
 				</div>
-				<div class="def">
-					<div class="term-def-header">SHACL Core and SHACL-SPARQL</div>
-					<div>
-						The SHACL specification is divided into SHACL Core and SHACL-SPARQL.
-						<dfn>SHACL Core</dfn> consists of frequently needed features for the representation of shapes, constraints and targets.
-						All SHACL implementations MUST at least implement SHACL Core.
-						<dfn>SHACL-SPARQL</dfn> consists of all features of SHACL Core plus the advanced features
-						of SPARQL-based constraints and an extension mechanism to declare new constraint components.
-					</div>
-				</div>
 
 			</section>
 
@@ -544,24 +578,34 @@
 					Throughout the document, color-coded boxes containing RDF graphs in Turtle will appear.
 					These fragments of Turtle documents use the prefix bindings given above.
 				</p>
-				<pre class="example-shapes">
+
+				<div class="shapes-graph">
+					<div class="turtle">
 # This box represents an input shapes graph
 
 # Triples that can be omitted are marked as grey e.g.
-<span class="triple-can-be-skipped">&lt;s&gt; &lt;p&gt; &lt;o&gt; .</span></pre>
+<span class="triple-can-be-skipped">&lt;s&gt; &lt;p&gt; &lt;o&gt; .</span>
+					</div>
+				</div>
 
-				<pre class="example-data">
+				<div class="data-graph">
+					<div class="turtle">
 # This box represents an input data graph.
 # When highlighting is used in the examples:
 
 # Elements highlighted in blue are <a>focus nodes</a>
 <span class="focus-node-selected">ex:Bob</span> a ex:Person .
 
-# Elements highlighted in red are focus nodes that fail <a href="#validation">validation</a>
-<span class="focus-node-error">ex:Alice</span> a ex:Person .</pre>
+# Elements highlighted in red are focus nodes that fail validation
+<span class="focus-node-error">ex:Alice</span> a ex:Person .
+					</div>
+				</div>
 
-				<pre class="example-results">
-# This box represents an output results graph</pre>
+				<div class="results-graph">
+					<div class="turtle">
+# This box represents an output results graph
+					</div>
+				</div>
 
 				<p>
 					SHACL Definitions appear in blue boxes:
@@ -606,7 +650,9 @@
 				<p>
 					The following example <a>data graph</a> contains three <a>SHACL instances</a> of the <a>class</a> <code>ex:Person</code>.
 				</p>
-				<pre class="example-data">
+				<aside class="example">
+					<div class="data-graph">
+						<div class="turtle">
 ex:Alice
 	a ex:Person ;
 	ex:ssn "987-65-432A" .
@@ -619,29 +665,32 @@ ex:Bob
 ex:Calvin
 	a ex:Person ;
 	ex:birthDate "1971-07-07"^^xsd:date ;
-	ex:worksFor ex:UntypedCompany .</pre>
-				<p>
-					The following conditions are shown in the example:
-				<p>
-				<ul>
-					<li>
-						A <a>SHACL instance</a> of <code>ex:Person</code> can have at most one <a>value</a> for the property <code>ex:ssn</code>,
-						and this <a>value</a> is a <a>literal</a> with the datatype <code>xsd:string</code> that matches
-						a specified regular expression.
-					</li>
-					<li>
-						A <a>SHACL instance</a> of <code>ex:Person</code> can have unlimited <a>values</a> for the property <code>ex:worksFor</code>,
-						and these <a>values</a> are <a>IRIs</a> and <a>SHACL instances</a> of <code>ex:Company</code>.
-					</li>
-					<li>
-						A <a>SHACL instance</a> of <code>ex:Person</code> cannot have <a>values</a> for any other property apart from
-						<code>ex:ssn</code>, <code>ex:worksFor</code> and <code>rdf:type</code>.
-					</li>
-				</ul>
-				<p>
-					The aforementioned conditions can be represented as <a>shapes</a> and <a>constraints</a> in the following <a>shapes graph</a>:
-				</p>
-				<pre class="example-shapes ttl">
+	ex:worksFor ex:UntypedCompany .
+						</div>
+					</div>
+					<p>
+						The following conditions are shown in the example:
+					</p>
+					<ul>
+						<li>
+							A <a>SHACL instance</a> of <code>ex:Person</code> can have at most one <a>value</a> for the property <code>ex:ssn</code>,
+							and this <a>value</a> is a <a>literal</a> with the datatype <code>xsd:string</code> that matches
+							a specified regular expression.
+						</li>
+						<li>
+							A <a>SHACL instance</a> of <code>ex:Person</code> can have unlimited <a>values</a> for the property <code>ex:worksFor</code>,
+							and these <a>values</a> are <a>IRIs</a> and <a>SHACL instances</a> of <code>ex:Company</code>.
+						</li>
+						<li>
+							A <a>SHACL instance</a> of <code>ex:Person</code> cannot have <a>values</a> for any other property apart from
+							<code>ex:ssn</code>, <code>ex:worksFor</code> and <code>rdf:type</code>.
+						</li>
+					</ul>
+					<p>
+						The aforementioned conditions can be represented as <a>shapes</a> and <a>constraints</a> in the following <a>shapes graph</a>:
+					</p>
+					<div class="shapes-graph">
+						<div class="turtle">
 ex:PersonShape
 	a sh:NodeShape ;
 	sh:targetClass ex:Person ;    # Applies to all persons
@@ -657,14 +706,17 @@ ex:PersonShape
 		sh:nodeKind sh:IRI ;
 	] ;
 	sh:closed true ;
-	sh:ignoredProperties ( rdf:type ) .</pre>
+	sh:ignoredProperties ( rdf:type ) .
+						</div>
+					</div>
+				</aside>
 				<p>
 					The example below shows the same shape definition as a possible JSON-LD [[json-ld]] fragment.
 					Note that we have left out a <code>@context</code> declaration, and depending on the
 					<code>@context</code> the rendering may look quite different.
 					Therefore this example should be understood as an illustration only.
 				</p>
-				<pre class="example-shapes jsonld">
+				<pre class="jsonld">
 {
 	"@id" : "ex:PersonShape",
 	"@type" : "NodeShape",
@@ -707,7 +759,9 @@ ex:PersonShape
 					SHACL <a>validation</a> based on the provided <a>data graph</a> and <a>shapes graph</a> would produce the following <a>validation report</a>.
 					See the section <a href="#validation-report">Validation Report</a> for details on the format.
 				</p>
-				<pre class="example-results">
+				<aside class="example">
+					<div class="results-graph">
+						<div class="turtle">
 [	a sh:ValidationReport ;
 	sh:conforms false ;
 	sh:result
@@ -742,7 +796,10 @@ ex:PersonShape
 		sh:sourceConstraintComponent sh:ClosedConstraintComponent ;
 		sh:sourceShape sh:PersonShape ;
 	] 
-] .</pre>
+] .
+						</div>
+					</div>
+				</aside>
 				<p>
 					The <a>validation results</a> are enclosed in a <a>validation report</a>.
 					The first <a>validation result</a> is produced because <code>ex:Alice</code> has a <a>value</a> for <code>ex:ssn</code>
@@ -763,7 +820,7 @@ ex:PersonShape
 					SHACL uses the RDF and RDFS vocabularies, but full RDFS inferencing is not required.
 				</p>
 				<p>
-					However, SHACL processors MAY operate on RDF graphs that include entailments [[!sparql11-entailment]] -
+					However, SHACL processors MAY operate on RDF graphs that include entailments [[!sparql12-entailment]] -
 					either pre-computed before being submitted to a SHACL processor or performed on the fly as
 					part of SHACL processing (without modifying either <a>data graph</a> or <a>shapes graph</a>).
 					To support processing of entailments, SHACL includes the property
@@ -772,7 +829,7 @@ ex:PersonShape
 				</p>
 				<p class="syntax">
 					<span data-syntax-rule="entailment-nodeKind">The <a>values</a> of the property <code>sh:entailment</code> are IRIs.</span>
-					Common values for this property are covered by [[!sparql11-entailment]].
+					Common values for this property are covered by [[!sparql12-entailment]].
 				</p>
 				<p>
 					SHACL implementations MAY, but are not required to, support entailment regimes.
@@ -787,18 +844,16 @@ ex:PersonShape
 			<section id="shacl-sparql" class="informative">
 				<h3>Relationship between SHACL and SPARQL</h3>
 				<p>
-					For <a>SHACL Core</a> this specification uses parts of SPARQL 1.1 in non-normative alternative definitions of the semantics of <a>constraint components</a> and <a>targets</a>.
+					This specification uses parts of SPARQL 1.1 in non-normative alternative definitions of the semantics of <a>constraint components</a> and <a>targets</a>.
 					While these may help some implementers, SPARQL is not required for the implementation of the SHACL Core language.
 				</p>
 				<p>
-					SPARQL variables using the <code>$</code> marker represent external <a>bindings</a> that are <a>pre-bound</a> or, in the case of <code>$PATH</code>, <a>substituted</a> in the SPARQL query before execution (as explained in <a href="#constraint-components-validation"></a>).
+					SPARQL variables using the <code>$</code> marker represent external <a>bindings</a> that are <a>pre-bound</a> or, in the case of <code>$PATH</code>, <a>substituted</a> in the SPARQL query before execution (as explained in <a href="shacl12-sparql#constraint-components-validation"></a>).
 				</p>
 				<p>
 					The definition of some <a>constraints</a> requires or is simplified through access to the <a>shapes graph</a> during query execution.
 					SHACL-SPARQL processors MAY <a>pre-bind</a> the variable <code>shapesGraph</code> to provide access to the <a>shapes graph</a>.
 					Access to the <a>shapes graph</a> is not a requirement for supporting the SHACL Core language.
-					The variable <code>shapesGraph</code> can also be used in <a href="#sparql-constraints">SPARQL-based constraints</a> and <a href="#sparql-constraint-components">SPARQL-based constraint components</a>.
-					However, such <a>constraints</a> may not be interoperable across different SHACL-SPARQL processors or not applicable to remote RDF datasets.
 				</p>
 				<p>
 					Note that at the time of writing, SPARQL EXISTS has been imperfectly defined and implementations vary.
@@ -963,14 +1018,19 @@ ex:PersonShape
 						The following example specifies that the values of <code>ex:customer</code> have to be <a>SHACL instances</a> of both
 						<code>ex:Customer</code> and <code>ex:Person</code>.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:InvoiceShape
 	a sh:NodeShape ;
 	sh:property [
 		sh:path ex:customer ;
 		sh:class ex:Customer ;
 		sh:class ex:Person ;
-	] .</pre>
+	] .
+							</div>
+						</div>
+					</aside>
 					<p class="syntax" data-syntax-rule="multiple-parameters">
 						Some constraint components such as <a href="#PatternConstraintComponent"><code>sh:PatternConstraintComponent</code></a> declare more than one parameter.
 						Shapes that have more than one value for any of the parameters of such components are <a>ill-formed</a>.
@@ -978,7 +1038,9 @@ ex:InvoiceShape
 					<p>
 						One way to bypass this syntax rule is to spread the constraints across multiple (property) shapes, as illustrated in the following example.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:MultiplePatternsShape
 	a sh:NodeShape ;
 	sh:property [
@@ -989,9 +1051,12 @@ ex:MultiplePatternsShape
 	sh:property [
 		sh:path ex:name ;
 		sh:pattern "End$" ;
-	] .</pre>
+	] .
+							</div>
+						</div>
+					</aside>
 					<p>
-						Constraint components are associated with <dfn data-lt="validator">validators</dfn>, which provide instructions (for example expressed via SPARQL queries)
+						Constraint components are associated with <dfn data-lt="validator|validators">validators</dfn>, which provide instructions (for example expressed via SPARQL queries)
 						on how the parameters are used to validate data.
 						Validating an <a>RDF term</a> against a <a>shape</a> involves validating the term against each <a>constraint</a> where the 
 						shape has <a>values</a> for all <a>mandatory parameters</a> of the <a>component</a> of the <a>constraint</a>,
@@ -999,7 +1064,7 @@ ex:MultiplePatternsShape
 					</p>
 					<p>
 						The list of constraint components included in SHACL Core is described in <a href="#constraints">section 4</a>.
-						SHACL-SPARQL can be used to declare additional <a href="#sparql-constraint-components">constraint components based on SPARQL</a>.
+						SHACL-SPARQL can be used to declare additional <a href="shacl12-sparql#sparql-constraint-components">constraint components based on SPARQL</a>.
 					</p>
 				</section>
 
@@ -1065,18 +1130,25 @@ ex:MultiplePatternsShape
 						<p>
 							With the example data below, only <code>ex:Alice</code> is the target of the provided shape:
 						</p>
-						<pre class="example-shapes">
-ex:PersonShape
+						<aside class="example">
+							<div class="shapes-graph">
+								<div class="turtle">
+	ex:PersonShape
 	a sh:NodeShape ;
-	sh:targetNode ex:Alice .</pre>
-
-						<pre class="example-data">
+	sh:targetNode ex:Alice .
+								</div>
+							</div>
+							<div class="data-graph">
+								<div class="turtle">
 <span class="focus-node-selected">ex:Alice</span> a ex:Person .
-ex:Bob a ex:Person .</pre>
+ex:Bob a ex:Person .
+								</div>
+							</div>
+						</aside>
 	
 						<p class="def-sparql">
 							The following query expresses a potential definition of node targets in SPARQL.
-							The variable <code>targetNode</code> will be <a href="#pre-binding">pre-bound</a> to the given value of <code>sh:targetNode</code>.
+							The variable <code>targetNode</code> will be <a>pre-bound</a> to the given value of <code>sh:targetNode</code>.
 							All <a>bindings</a> of the variable <code>this</code> from the <a>solution</a> become focus nodes.
 						</p>
 						<div class="def def-sparql">
@@ -1084,7 +1156,7 @@ ex:Bob a ex:Person .</pre>
 <pre class="def-sparql-body">
 SELECT DISTINCT ?this    <span class="triple-can-be-skipped"># ?this is the focus node</span>
 WHERE {
-	BIND ($targetNode AS ?this)    <span class="triple-can-be-skipped"># $targetNode is <a href="#pre-binding">pre-bound</a> to ex:Alice</span>
+	BIND ($targetNode AS ?this)    <span class="triple-can-be-skipped"># $targetNode is <a>pre-bound</a> to ex:Alice</span>
 }</pre>
 						</div>
 					</section>
@@ -1102,15 +1174,23 @@ WHERE {
 							<code>DG</code> is a <a>target</a> from <code>DG</code> for <code>s</code> in <code>SG</code>.
 						</div>
 						<p><em>The remainder of this section is informative.</em></p>
-						<pre class="example-shapes">
+						<aside class="example">
+							<div class="shapes-graph">
+								<div class="turtle">
 ex:PersonShape
 	a sh:NodeShape ;
-	sh:targetClass ex:Person .</pre>
+	sh:targetClass ex:Person .
+								</div>
+							</div>
 
-						<pre class="example-data">
+							<div class="data-graph">
+								<div class="turtle">
 <span class="focus-node-selected">ex:Alice</span> a ex:Person .
 <span class="focus-node-selected">ex:Bob</span> a ex:Person .
-ex:NewYork a ex:Place .</pre>
+ex:NewYork a ex:Place .
+								</div>
+							</div>
+						</aside>
 						<p>
 							In this example, only <code>ex:Alice</code> and <code>ex:Bob</code> are focus nodes.
 							Note that, according to the <a>SHACL instance</a> definition, all the <code>rdfs:subClassOf</code> declarations needed to walk the class hierarchy need to exist in the <a>data graph</a>.
@@ -1119,14 +1199,18 @@ ex:NewYork a ex:Place .</pre>
 						<p>
 							In the following example, the selected focus node is only <code>ex:Who</code>.
 						</p>
-						<pre class="example-data">
+						<aside class="example">
+							<div class="data-graph">
+								<div class="turtle">
 ex:Doctor rdfs:subClassOf ex:Person .
 <span class="focus-node-selected">ex:Who</span> a ex:Doctor .
-ex:House a ex:Nephrologist .</pre>
-	
+ex:House a ex:Nephrologist .
+								</div>
+							</div>
+						</aside>
 						<p class="def-sparql">
 							The following query expresses a potential definition of class targets in SPARQL.
-							The variable <code>targetClass</code> will be <a href="#pre-binding">pre-bound</a> to the given value of <code>sh:targetClass</code>.
+							The variable <code>targetClass</code> will be <a>pre-bound</a> to the given value of <code>sh:targetClass</code>.
 							All <a>bindings</a> of the variable <code>this</code> from the <a>solutions</a> become focus nodes.
 						</p>
 						<div class="def def-sparql">
@@ -1134,7 +1218,7 @@ ex:House a ex:Nephrologist .</pre>
 <pre class="def-sparql-body">
 SELECT DISTINCT ?this    <span class="triple-can-be-skipped"># ?this is the focus node</span>
 WHERE {
-	?this rdf:type/rdfs:subClassOf* $targetClass .    <span class="triple-can-be-skipped"># $targetClass is <a href="#pre-binding">pre-bound</a> to ex:Person</span>
+	?this rdf:type/rdfs:subClassOf* $targetClass .    <span class="triple-can-be-skipped"># $targetClass is <a>pre-bound</a> to ex:Person</span>
 }</pre>
 						</div>
 	
@@ -1162,12 +1246,20 @@ WHERE {
 							In the following example, <code>ex:Alice</code> is a focus node, because it is a <a>SHACL instance</a> of
 							<code>ex:Person</code> which is both a class and a shape in the <a>shapes graph</a>.
 						</p>
-						<pre class="example-shapes">
+						<aside class="example">
+							<div class="shapes-graph">
+								<div class="turtle">
 ex:Person
-	<b>a rdfs:Class</b>, sh:NodeShape .</pre>
-							<pre class="example-data">
+	<b>a rdfs:Class</b>, sh:NodeShape .
+								</div>
+							</div>
+							<div class="data-graph">
+								<div class="turtle">
 <span class="focus-node-selected">ex:Alice</span> a ex:Person .
-ex:NewYork a ex:Place .</pre>
+ex:NewYork a ex:Place .
+								</div>
+							</div>
+						</aside>
 					</section>
 					
 					<section id="targetSubjectsOf">
@@ -1184,13 +1276,20 @@ ex:NewYork a ex:Place .</pre>
 							<code>p</code> is a <a>target</a> from <code>DG</code> for <code>s</code> in <code>SG</code>.
 						</div>
 						<p><em>The remainder of this section is informative.</em></p>
-						<pre class="example-shapes">
+						<aside class="example">
+							<div class="shapes-graph">
+								<div class="turtle">
 ex:TargetSubjectsOfExampleShape
 	a sh:NodeShape ;
-	sh:targetSubjectsOf ex:knows .</pre>
-						<pre class="example-data">
+	sh:targetSubjectsOf ex:knows .
+								</div>
+							</div>
+							<div class="data-graph">
+								<div class="turtle">
 <span class="focus-node-selected">ex:Alice</span> ex:knows ex:Bob .
-ex:Bob ex:livesIn ex:NewYork .</pre>
+ex:Bob ex:livesIn ex:NewYork .
+								</div>
+							</div>
 						<p>
 							In the example above, only <code>ex:Alice</code> is validated against the given shape,
 							because it is the <a>subject</a> of a <a>triple</a> that has <code>ex:knows</code> as its <a>predicate</a>.
@@ -1198,7 +1297,7 @@ ex:Bob ex:livesIn ex:NewYork .</pre>
 	
 						<p class="def-sparql">
 							The following query expresses a potential definition of subjects-of targets in SPARQL.
-							The variable <code>targetSubjectsOf</code> will be <a href="#pre-binding">pre-bound</a> to the given value of <code>sh:targetSubjectsOf</code>.
+							The variable <code>targetSubjectsOf</code> will be <a>pre-bound</a> to the given value of <code>sh:targetSubjectsOf</code>.
 							All <a>bindings</a> of the variable <code>this</code> from the <a>solutions</a> become focus nodes.
 						</p>
 						<div class="def def-sparql">
@@ -1206,7 +1305,7 @@ ex:Bob ex:livesIn ex:NewYork .</pre>
 <pre class="def-sparql-body">
 SELECT DISTINCT ?this    <span class="triple-can-be-skipped"># ?this is the focus node</span>
 WHERE {
-	?this $targetSubjectsOf ?any .    <span class="triple-can-be-skipped"># $targetSubjectsOf is <a href="#pre-binding">pre-bound</a> to ex:knows</span>
+	?this $targetSubjectsOf ?any .    <span class="triple-can-be-skipped"># $targetSubjectsOf is <a>pre-bound</a> to ex:knows</span>
 }</pre>
 						</div>
 					</section>
@@ -1225,13 +1324,21 @@ WHERE {
 							<code>p</code> is a <a>target</a> from <code>DG</code> for <code>s</code> in <code>SG</code>.
 						</div>
 						<p><em>The remainder of this section is informative.</em></p>
-						<pre class="example-shapes">
+						<aside class="example">
+							<div class="shapes-graph">
+								<div class="turtle">
 ex:TargetObjectsOfExampleShape
 	a sh:NodeShape ;
-	sh:targetObjectsOf ex:knows .</pre>
-					<pre class="example-data">
+	sh:targetObjectsOf ex:knows .
+								</div>
+							</div>
+							<div class="data-graph">
+								<div class="turtle">
 ex:Alice ex:knows <span class="focus-node-selected">ex:Bob</span> .
-ex:Bob ex:livesIn ex:NewYork .</pre>
+ex:Bob ex:livesIn ex:NewYork .
+								</div>
+							</div>
+						</aside>
 						<p>
 							In the example above, only <code>ex:Bob</code> is validated against the given shape,
 							because it is the <a>object</a> of a <a>triple</a> that has <code>ex:knows</code> as its <a>predicate</a>.
@@ -1239,7 +1346,7 @@ ex:Bob ex:livesIn ex:NewYork .</pre>
 	
 						<p class="def-sparql">
 							The following query expresses a potential definition of objects-of targets in SPARQL.
-							The variable <code>targetObjectsOf</code> will be <a href="#pre-binding">pre-bound</a> to the given value of <code>sh:targetObjectsOf</code>.
+							The variable <code>targetObjectsOf</code> will be <a>pre-bound</a> to the given value of <code>sh:targetObjectsOf</code>.
 							All <a>bindings</a> of the variable <code>this</code> from the <a>solutions</a> become focus nodes.
 						</p>
 						<div class="def def-sparql">
@@ -1247,7 +1354,7 @@ ex:Bob ex:livesIn ex:NewYork .</pre>
 <pre class="def-sparql-body">
 SELECT DISTINCT ?this    <span class="triple-can-be-skipped"># ?this is the focus node</span>
 WHERE {
-	?any $targetObjectsOf ?this .    <span class="triple-can-be-skipped"># $targetObjectsOf is <a href="#pre-binding">pre-bound</a> to ex:knows</span>
+	?any $targetObjectsOf ?this .    <span class="triple-can-be-skipped"># $targetObjectsOf is <a>pre-bound</a> to ex:knows</span>
 }</pre>
 						</div>
 					</section>
@@ -1294,7 +1401,9 @@ WHERE {
 						For every shape, <code>sh:Violation</code> is the default if <code>sh:severity</code> is unspecified.
 						The following example illustrates this.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:MyShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:MyInstance ;</span>
@@ -1311,11 +1420,17 @@ ex:MyShape
 		sh:maxLength 10 ;
 		sh:message "Too many characters"@en ;
 		sh:message "Zu viele Zeichen"@de ;
-	] .</pre>
-					<pre class="example-data">
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:MyInstance
-	ex:myProperty "http://toomanycharacters"^^xsd:anyURI .</pre>
-					<pre class="example-results">
+	ex:myProperty "http://toomanycharacters"^^xsd:anyURI .
+							</div>
+						</div>
+						<div class="results-graph">
+							<div class="turtle">
 [	a sh:ValidationReport ;
 	sh:conforms false ;
 	sh:result
@@ -1337,7 +1452,10 @@ ex:MyInstance
 		sh:sourceConstraintComponent sh:MaxLengthConstraintComponent ;
 		sh:sourceShape _:b2 ;
 	]
-] .</pre>
+] .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="message">
@@ -1352,7 +1470,6 @@ ex:MyInstance
 						all <a>validation results</a> produced as a result of the shape will have exactly these messages
 						as their value of <code>sh:resultMessage</code>, i.e. the values will be copied from the shapes graph
 						into the results graph.
-						(Note that in SHACL-SPARQL, <a>SPARQL-based constraints</a> and <a href="#sparql-constraint-components">SPARQL-based constraint components</a> provide additional means to declare such messages.)
 					</p>
 					<p><em>The remainder of this section is informative.</em></p>
 					<p>
@@ -1388,7 +1505,9 @@ ex:MyInstance
 						The following example illustrates the use of <code>sh:deactivated</code> to deactivate a shape.
 						In cases where shapes are imported from other graphs, the <code>sh:deactivated true</code> triple would be in the importing graph.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:PersonShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetClass ex:Person ;</span>
@@ -1398,12 +1517,18 @@ ex:PersonShape-name
 	a sh:PropertyShape ;
 	sh:path ex:name ;
 	sh:minCount 1 ;
-	sh:deactivated true .</pre>
-					<p>
-						With the following data, no constraint violation will be reported even though the instance does not have any value for <code>ex:name</code>. 
-					</p>
-					<pre class="example-data">
-ex:JohnDoe a ex:Person .</pre>
+	sh:deactivated true .
+							</div>
+						</div>
+						<p>
+							With the following data, no constraint violation will be reported even though the instance does not have any value for <code>ex:name</code>. 
+						</p>
+						<div class="data-graph">
+							<div class="turtle">
+ex:JohnDoe a ex:Person .
+							</div>
+						</div>
+					</aside>
 				</section>
 			</section>
 			
@@ -1442,7 +1567,9 @@ ex:JohnDoe a ex:Person .</pre>
 				<p>
 					The following example illustrates some syntax variations of property shapes.
 				</p>
-				<pre class="example-shapes">
+				<aside class="example">
+					<div class="shapes-graph">
+						<div class="turtle">
 ex:ExampleNodeShapeWithPropertyShapes
 	a sh:NodeShape ;
 	sh:property [
@@ -1462,7 +1589,10 @@ ex:ExamplePropertyShape
 	a sh:PropertyShape ;
 	sh:path ex:email ;
 	sh:description "We need at least one email value" ;
-	sh:minCount 1 .</pre>
+	sh:minCount 1 .
+						</div>
+					</div>
+				</aside>
 
 				<section id="property-paths">
 					<h4>SHACL Property Paths</h4>
@@ -1484,8 +1614,8 @@ ex:ExamplePropertyShape
 					<p>
 						The following example illustrates some valid SHACL property paths, together with their SPARQL 1.1 equivalents.
 					</p>
-					<pre class="example-other">
-SPARQL Property path: ex:parent
+					<aside class="example">
+						<pre>SPARQL Property path: ex:parent
 SHACL Property path: ex:parent
 
 SPARQL Property path: ^ex:parent
@@ -1498,7 +1628,9 @@ SPARQL Property path: rdf:type/rdfs:subClassOf*
 SHACL Property path: ( rdf:type [ sh:zeroOrMorePath rdfs:subClassOf ] )
 
 SPARQL Property path: ex:father|ex:mother
-SHACL Property path: [ sh:alternativePath ( ex:father ex:mother  ) ]</pre>
+SHACL Property path: [ sh:alternativePath ( ex:father ex:mother  ) ]
+						</pre>
+					</aside>
 					<section id="property-path-predicate">
 						<h5>Predicate Paths</h5>
 						<p class="syntax">
@@ -1635,7 +1767,9 @@ SHACL Property path: [ sh:alternativePath ( ex:father ex:mother  ) ]</pre>
 						<p>
 							The following example illustrates the use of these various features together.
 						</p>
-						<pre class="example-shapes">
+						<aside class="example">
+							<div class="shapes-graph">
+								<div class="turtle">
 ex:PersonFormShape
 	a sh:NodeShape ;
 	sh:property [
@@ -1683,7 +1817,10 @@ ex:NameGroup
 ex:AddressGroup
 	a sh:PropertyGroup ;
 	sh:order 1 ;
-	rdfs:label "Address" .</pre>
+	rdfs:label "Address" .
+								</div>
+							</div>
+						</aside>
 						<p>
 							A form building application MAY use the information above to display information as follows:
 						</p>
@@ -1785,10 +1922,15 @@ ex:AddressGroup
 					In the following example, a SHACL processor SHOULD use the union of <code>ex:graph-shapes1</code> and <code>ex:graph-shapes2</code> graphs (and their <code>owl:imports</code>) as the <a>shapes graph</a> when validating the given graph.
 				</p>
 
-				<pre class="example-data">
+				<aside class="example">
+					<div class="data-graph">
+						<div class="turtle">
 &lt;http://example.com/myDataGraph&gt;
 	sh:shapesGraph ex:graph-shapes1 ;
-	sh:shapesGraph ex:graph-shapes2 .</pre>
+	sh:shapesGraph ex:graph-shapes2 .
+						</div>
+					</div>
+				</aside>
 			</section>
 			
 			<section id="validation-definition">
@@ -1937,15 +2079,22 @@ ex:AddressGroup
 				<p>
 					The following graph represents an example of a validation report for the validation of a data graph that conforms to a shapes graph.
 				</p>
-				<pre class="example-results">
+				<aside class="example">
+					<div class="results-graph">
+						<div class="turtle">
 [ 	a sh:ValidationReport ;
 	sh:conforms true ;
-] .</pre>
+] .
+						</div>
+					</div>
+				</aside>
 				<p>
 					The following graph represents an example of a validation report for the validation of a data graph that does not conform to a shapes graph.
 					Note that the specific value of <code>sh:resultMessage</code> is not mandated by SHACL and considered implementation-specific.
 				</p>
-				<pre class="example-results">
+				<aside class="example">
+					<div class="results-graph">
+						<div class="turtle">
 [	a sh:ValidationReport ;
 	sh:conforms false ;
 	sh:result [
@@ -1958,7 +2107,10 @@ ex:AddressGroup
 		sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
 		sh:sourceShape ex:PersonShape-age ;
 	]
-] .</pre>
+] .
+						</div>
+					</div>
+				</aside>
 
 				<section id="results-validation-report">
 					<h4>Validation Report (sh:ValidationReport)</h4>
@@ -2137,18 +2289,18 @@ ex:AddressGroup
 				Examples of this include <code>sh:minCount</code> which is only supported for <a>property shapes</a>.
 			</p>
 			<p class="def-sparql">
-				The SPARQL definitions in this section represent potential <a href="#constraint-components-validators">validators</a>.
+				The SPARQL definitions in this section represent potential <a>validators</a>.
 				They are included for illustration purposes only and have no formal status otherwise.
 				Many constraint components are written as SPARQL ASK queries.
 				These queries are interpreted against each <a>value node</a>, bound to the variable <code>value</code>.
 				If an ASK query does not evaluate to <code>true</code> for a <a>value node</a>, then there is a <a>validation result</a> based on the rules outlined in
-				the <a href="#SPARQLAskValidator">section on ASK-based validators</a>.
+				the <a href="shacl12-sparql#SPARQLAskValidator">section on ASK-based validators</a>.
 				Constraint components that are described using a SELECT query are interpreted based on the rules outlined in
-				the <a href="#SPARQLSelectValidator">section on SELECT-based validators</a>.
+				the <a href="shacl12-sparql#SPARQLSelectValidator">section on SELECT-based validators</a>.
 				In particular, for <a>property shapes</a>, the variable <code>PATH</code> is <a>substituted</a> with a path expression
 				based on the value of <code>sh:path</code> in the shape.
 				All SPARQL queries also require the variable bindings and result variable mapping rules detailed in the
-				<a href="#sparql-constraints">section on SPARQL-based Constraints</a>.
+				<a href="shacl12-sparql#sparql-constraints">section on SPARQL-based Constraints</a>.
 				The variable <code>this</code> represents the currently validated <a>focus node</a>.
 				Based on the parameter IRIs on the tables, <a>pre-bound</a> variables are derived using the syntax rules for <a>parameter names</a>.
 			</p>
@@ -2202,19 +2354,26 @@ ASK {
 	$value rdf:type/rdfs:subClassOf* $class .
 }</pre>
 					</div>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:ClassExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:Bob, ex:Alice, ex:Carol ;</span>
 	sh:property [
 		sh:path ex:address ;
 		sh:class ex:PostalAddress ;
-	] .</pre>
-
-					<pre class="example-data">
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:Alice a ex:Person .
 ex:Bob ex:address [ a ex:PostalAddress ; ex:city ex:Berlin ] .
-<span class="focus-node-error">ex:Carol</span> ex:address [ ex:city ex:Cairo ] .</pre>
+<span class="focus-node-error">ex:Carol</span> ex:address [ ex:city ex:Cairo ] .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="DatatypeConstraintComponent">
@@ -2257,19 +2416,26 @@ ex:Bob ex:address [ a ex:PostalAddress ; ex:city ex:Berlin ] .
 						The values of <code>sh:datatype</code> are typically <a>datatypes</a>, such as <code>xsd:string</code>.
 						Note that using <code>rdf:langString</code> as value of <code>sh:datatype</code> can be used to test if value nodes have a language tag.
 					</p>
-					<pre class="example-shapes" title="Shape with sh:datatype property constraint">
+					<aside class="example" title="Shape with sh:datatype property constraint">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:DatatypeExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:Alice, ex:Bob, ex:Carol ;</span>
 	sh:property [
 		sh:path ex:age ;
 		sh:datatype xsd:integer ;
-	] .</pre>
-
-					<pre class="example-data">
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:Alice ex:age "23"^^xsd:integer .
 <span class="focus-node-error">ex:Bob</span> ex:age "twenty two" .
-<span class="focus-node-error">ex:Carol</span> ex:age "23"^^xsd:int .</pre>
+<span class="focus-node-error">ex:Carol</span> ex:age "23"^^xsd:int .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="NodeKindConstraintComponent">
@@ -2322,15 +2488,22 @@ ASK {
 					<p>
 						The following example states that all values of <code>ex:knows</code> need to be IRIs, at any subject.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:NodeKindExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetObjectsOf ex:knows ;</span>
-	sh:nodeKind sh:IRI .</pre>
-
-					<pre class="example-data">
+	sh:nodeKind sh:IRI .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:Bob ex:knows ex:Alice .
-	ex:Alice ex:knows <span class="focus-node-error">"Bob"</span> .</pre>
+	ex:Alice ex:knows <span class="focus-node-error">"Bob"</span> .
+							</div>
+						</div>
+					</aside>
 				</section>
 			</section>
 
@@ -2373,28 +2546,23 @@ ex:Bob ex:knows ex:Alice .
 						</div>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
-					<!-- div class="def def-sparql">
-						<div class="def-header">POTENTIAL DEFINITION IN SPARQL (Must return no results for the given $PATH)</div>
-<pre class="def-sparql-body">
-SELECT $this
-WHERE {
-	OPTIONAL {
-		$this $PATH ?value .
-	}
-} 
-GROUP BY $this
-HAVING (COUNT(DISTINCT ?value) &lt; $minCount)</pre>
-					</div-->
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:MinCountExampleShape
 	a sh:PropertyShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:Alice, ex:Bob ;</span>
 	sh:path ex:name ;
-	sh:minCount 1 .</pre>
-
-					<pre class="example-data">
-ex:Alice ex:name "Alice" .
-<span class="focus-node-error">ex:Bob</span> ex:givenName "Bob"@en .</pre>
+	sh:minCount 1 .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
+	ex:Alice ex:name "Alice" .
+<span class="focus-node-error">ex:Bob</span> ex:givenName "Bob"@en .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="MaxCountConstraintComponent">
@@ -2430,27 +2598,23 @@ ex:Alice ex:name "Alice" .
 						</div>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
-					<!-- div class="def def-sparql">
-						<div class="def-header">POTENTIAL DEFINITION IN SPARQL (Must return no results for the given $PATH)</div>
-<pre class="def-sparql-body">
-SELECT $this
-WHERE {
-	$this $PATH ?value .
-}
-GROUP BY $this
-HAVING (COUNT(DISTINCT ?value) > $maxCount)</pre>
-					</div-->
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:MaxCountExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:Bob ;</span>
 	sh:property [
 		sh:path ex:birthDate ;
 		sh:maxCount 1 ;
-	] .</pre>
-
-					<pre class="example-data">
-ex:Bob ex:birthDate "May 5th 1990" .</pre>
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
+ex:Bob ex:birthDate "May 5th 1990" .
+							</div>
+						</div>
 				</section>
 			</section>
 			
@@ -2461,7 +2625,9 @@ ex:Bob ex:birthDate "May 5th 1990" .</pre>
 					via operators such as <code>&lt;</code>, <code>&lt;=</code>, <code>&gt;</code> and <code>&gt;=</code>.
 					The following example illustrates a typical use case of these constraint components.
 				</p>
-				<pre class="example-shapes">
+				<aside class="example">
+					<div class="shapes-graph">
+						<div class="turtle">
 ex:NumericRangeExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:Bob, ex:Alice, ex:Ted ;</span>
@@ -2469,12 +2635,18 @@ ex:NumericRangeExampleShape
 		sh:path ex:age ;
 		sh:minInclusive 0 ;
 		sh:maxInclusive 150 ;
-	] .</pre>
+	] .
+						</div>
+					</div>
 
-				<pre class="example-data">
+					<div class="data-graph">
+						<div class="turtle">
 ex:Bob ex:age 23 .
 <span class="focus-node-error">ex:Alice</span> ex:age 220 .
-<span class="focus-node-error">ex:Ted</span> ex:age "twenty one" .</pre>
+<span class="focus-node-error">ex:Ted</span> ex:age "twenty one" .
+						</div>
+					</div>
+				</aside>
 				
 				<section id="MinExclusiveConstraintComponent">
 					<h4>sh:minExclusive</h4>
@@ -2733,7 +2905,9 @@ ASK {
 	FILTER (STRLEN(str($value)) &lt;= $maxLength) .
 }</pre>
 					</div>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:PasswordExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:Bob, ex:Alice ;</span>
@@ -2741,11 +2915,16 @@ ex:PasswordExampleShape
 		sh:path ex:password ;
 		sh:minLength 8 ;
 		sh:maxLength 10 ;
-	] .</pre>
-
-					<pre class="example-data">
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:Bob ex:password "123456789" .
-<span class="focus-node-error">ex:Alice</span> ex:password "1234567890ABC" .</pre>
+<span class="focus-node-error">ex:Alice</span> ex:password "1234567890ABC" .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="PatternConstraintComponent">
@@ -2798,7 +2977,9 @@ ASK {
 	FILTER (!isBlank($value) &amp;&amp; IF(bound($flags), regex(str($value), $pattern, $flags), regex(str($value), $pattern)))
 }</pre>
 					</div>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:PatternExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:Bob, ex:Alice, ex:Carol ;</span>
@@ -2806,11 +2987,17 @@ ex:PatternExampleShape
 		sh:path ex:bCode ;
 		sh:pattern "^B" ;    # starts with 'B'
 		sh:flags "i" ;       # Ignore case
-	] .</pre>
-					<pre class="example-data">
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:Bob ex:bCode "b101" .
 ex:Alice ex:bCode "B102" .
-<span class="focus-node-error">ex:Carol</span> ex:bCode "C103" .</pre>
+<span class="focus-node-error">ex:Carol</span> ex:bCode "C103" .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="LanguageInConstraintComponent">
@@ -2849,37 +3036,28 @@ ex:Alice ex:bCode "B102" .
 						</div>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
-					<!-- Disabled due to the use of EXISTS
-					<div class="def def-sparql">
-						<div class="def-header">POTENTIAL DEFINITION IN SPARQL (Must evaluate to true for each value node $value)</div>
-<pre class="def-sparql-body">
-ASK {
-	BIND (lang($value) AS ?valueLang) .
-	FILTER EXISTS {
-			GRAPH $shapesGraph {
-				$languageIn (rdf:rest*)/rdf:first ?lang .
-				FILTER (langMatches(?valueLang, ?lang))
-			} 
-		}
-}</pre>
-					</div-->
 					<p>
 						The following example shape states that all values of <code>ex:prefLabel</code>
 						can be either in English or Māori.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:NewZealandLanguagesShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:Mountain, ex:Berg ;</span>
 	sh:property [
 		sh:path ex:prefLabel ;
 		sh:languageIn ( "en" "mi" ) ;
-	] .</pre>
-					<p>
-						From the example instances, <code>ex:Berg</code> will lead to constraint violations for all
-						of its labels.
-					</p>
-					<pre class="example-data">
+	] .
+							</div>
+						</div>
+						<p>
+							From the example instances, <code>ex:Berg</code> will lead to constraint violations for all
+							of its labels.
+						</p>
+						<div class="data-graph">
+							<div class="turtle">
 ex:Mountain
 	ex:prefLabel "Mountain"@en ;
 	ex:prefLabel "Hill"@en-NZ ;
@@ -2888,7 +3066,10 @@ ex:Mountain
 <span class="focus-node-error">ex:Berg</span>
 	ex:prefLabel "Berg" ;
 	ex:prefLabel "Berg"@de ;
-	ex:prefLabel ex:BergLabel .</pre>
+	ex:prefLabel ex:BergLabel .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="UniqueLangConstraintComponent">
@@ -2925,34 +3106,20 @@ ex:Mountain
 						</div>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
-					<!-- Deactivated due to the use of EXISTS
-					<div class="def def-sparql">
-						<div class="def-header">POTENTIAL DEFINITION IN SPARQL (Must return no results for the given $PATH)</div>
-<pre class="def-sparql-body">
-SELECT DISTINCT $this ?lang
-WHERE {
-	{
-		FILTER ($uniqueLang) .
-	}
-	$this $PATH ?value .
-	BIND (lang(?value) AS ?lang) .
-	FILTER (bound(?lang) &amp;&amp; ?lang != "") . 
-	FILTER EXISTS {
-		$this $PATH ?otherValue .
-		FILTER (?otherValue != ?value &amp;&amp; ?lang = lang(?otherValue)) .
-	}
-}</pre>
-					</div-->
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:UniqueLangExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:Alice, ex:Bob ;</span>
 	sh:property [
 		sh:path ex:label ;
 		sh:uniqueLang true ;
-	] .</pre>
-
-					<pre class="example-data">
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:Alice
 	ex:label "Alice" ;
 	ex:label "Alice"@en ;
@@ -2960,7 +3127,10 @@ ex:Alice
 
 <span class="focus-node-error">ex:Bob</span>
 	ex:label "Bob"@en ;
-	ex:label "Bobby"@en .</pre>
+	ex:label "Bobby"@en .
+							</div>
+						</div>
+					</aside>
 				</section>
 			</section>
 			
@@ -3010,18 +3180,26 @@ ex:Alice
 						The following example illustrates the use of <code>sh:equals</code> in a shape to specify
 						that certain focus nodes need to have the same set of values for <code>ex:firstName</code> and <code>ex:givenName</code>.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example" title="Shape with sh:datatype property constraint">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:EqualExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:Bob ;</span>
 	sh:property [
 		sh:path ex:firstName ;
 		sh:equals ex:givenName ;
-	] .</pre>
-					<pre class="example-data">
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:Bob
 	ex:firstName "Bob" ;
-	ex:givenName "Bob" .</pre>
+	ex:givenName "Bob" .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="DisjointConstraintComponent">
@@ -3072,22 +3250,30 @@ WHERE {
 						The following example illustrates the use of <code>sh:disjoint</code> in a shape to specify
 						that certain focus nodes cannot share any values for <code>ex:prefLabel</code> and <code>ex:altLabel</code>.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:DisjointExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:USA, ex:Germany ;</span>
 	sh:property [
 		sh:path ex:prefLabel ;
 		sh:disjoint ex:altLabel ;
-	] .</pre>
-					<pre class="example-data">
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:USA
 	ex:prefLabel "USA" ;
 	ex:altLabel "United States" .
 
 <span class="focus-node-error">ex:Germany</span>
 	ex:prefLabel "Germany" ;
-	ex:altLabel "Germany" .</pre>
+	ex:altLabel "Germany" .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="LessThanConstraintComponent">
@@ -3139,13 +3325,18 @@ WHERE {
 						The following example illustrates the use of <code>sh:lessThan</code> in a shape to specify
 						that all values of <code>ex:startDate</code> are "before" the values of <code>ex:endDate</code>.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:LessThanExampleShape
 	a sh:NodeShape ;
 	sh:property [
 		sh:path ex:startDate ;
 		sh:lessThan ex:endDate ;
-	] .</pre>
+	] .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="LessThanOrEqualsConstraintComponent">
@@ -3241,7 +3432,9 @@ WHERE {
 						The following example illustrates the use of <code>sh:not</code> in a shape to specify the condition
 						that certain focus nodes cannot have any value of <code>ex:property</code>.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:NotExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:InvalidInstance1 ;</span>
@@ -3249,9 +3442,15 @@ ex:NotExampleShape
 		a sh:PropertyShape ;
 		sh:path ex:property ;
 		sh:minCount 1 ;
-	] .</pre>
-					<pre class="example-data">
-<span class="focus-node-error">ex:InvalidInstance1</span> ex:property "Some value" .</pre>
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
+<span class="focus-node-error">ex:InvalidInstance1</span> ex:property "Some value" .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="AndConstraintComponent">
@@ -3300,7 +3499,9 @@ ex:NotExampleShape
 						the minimum count, and a blank node shape that additionally specifies the maximum count.
 						As shown here, <code>sh:and</code> can be used to implement a specialization mechanism between shapes.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:SuperShape
 	a sh:NodeShape ;
 	sh:property [
@@ -3317,16 +3518,21 @@ ex:ExampleAndShape
 			sh:path ex:property ;
 			sh:maxCount 1 ;
 		]
-	) .</pre>
-
-<pre class="example-data">
+	) .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:ValidInstance
 	ex:property "One" .
 
 # Invalid: more than one property
 <span class="focus-node-error">ex:InvalidInstance</span>
 	ex:property "One" ;
-	ex:property "Two" .</pre>
+	ex:property "Two" .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="OrConstraintComponent">
@@ -3373,7 +3579,9 @@ ex:ValidInstance
 						that certain focus nodes have at least one value of <code>ex:firstName</code>
 						or at least one value of <code>ex:givenName</code>.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:OrConstraintExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:Bob ;</span>
@@ -3386,15 +3594,23 @@ ex:OrConstraintExampleShape
 			sh:path ex:givenName ;
 			sh:minCount 1 ;
 		]
-	) .</pre>
-					<pre class="example-data">
-ex:Bob ex:firstName "Robert" .</pre>
+	) .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
+ex:Bob ex:firstName "Robert" .
+							</div>
+						</div>
+					</aside>
 					<p>
 						The next example shows how <code>sh:or</code> can be used in a <a>property shape</a> to state that the values of
 						the given property <code>ex:address</code> may be either literals with datatype <code>xsd:string</code>
 						or <a>SHACL instances</a> of the class <code>ex:Address</code>.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:PersonAddressShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetClass ex:Person ;</span>
@@ -3408,9 +3624,15 @@ ex:PersonAddressShape
 				sh:class ex:Address ;
 			]
 		)
-	] .</pre>
-					<pre class="example-data">
-ex:Bob ex:address "123 Prinzengasse, Vaduz, Liechtenstein" .</pre>
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
+ex:Bob ex:address "123 Prinzengasse, Vaduz, Liechtenstein" .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="XoneConstraintComponent">
@@ -3458,7 +3680,9 @@ ex:Bob ex:address "123 Prinzengasse, Vaduz, Liechtenstein" .</pre>
 						that certain focus nodes must either have a value for <code>ex:fullName</code> or values for
 						<code>ex:firstName</code> and <code>ex:lastName</code>, but not both.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:XoneConstraintExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetClass ex:Person ;</span>
@@ -3479,8 +3703,11 @@ ex:XoneConstraintExampleShape
 				sh:minCount 1 ;
 			]
 		]
-	) .</pre>
-					<pre class="example-data">
+	) .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:Bob a ex:Person ;
 	ex:firstName "Robert" ; 
 	ex:lastName "Coin" .
@@ -3491,7 +3718,10 @@ ex:Carla a ex:Person ;
 <span class="focus-node-error">ex:Dory</span> a ex:Person ;
 	ex:firstName "Dory" ;
 	ex:lastName "Dunce" ;
-	ex:fullName "Dory Dunce" .</pre>
+	ex:fullName "Dory Dunce" .
+							</div>
+						</div>
+					</aside>
 				</section>
 			</section>
 	
@@ -3538,7 +3768,9 @@ ex:Carla a ex:Person ;
 						In the following example, all values of the property <code>ex:address</code> must fulfill the
 						constraints expressed by the <a>shape</a> <code>ex:AddressShape</code>.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:AddressShape
 	a sh:NodeShape ;
 	sh:property [
@@ -3554,8 +3786,11 @@ ex:PersonShape
 		sh:path ex:address ;
 		sh:minCount 1 ;
 		sh:node ex:AddressShape ;
-	] .</pre>
-					<pre class="example-data">
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:Bob a ex:Person ;
 	ex:address ex:BobsAddress .
 	
@@ -3566,8 +3801,11 @@ ex:BobsAddress
 	ex:address ex:RetosAddress .
 
 ex:RetosAddress
-	ex:postalCode 5678 .</pre>
-					<pre class="example-results">
+	ex:postalCode 5678 .
+							</div>
+						</div>
+						<div class="results-graph">
+							<div class="turtle">
 [	a sh:ValidationReport ;
 	sh:conforms false ;
 	sh:result [
@@ -3580,7 +3818,10 @@ ex:RetosAddress
 		sh:sourceConstraintComponent sh:NodeConstraintComponent ;
 		sh:sourceShape _:b1 ;
 	]
-] .</pre>
+] .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="PropertyConstraintComponent">
@@ -3720,7 +3961,9 @@ ex:RetosAddress
 						In the following example shape can be used to specify the condition that the property <code>ex:parent</code> has exactly two values,
 						and at least one of them is female.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:QualifiedValueShapeExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:QualifiedValueShapeExampleValidResource ;</span>
@@ -3733,9 +3976,11 @@ ex:QualifiedValueShapeExampleShape
 			sh:hasValue ex:female ;
 		] ;
 		sh:qualifiedMinCount 1 ;
-	] .</pre>
-
-					<pre class="example-data">
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:QualifiedValueShapeExampleValidResource
 	ex:parent ex:John ;
 	ex:parent ex:Jane .
@@ -3744,7 +3989,10 @@ ex:John
 	ex:gender ex:male .
 
 ex:Jane
-	ex:gender ex:female .</pre>
+	ex:gender ex:female .
+							</div>
+						</div>
+					</aside>
 					<p>
 						The following example illustrates the use of <code>sh:qualifiedValueShapesDisjoint</code>
 						to express that a hand must have at most 5 values of <code>ex:property</code> (expressed using <code>sh:maxCount</code>),
@@ -3752,7 +4000,9 @@ ex:Jane
 						but thumbs and fingers must be disjoint.
 						In other words, on a hand, none of the fingers can also be counted as the thumb. 
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:HandShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetClass ex:Hand ;</span>
@@ -3773,7 +4023,10 @@ ex:HandShape
 		sh:qualifiedValueShapesDisjoint true ;
 		sh:qualifiedMinCount 4 ;
 		sh:qualifiedMaxCount 4 ;
-	] .</pre>
+	] .
+							</div>
+						</div>
+					</aside>
 				</section>
 			</section>
 			
@@ -3833,33 +4086,14 @@ ex:HandShape
 						</div>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
-					<!-- Deactivated due to the use of EXISTS
-					<div class="def def-sparql">
-						<div class="def-header">POTENTIAL DEFINITION IN SPARQL (Must return no results)</div>
-<pre class="def-sparql-body">
-SELECT $this (?predicate AS ?path) ?value
-WHERE {
-	{
-		FILTER ($closed) .
-	}
-	$this ?predicate ?value .
-	FILTER (NOT EXISTS {
-		GRAPH $shapesGraph {
-			$currentShape sh:property/sh:path ?predicate .
-		}
-	} &amp;&amp; (!bound($ignoredProperties) || NOT EXISTS {
-		GRAPH $shapesGraph {
-			$ignoredProperties rdf:rest*/rdf:first ?predicate .
-		}
-	}))
-}</pre>
-					</div -->
 					<p>
 						The following example illustrates the use of <code>sh:closed</code> in a shape to specify the condition
 						that certain focus nodes only have values for <code>ex:firstName</code> and <code>ex:lastName</code>.
 						The "ignored" property <code>rdf:type</code> would also be allowed.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:ClosedShapeExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:Alice, ex:Bob ;</span>
@@ -3870,15 +4104,20 @@ ex:ClosedShapeExampleShape
 	] ;
 	sh:property [
 		sh:path ex:lastName ;
-	] .</pre>
-
-					<pre class="example-data">
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:Alice
 	ex:firstName "Alice" .
 
 <span class="focus-node-error">ex:Bob</span>
 	ex:firstName "Bob" ;
-	ex:middleInitial "J" .</pre>
+	ex:middleInitial "J" .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="HasValueConstraintComponent">
@@ -3911,28 +4150,26 @@ ex:Alice
 						</div>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
-					<!-- Deactivated due to the use of EXISTS
-					<div class="def def-sparql">
-						<div class="def-header">POTENTIAL DEFINITION IN SPARQL (Must return no results for the given $PATH)</div>
-<pre class="def-sparql-body">
-SELECT $this
-WHERE {
-	FILTER NOT EXISTS { $this $PATH $hasValue }
-}</pre>
-					</div-->
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:StanfordGraduate
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:Alice ;</span>
 	sh:property [
 		sh:path ex:alumniOf ;
 		sh:hasValue ex:Stanford ;
-	] .</pre>
-
-					<pre class="example-data">
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:Alice
 	ex:alumniOf ex:Harvard ;
-	ex:alumniOf ex:Stanford .</pre>
+	ex:alumniOf ex:Stanford .
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="InConstraintComponent">
@@ -3980,17 +4217,24 @@ ASK {
 	}
 }</pre>
 					</div>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:InExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:RainbowPony ;</span>
 	sh:property [
 		sh:path ex:color ;
 		sh:in ( ex:Pink ex:Purple ) ;
-	] .</pre>
-
-					<pre class="example-data">
-ex:RainbowPony ex:color ex:Pink .</pre>
+	] .
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
+ex:RainbowPony ex:color ex:Pink .
+							</div>
+						</div>
+					</aside>
 				</section>
 			</section>
 		</section>
@@ -4027,7 +4271,9 @@ ex:RainbowPony ex:color ex:Pink .</pre>
         		This shapes graph is available at <a href="http://www.w3.org/ns/shacl-shacl">http://www.w3.org/ns/shacl-shacl</a>.
         		That version may be more up-to-date than this specification as errata are noted against this specification.
 			</p>
-			<div id="shacl-shacl-pre" class="prediv">@prefix rdf:  &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+			<div class="shapes-graph">
+				<div class="turtle" id="shacl-shacl-pre">
+@prefix rdf:  &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh:   &lt;http://www.w3.org/ns/shacl#> .
 @prefix xsd:  &lt;http://www.w3.org/2001/XMLSchema#> .
@@ -4432,7 +4678,8 @@ shsh:EntailmentShape
 	a sh:NodeShape ;
 	sh:targetObjectsOf sh:entailment ;
 	sh:nodeKind sh:IRI .                # entailment-nodeKind
-</div>
+				</div>
+			</div>
 		</section>
 		
 		<section id="core-validators" class="appendix">

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -500,7 +500,7 @@
 				<div class="def">
 					<div class="term-def-header">Binding, Solution</div>
 					<div>
-						A <dfn data-lt="bindings">binding</dfn> is a pair (<a href="https://www.w3.org/TR/sparql11-query/#defn_QueryVariable">variable</a>, <a>RDF term</a>), consistent with the term's use in <a href="https://www.w3.org/TR/sparql11-query/">SPARQL</a>.
+						A <dfn data-lt="bindings">binding</dfn> is a pair (<a data-cite="sparql12-query/#defn_QueryVariable">variable</a>, <a>RDF term</a>), consistent with the term's use in [[!sparql12-query]]</a>.
 					    A <dfn data-lt="solutions">solution</dfn> is a set of bindings, informally often understood as one row in the body of the result table of a SPARQL query.
 					    Variables are not required to be bound in a solution.
 					</div>
@@ -844,7 +844,7 @@ ex:PersonShape
 			<section id="shacl-sparql" class="informative">
 				<h3>Relationship between SHACL and SPARQL</h3>
 				<p>
-					This specification uses parts of SPARQL 1.1 in non-normative alternative definitions of the semantics of <a>constraint components</a> and <a>targets</a>.
+					This specification uses parts of SPARQL 1.2 in non-normative alternative definitions of the semantics of <a>constraint components</a> and <a>targets</a>.
 					While these may help some implementers, SPARQL is not required for the implementation of the SHACL Core language.
 				</p>
 				<p>
@@ -1603,7 +1603,7 @@ ex:ExamplePropertyShape
 					</p>
 					<p>
 						The following sub-sections provide syntax rules of <a>well-formed</a> <a>SHACL property paths</a>
-						together with mapping rules to <a href="https://www.w3.org/TR/sparql11-query/#pp-language">SPARQL 1.1 property paths</a>.
+						together with mapping rules to <a href="https://www.w3.org/TR/sparql12-query/#pp-language">SPARQL 1.2 property paths</a>.
 						These rules define the <dfn>path mapping</dfn> <code>path(p,G)</code> in an RDF graph <code>G</code> of an RDF term <code>p</code> that is a SHACL property path in <code>G</code>.
 						Two SHACL property paths are considered <dfn data-lt="equivalent path">equivalent paths</dfn> when they map to the exact same SPARQL property paths.
 					</p>
@@ -1612,7 +1612,7 @@ ex:ExamplePropertyShape
 						<span data-syntax-rule="path-non-recursive">A node <code>p</code> is not a <a>well-formed</a> SHACL property path if <code>p</code> is a blank node and any path mappings of <code>p</code> directly or transitively reference <code>p</code>.</span>
 					</p>
 					<p>
-						The following example illustrates some valid SHACL property paths, together with their SPARQL 1.1 equivalents.
+						The following example illustrates some valid SHACL property paths, together with their SPARQL 1.2 equivalents.
 					</p>
 					<aside class="example">
 						<pre>SPARQL Property path: ex:parent
@@ -1881,9 +1881,9 @@ ex:AddressGroup
 				</p>
 				<p><em>The remainder of this section is informative.</em></p>
 				<p>
-					Shapes graphs can be reusable validation modules that can be cross-referenced with the predicate <a href="http://www.w3.org/TR/owl2-syntax/#Imports"><code>owl:imports</code></a>.
+					Shapes graphs can be reusable validation modules that can be cross-referenced with the predicate <a data-cite="owl2-syntax/#Imports"><code>owl:imports</code></a>.
 					As a pre-validation step, SHACL processors SHOULD extend the originally provided <a>shapes graph</a> by transitively following and importing all referenced <a>shapes graphs</a>
-					through the <a href="http://www.w3.org/TR/owl2-syntax/#Imports"><code>owl:imports</code></a> predicate.
+					through the <a data-cite="owl2-syntax/#Imports"><code>owl:imports</code></a> predicate.
 					The resulting graph forms the input <a>shapes graph</a> for validation and MUST NOT be further modified during the validation process.
 				</p>
 				<p>
@@ -1903,7 +1903,7 @@ ex:AddressGroup
 					For example, it can be an in-memory graph or a named graph from an RDF dataset or a SPARQL endpoint.
 				</p>
 				<p>
-					SHACL can be used with RDF graphs that are obtained by any means, e.g. from the file system, HTTP requests, or <a href="http://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF datasets</a>.
+					SHACL can be used with RDF graphs that are obtained by any means, e.g. from the file system, HTTP requests, or <a data-cite="rdf12-concepts/#section-dataset">RDF datasets</a>.
 					SHACL makes no assumptions about whether a graph contains triples that are entailed from the graph under any RDF entailment regime.
 				</p>
 				<p>
@@ -2406,9 +2406,9 @@ ex:Bob ex:address [ a ex:PostalAddress ; ex:city ex:Berlin ] .
 							For each <a>value node</a>
 							that is not a <a>literal</a>, or is a <a>literal</a> with a datatype that does not match <code>$datatype</code>,
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
-							The datatype of a literal is determined following the <a href="https://www.w3.org/TR/sparql11-query/#func-datatype">datatype</a> function of SPARQL 1.1.
+							The datatype of a literal is determined following the <a data-cite="sparql12-query/#func-datatype">datatype</a> function of SPARQL 1.2.
 							A <a>literal</a> matches a datatype if the <a>literal</a>'s datatype has the same <a>IRI</a>
-							and, for the datatypes supported by SPARQL 1.1, is not an <a href="https://www.w3.org/TR/rdf11-concepts#section-Graph-Literal">ill-typed</a> literal.
+							and, for the datatypes supported by SPARQL 1.2, is not an <a data-cite="rdf12-concepts#section-Graph-Literal">ill-typed</a> literal.
 						</div>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
@@ -2842,8 +2842,8 @@ ASK {
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MinLength">
 							For each <a>value node</a> <code>v</code>
-							where the length (as defined by the <a href="https://www.w3.org/TR/sparql11-query/#func-strlen">SPARQL STRLEN function</a>)
-							of the string representation of <code>v</code> (as defined by the <a href="http://www.w3.org/TR/sparql11-query/#func-str">SPARQL str function</a>)
+							where the length (as defined by the <a data-cite="sparql12-query/#func-strlen">SPARQL STRLEN function</a>)
+							of the string representation of <code>v</code> (as defined by the <a data-cite="sparql12-query/#func-str">SPARQL str function</a>)
 							is less than <code>$minLength</code>, or where <code>v</code> is a <a>blank node</a>,
 							there is a <a>validation result</a> with <code>v</code> as <code>sh:value</code>.
 						</div>
@@ -2891,8 +2891,8 @@ ASK {
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MaxLength">
 							For each <a>value node</a> <code>v</code>
-							where the length (as defined by the <a href="https://www.w3.org/TR/sparql11-query/#func-strlen">SPARQL STRLEN function</a>)
-							of the string representation of <code>v</code> (as defined by the <a href="http://www.w3.org/TR/sparql11-query/#func-str">SPARQL str function</a>)
+							where the length (as defined by the <a data-cite="sparql12-query/#func-strlen">SPARQL STRLEN function</a>)
+							of the string representation of <code>v</code> (as defined by the <a data-cite="sparql12-query/#func-str">SPARQL str function</a>)
 							is greater than <code>$maxLength</code>, or where <code>v</code> is a <a>blank node</a>,
 							there is a <a>validation result</a> with <code>v</code> as <code>sh:value</code>.
 						</div>
@@ -2947,13 +2947,13 @@ ex:Bob ex:password "123456789" .
 							<td>
 								A regular expression that all value nodes need to match.
 								<span data-syntax-rule="pattern-datatype">The values of <code>sh:pattern</code> in a shape are literals with datatype <code>xsd:string</code>.</span>
-								<span data-syntax-rule="pattern-regex">The values of <code>sh:pattern</code> in a shape are valid pattern arguments for the <a href="http://www.w3.org/TR/sparql11-query/#func-regex">SPARQL REGEX function</a>.</span>
+								<span data-syntax-rule="pattern-regex">The values of <code>sh:pattern</code> in a shape are valid pattern arguments for the <a data-cite="sparql12-query/#func-regex">SPARQL REGEX function</a>.</span>
 							</td>
 						</tr>
 						<tr>
 							<td><code>sh:flags</code></td>
 							<td>
-								An optional string of flags, interpreted as in <a href="http://www.w3.org/TR/sparql11-query/#func-regex">SPARQL 1.1 REGEX</a>.
+								An optional string of flags, interpreted as in <a data-cite="sparql12-query/#func-regex">SPARQL 1.2 REGEX</a>.
 								<span data-syntax-rule="flags-datatype">The values of <code>sh:flags</code> in a shape are literals with datatype <code>xsd:string</code>.</span>
 							</td>
 						</tr>
@@ -2963,8 +2963,8 @@ ex:Bob ex:password "123456789" .
 						<div class="def-text-body" data-validator="Pattern">
 							For each <a>value node</a>
 							that is a blank node or
-							where the string representation (as defined by the <a href="http://www.w3.org/TR/sparql11-query/#func-str">SPARQL str function</a>)
-							does not match the regular expression <code>$pattern</code> (as defined by the <a href="http://www.w3.org/TR/sparql11-query/#func-regex">SPARQL REGEX function</a>),
+							where the string representation (as defined by the <a data-cite="sparql12-query/#func-str">SPARQL str function</a>)
+							does not match the regular expression <code>$pattern</code> (as defined by the <a data-cite="sparql12-query/#func-regex">SPARQL REGEX function</a>),
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
 							If <code>$flags</code> has a value then the matching MUST follow the definition of the 3-argument variant of the SPARQL REGEX function, using <code>$flags</code> as third argument.
 						</div>
@@ -3031,7 +3031,7 @@ ex:Alice ex:bCode "B102" .
 							For each <a>value node</a>
 							that is either not a <a>literal</a> or that does not have a language tag
 							matching any of the basic language ranges that are the <a>members</a> of <code>$languageIn</code>
-							following the filtering schema defined by the <a href="https://www.w3.org/TR/sparql11-query/#func-langMatches">SPARQL langMatches</a> function,
+							following the filtering schema defined by the <a data-cite="sparql12-query/#func-langMatches">SPARQL langMatches</a> function,
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
 						</div>
 					</div>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -4,30 +4,52 @@
 		<title>SHACL 1.2 SPARQL Extensions</title>
 		<meta charset="utf-8">
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 		<script class="remove">
 		
-		function prepareSyntaxRules() {
-				var ttl = $("#shacl-shacl-pre").html();
-				$("[data-syntax-rule]").each(function(index, element) {
-					var ruleId = $(element).attr("data-syntax-rule");
-					var tr = $("<tr class=\"syntax-rule-tr\"><td class=\#syntax-rule-id\"><a class=\"syntax-rule-id-a\" href=\"#syntax-rule-" + ruleId + "\">" + ruleId + "</a></td><td>" + $(element).html() + "</td></tr>");
-					tr.find("dfn").replaceWith(function(el) { return $("<a>" + $(this).text() + "</a>"); });
-					$("#syntax-rules-table").append(tr);
-					$(element).attr("id", "syntax-rule-" + ruleId);
-					if("shape" !== ruleId) { 
-						ttl = ttl.split("# " + ruleId).join("<a href=\"#syntax-rule-" + ruleId + "\"># " + ruleId + "</a>");
-					}
+			function prepareSyntaxRules() {
+				document.querySelectorAll("[data-syntax-rule]").forEach(element => {
+					let ruleId = element.getAttribute("data-syntax-rule");
+					let tr = document.createElement("tr");
+					tr.classList.add("syntax-rule-tr");
+					let td1 = document.createElement("td");
+					td1.classList.add("syntax-rule-id");
+					let a = document.createElement("a");
+					a.classList.add("syntax-rule-id-a");
+					a.href = "#syntax-rule-" + ruleId;
+					a.textContent = ruleId;
+					td1.appendChild(a);
+					let td2 = document.createElement("td");
+					td2.innerHTML = element.innerHTML;
+					tr.appendChild(td1);
+					tr.appendChild(td2);
+
+					// Replace <dfn> elements inside `tr` with <a> elements
+					tr.querySelectorAll("dfn").forEach(dfn => {
+    					let a = document.createElement("a");
+    					a.textContent = dfn.textContent;
+    					dfn.replaceWith(a);
+					});
+
+					document.getElementById("syntax-rules-table").appendChild(tr);
+					element.setAttribute("id", "syntax-rule-" + ruleId);
 				});
-				$("#shacl-shacl-pre").html(ttl);
 			}
 		
 			function prepareValidators() {
-				$("[data-validator]").each(function(index, element) {
-					var validatorId = $(element).attr("data-validator") + "ConstraintComponent";
-					var tr = $("<tr class=\"validator-tr\"><td><a class=\"validator-id-a\" href=\"#validator-" + validatorId + "\">sh:" + validatorId + "</a>: " + $(element).html() + "</td></tr>");
-					$("#validators-table").append(tr);
-					$(element).attr("id", "validator-" + validatorId);
+				document.querySelectorAll("[data-validator]").forEach(element => {
+					let validatorId = element.getAttribute("data-validator") + "ConstraintComponent";
+					let tr = document.createElement("tr");
+					tr.classList.add("validator-tr");
+					let td = document.createElement("td");
+					tr.appendChild(td);
+					let a = document.createElement("a");
+					a.classList.add("validator-id-a");
+					a.href = `#validator-${validatorId}`;
+					a.textContent = `sh:${validatorId}`;
+					td.appendChild(a);
+					td.innerHTML += ": " + element.innerHTML;
+					document.getElementById("validators-table").appendChild(tr);
+					element.id = "validator-" + validatorId;
 				});
 			}
 		
@@ -62,8 +84,18 @@
 				previousMaturity: "REC",
 				prevRecShortname: "shacl",
 				prevRecURI: "https://www.w3.org/TR/2017/REC-shacl-20170720/#part2",
-
+				lint: {
+					"no-unused-dfns": false,  // This should be removed near the end of the process
+  				},
 				wgPublicList: "public-shacl",
+				localBiblio: {
+					"shacl12-core": {
+						title: "SHACL 1.2 Core",
+						href: "https://w3c.github.io/data-shapes/shacl12-core/",
+						status: "ED",
+						publisher: "W3C",
+					}
+				}
 			};
 		</script>
 		<style>
@@ -152,6 +184,10 @@
 				padding: 8px;
 			}
 			
+			.example {
+				overflow-y: hidden !important;
+			}
+
 			.focus-node-selected {
 				color: blue;
 			}
@@ -236,76 +272,78 @@
 			.todo {
 				color: red;
 			}
+
+			.turtle {
+				font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
+				font-size: 14.4px;
+				hyphens: none;
+				overflow-x: auto;
+				padding: .5em;
+				tab-size: 3;
+				-moz-tab-size: 3; /* Code for Firefox */
+				-o-tab-size: 3; /* Code for Opera */
+				text-align: start;
+				margin-bottom: -1.5em;
+				margin-top: -1.5em;
+				white-space: pre;
+			}
 			
-			pre {
-				word-wrap: normal;
+			.data-graph { 
+				background: #eeb; 
+				border: 1px solid #cc9;
+				margin-top: 0.3em;
+			}
+			.data-graph:before { 
+				color: #996; 
+				content: "Data graph"; 
+				padding-left: 0.4em;
+			}
+			
+			.results-graph { 
+				background: #edb; 
+				border: 1px solid #bbb;
+				margin-top: 0.3em;
+			}
+			.results-graph:before { 
+				color: #997; 
+				content: "Validation results"; 
+				padding-left: 0.4em;
+			}
+			
+			.shapes-graph { 
+				background: #deb; 
+				border: 1px solid #bbb;
+				margin-top: 0.3em;
+			}
+			.shapes-graph:before { 
+				color: #888; 
+				content: "Shapes graph"; 
+				padding-left: 0.4em;
 			}
 
-			/* example pre taken / adapted from R2RML */
-			pre.shapes, pre.example-shapes, pre.example-data, pre.example-results, pre.example-other { margin-left: 0; padding: 0 2em; margin-top: 1.5em; padding: 1em; }
-			pre.example-shapes:before, pre.example-data:before, pre.example-results:before, pre.example-other:before { background: white; display: block; font-family: sans-serif; margin: -1em 0 0.4em -1em; padding: 0.2em 1em; }
-			pre.shapes, pre.example-shapes { background: #deb; }
-			pre.shapes, pre.example-shapes, pre.example-shapes:before { border: 1px solid #bbb; }
-			pre.example-shapes:before { color: #888; content: "Example shapes graph"; width: 13em; }
-			pre.example-data { background: #eeb; }
-			pre.example-data, pre.example-data:before { border: 1px solid #cc9; }
-			pre.example-data:before { color: #996; content: "Example data graph"; width: 13em; }
-			.example-results { background: #edb; }
-			.example-results, .example-results:before, .example-results th, .example-results td { border: 1px solid #cca; }
-			pre.example-results:before { color: #997; content: "Example validation results"; width: 13em; }
-			pre.example-other { background: #bed; }
-			pre.example-other, pre.example-other:before { border: 1px solid #ddd; }
-			pre.example-other:before { color: #888; content: "Example"; width: 13em; }
-
-			/* our syntax menu for switching */
-			div.syntaxmenu {
-				border: 1px dotted black;
-				padding:0.5em;
-				margin: 1em; 
-			}
-
-			@media print {
-				div.syntaxmenu { display:none; }
-			}
 		</style>
 	</head>
 	<body>
 
 		<section id="abstract">
 			<p>
-				This document defines the SPARQL-related features of the SHACL Shapes Constraint Language. 
+				This document defines SPARQL-related extensions of the SHACL Shapes Constraint Language.
 				SHACL is a language for validating RDF graphs against a set of conditions.
 				These conditions are provided as shapes and other constructs expressed in the form of an RDF graph.
-				RDF graphs that are used in this manner are called "shapes graphs" in SHACL and
-				the RDF graphs that are validated against a shapes graph are called "data graphs".
-				As SHACL shape graphs are used to validate that data graphs satisfy a set of conditions
-				they can also be viewed as a description of the data graphs that do satisfy these conditions.
-				Such descriptions may be used for a variety of purposes beside validation, including
-				user interface building, code generation and data integration.
+				While the Core part of SHACL defines the basic syntax of shapes and the most common constraint components
+				supported by SHACL, the SPARQL-related extensions cover features that extend the expressiveness of Core
+				by means of SPARQL.
+				In particular, this document defines how constraints and constraint components can be defined using SPARQL.
+			</p>
+			<p class="todo">
+				TODO: More will be added on Node Expressions/targets once that part is ready.
+				Other features from SHACL-AF such as user-defined functions may get added.
 			</p>
 		</section>
 
 		<section id="sotd">
 		</section>
 
-
-		<section class="introductory">
-			<h2>Document Outline</h2>
-			<p>
-				The introduction includes a <a href="#terminology">Terminology</a> section.
-			</p>
-			<p>
-				The sections 2 and 3 are about the features that <a>SHACL-SPARQL</a> has in addition to the Core language.
-				These advanced features are SPARQL-based constraints and constraint components.
-			</p>
-			<p>
-				The syntax of SHACL is RDF.
-				The examples in this document use Turtle [[!turtle]] and (in one instance) JSON-LD [[json-ld]].
-				Other RDF serializations such as RDF/XML may be used in practice.
-				The reader should be familiar with basic RDF concepts [[!rdf11-concepts]] such as triples and with SPARQL [[!sparql11-query]].
-			</p>
-		</section>
-	
 		<section id="introduction">
 			<h2>Introduction</h2>
 			<p>
@@ -317,11 +355,13 @@
 					Throughout this document, the following terminology is used.
 				</p>
 				<p>
-					Terminology that is linked to portions of RDF 1.1 Concepts and Abstract
-					Syntax is used in SHACL as defined there. Terminology that is linked to
-					portions of SPARQL 1.1 Query Language is used in SHACL as defined there. A
-					single linkage is sufficient to provide a definition for all occurences of a
-					particular term in this document.
+					The SHACL SPARQL Extensions defined in this document are sometimes called SHACL-SPARQL.
+				</p>
+				<p>
+					Terminology that is linked to portions of RDF 1.2 Concepts and Abstract Syntax is used in SHACL-SPARQL as defined there.
+					Terminology that is linked to portions of SPARQL 1.2 Query Language is used in SHACL-SPARQL as defined there. 
+					Terminology that is linked to portions of SHACL 1.2 Core is used in SHACL-SPARQL as defined there. 
+					A single linkage is sufficient to provide a definition for all occurences of a particular term in this document.
 				</p>
 				<p>
 					Definitions are complete within this document, i.e., if there is no rule to
@@ -331,52 +371,44 @@
 					<div class="term-def-header">Basic RDF Terminology</div>
 					<div>
 						This document uses the terms 
-						<a href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-graph"><dfn data-lt="graph|graphs|RDF graphs">RDF graph</dfn></a>,
-						<a href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple"><dfn data-lt="triple|triples">RDF triple</dfn></a>,
-						<a href="http://www.w3.org/TR/rdf11-concepts/#dfn-iri"><dfn data-lt="IRI|IRIs">IRI</dfn></a>,
-						<a href="http://www.w3.org/TR/rdf11-concepts/#dfn-literal"><dfn data-lt="literal|literals">literal</dfn></a>,
-						<a href="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node"><dfn data-lt="blank node|blank nodes">blank node</dfn></a>,
-						<a href="http://www.w3.org/TR/rdf11-concepts/#dfn-node"><dfn data-lt="node|nodes">node</dfn></a> of an RDF graph,
-						<a href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-term"><dfn>RDF term</dfn></a>, and
-						<a href="https://www.w3.org/TR/rdf11-concepts/#dfn-subject"><dfn data-lt="subject|subjects">subject</dfn></a>,
-						<a href="https://www.w3.org/TR/rdf11-concepts/#dfn-predicate"><dfn data-lt="predicate|predicates">predicate</dfn></a>, and
-						<a href="https://www.w3.org/TR/rdf11-concepts/#dfn-object"><dfn data-lt="object|objects">object</dfn></a> of RDF triples, and
-						<a href="https://www.w3.org/TR/rdf11-concepts/#dfn-datatype"><dfn data-lt="datatypes">datatype</dfn></a>
-						as defined in RDF 1.1 Concepts and Abstract Syntax [[!rdf11-concepts]].
-						<dfn data-lt="language tag">Language tags</dfn> are defined as in [[!BCP47]].
+						<dfn data-cite="rdf12-concepts#dfn-rdf-graph" data-lt="graph|graphs|RDF graphs">RDF graph</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-rdf-triple" data-lt="triple|triples">RDF triple</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-iri" data-lt="IRI|IRIs">IRI</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-literal" data-lt="literal|literals">literal</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-blank-node" data-lt="blank node|blank nodes">blank node</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-node" data-lt="node|nodes">node</dfn> of an RDF graph,
+						<dfn data-cite="rdf12-concepts#dfn-rdf-term" data-lt="term|terms">RDF term</dfn>, and
+						<dfn data-cite="rdf12-concepts#dfn-subject" data-lt="subject|subjects">subject</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-predicate" data-lt="predicate|predicates">predicate</dfn>, and
+						<dfn data-cite="rdf12-concepts#dfn-object" data-lt="object|objects">object</dfn> of RDF triples
+						as defined in RDF 1.2 Concepts and Abstract Syntax [[!rdf12-concepts]].
 					</div>
 				</div>
-				<div class="def">
-					<div class="term-def-header">Property Value and Path</div>
+				<div class="def" id="shacl-terminology">
+					<div class="term-def-header">Basic SHACL Terminology</div>
 					<div>
-						A <dfn data-lt="properties">property</dfn> is an <a>IRI</a>.
-						An <a>RDF term</a> <code>n</code> has a <dfn data-lt="values|property value|property values">value</dfn> <code>v</code>
-						for property <code>p</code> in an <a>RDF graph</a> if there is an <a>RDF triple</a> in the graph
-						with <a>subject</a> <code>n</code>, <a>predicate</a> <code>p</code>, and <a>object</a> <code>v</code>.
-						The phrase "Every value of P in graph G ..." means "Every object of a triple in G with predicate P ...".
-						(In this document, the verbs <em>specify</em> or <em>declare</em> are sometimes used to express the fact that an RDF term has values for a given predicate in a graph.)
-						<br />
-						<dfn data-lt="SPARQL property path">SPARQL property paths</dfn> are defined as in <a href="https://www.w3.org/TR/sparql11-query/#pp-language">SPARQL 1.1</a>.
-						An RDF term <code>n</code> has value <code>v</code> for <a>SPARQL property path</a> expression
-						<code>p</code> in an RDF graph <code>G</code> if there is a solution mapping in the result of the SPARQL query
-						<code>SELECT ?s ?o WHERE { ?s p' ?o }</code> on <code>G</code> that binds <code>?s</code> to
-						<code>n</code> and <code>?o</code> to <code>v</code>, where	<code>p'</code> is SPARQL surface syntax for <code>p</code>.
-					</div>
-				</div>
-				<div class="def">
-					<div class="term-def-header">SHACL Lists</div>
-					<div>
-						<span data-syntax-rule="SHACL-list">A <dfn data-lt="SHACL lists">SHACL list</dfn> in an RDF graph <code>G</code> is an <a>IRI</a> or a <a>blank node</a>
-						that is either <code>rdf:nil</code>	(provided that <code>rdf:nil</code> has no <a>value</a>
-						for either <code>rdf:first</code> or <code>rdf:rest</code>), or has exactly one <a>value</a>
-						for the property <code>rdf:first</code> in <code>G</code> and exactly one <a>value</a>
-						for the property <code>rdf:rest</code> in <code>G</code> that is also a SHACL list in <code>G</code>,
-						and the list does not have itself as a value of the property path <code>rdf:rest+</code> in <code>G</code>.</span>
-						<br />
-						The  <dfn data-lt="member">members</dfn> of any SHACL list except <code>rdf:nil</code> in an RDF
-						graph <code>G</code> consist of its value for <code>rdf:first</code> in <code>G</code> followed by
-						the members in <code>G</code> of its value for <code>rdf:rest</code> in <code>G</code>.
-						The SHACL list <code>rdf:nil</code> has no members in any RDF graph.
+						This document uses the terms
+						<dfn data-cite="shacl12-core#dfn-focus-node" data-lt="focus node|focus nodes">focus node</dfn>,
+						<dfn data-cite="shacl12-core#dfn-value" data-lt="value">value</dfn>,
+						<dfn data-cite="shacl12-core#dfn-value-node" data-lt="value node|value nodes">value node</dfn>,
+						<dfn data-cite="shacl12-core#dfn-constraint" data-lt="constraint|constraints">constraint</dfn>,
+						<dfn data-cite="shacl12-core#dfn-constraint-component" data-lt="constraint component|constraint components">constraint component</dfn>,
+						<dfn data-cite="shacl12-core#dfn-parameter" data-lt="parameter|parameters">parameter</dfn>,
+						<dfn data-cite="shacl12-core#dfn-mandatory-parameter" data-lt="mandatory parameter|mandatory parameters">mandatory parameter</dfn>,
+						<dfn data-cite="shacl12-core#dfn-optional-parameter" data-lt="optional parameter|optional parameters">optional parameter</dfn>,
+						<dfn data-cite="shacl12-core#dfn-shape" data-lt="shape|shapes">shape</dfn>,
+						<dfn data-cite="shacl12-core#dfn-node-shape" data-lt="node shape|node shapes">node shape</dfn>,
+						<dfn data-cite="shacl12-core#dfn-property-shape" data-lt="property shape|property shapes">property shape</dfn>,
+						<dfn data-cite="shacl12-core#dfn-shacl-property-path" data-lt="shacl property path|shacl property paths">SHACL property path</dfn>,
+						<dfn data-cite="shacl12-core#dfn-sparql-property-path" data-lt="sparql property path|sparql property paths">SPARQL property path</dfn>,
+						<dfn data-cite="shacl12-core#dfn-shapes-graph" data-lt="shapes graph">shapes graph</dfn>,
+						<dfn data-cite="shacl12-core#dfn-validators" data-lt="validator|validators">validator</dfn>,
+						<dfn data-cite="shacl12-core#dfn-conform" data-lt="conform|conforms">conform</dfn>,
+						<dfn data-cite="shacl12-core#dfn-failure" data-lt="failure|failures">failure</dfn>,
+						<dfn data-cite="shacl12-core#dfn-shacl-instance" data-lt="shacl instance">SHACL instance</dfn>,
+						<dfn data-cite="shacl12-core#dfn-shacl-subclass" data-lt="shacl subclass">SHACL subclass</dfn>,
+						<dfn data-cite="shacl12-core#dfn-shacl-type" data-lt="shacl type">SHACL type</dfn>,
+						as defined in the SHACL 1.2 Core specification [[!shacl12-core]].
 					</div>
 				</div>
 				<div class="def">
@@ -387,51 +419,17 @@
 					    Variables are not required to be bound in a solution.
 					</div>
 				</div>
-				<div class="def">
-				<div class="term-def-header">SHACL Subclass, SHACL superclass</div>
-					<div>
-						A <a>node</a> <code>Sub</code> in an <a>RDF graph</a> is a <dfn data-lt="subclasses|subclass|SHACL subclasses">SHACL subclass</dfn> of another <a>node</a> <code>Super</code>
-						in the <a>graph</a> if there is a sequence of <a>triples</a> in the <a>graph</a> each with predicate <code>rdfs:subClassOf</code> such that the <a>subject</a> of the first <a>triple</a> is <code>Sub</code>,
-						the <a>object</a> of the last triple is <code>Super</code>, and the <a>object</a> of each <a>triple</a> except the last is the <a>subject</a> of the next.
-						If <code>Sub</code> is a <a>SHACL subclass</a> of <code>Super</code> in an <a>RDF graph</a> then <code>Super</code>
-						is a <dfn data-lt="superclass|superclasses|SHACL superclasses|">SHACL superclass</dfn> of <code>Sub</code> in the <a>graph</a>.
-					</div>
-				</div>
-				<div class="def">
-					<div class="term-def-header">SHACL Type</div>
-					<div>
-						The <dfn data-lt="type|types|SHACL type">SHACL types</dfn> of an <a>RDF term</a> in an <a>RDF graph</a> is the set of its <a>values</a> for <code>rdf:type</code> in the
-						<a>graph</a> as well as the <a>SHACL superclasses</a> of these <a>values</a> in the <a>graph</a>.
-					</div>
-				</div>
-				<div class="def">
-					<div class="term-def-header">SHACL Class</div>
-					<div>
-						<a>Nodes</a> in an <a>RDF graph</a> that are subclasses, superclasses, or types of <a>nodes</a> in the <a>graph</a> are referred to as <dfn data-lt="class|classes|SHACL classes">SHACL class</dfn>.
-					</div>
-				</div>
-				<div class="def">
-					<div class="term-def-header">SHACL Class Instance</div>
-					<div>
-						A <a>node</a> <code>n</code> in an <a>RDF graph</a> <code>G</code> is a <dfn data-lt="SHACL instance|SHACL instances">SHACL instance</dfn> of a <a>SHACL class</a> <code>C</code> in <code>G</code>
-						if one of the <a>SHACL types</a> of <code>n</code> in <code>G</code> is <code>C</code>.
-					</div>
-				</div>
-				<div class="def">
-					<div class="term-def-header">SHACL Core and SHACL-SPARQL</div>
-					<div>
-						The SHACL specification is divided into SHACL Core and SHACL-SPARQL.
-						<dfn>SHACL Core</dfn> consists of frequently needed features for the representation of shapes, constraints and targets.
-						All SHACL implementations MUST at least implement SHACL Core.
-						<dfn>SHACL-SPARQL</dfn> consists of all features of SHACL Core plus the advanced features
-						of SPARQL-based constraints and an extension mechanism to declare new constraint components.
-					</div>
-				</div>
 
 			</section>
 
 			<section id="conventions">
 				<h3>Document Conventions</h3>
+				<p>
+					The syntax of SHACL is RDF.
+					The examples in this document use Turtle [[rdf12-turtle]].
+					Other RDF serializations such as RDF/XML may be used in practice.
+					The reader should be familiar with basic RDF concepts [[rdf12-concepts]] such as triples and with SPARQL [[sparql12-query]].
+				</p>
 				<p>
 					Within this document, the following namespace prefix bindings are used:
 				</p>
@@ -470,24 +468,33 @@
 					Throughout the document, color-coded boxes containing RDF graphs in Turtle will appear.
 					These fragments of Turtle documents use the prefix bindings given above.
 				</p>
-				<pre class="example-shapes">
+				<div class="shapes-graph">
+					<div class="turtle">
 # This box represents an input shapes graph
 
 # Triples that can be omitted are marked as grey e.g.
-<span class="triple-can-be-skipped">&lt;s&gt; &lt;p&gt; &lt;o&gt; .</span></pre>
+<span class="triple-can-be-skipped">&lt;s&gt; &lt;p&gt; &lt;o&gt; .</span>
+					</div>
+				</div>
 
-				<pre class="example-data">
+				<div class="data-graph">
+					<div class="turtle">
 # This box represents an input data graph.
 # When highlighting is used in the examples:
 
 # Elements highlighted in blue are <a>focus nodes</a>
 <span class="focus-node-selected">ex:Bob</span> a ex:Person .
 
-# Elements highlighted in red are focus nodes that fail <a href="#validation">validation</a>
-<span class="focus-node-error">ex:Alice</span> a ex:Person .</pre>
+# Elements highlighted in red are focus nodes that fail validation
+<span class="focus-node-error">ex:Alice</span> a ex:Person .
+					</div>
+				</div>
 
-				<pre class="example-results">
-# This box represents an output results graph</pre>
+				<div class="results-graph">
+					<div class="turtle">
+# This box represents an output results graph
+					</div>
+				</div>
 
 				<p>
 					SHACL Definitions appear in blue boxes:
@@ -500,6 +507,10 @@
 				
 				<p class="syntax">
 					Grey boxes such as this include syntax rules that apply to the <a>shapes graph</a>.
+				</p>
+
+				<p>
+					SPARQL variables using the <code>$</code> marker represent external <a>bindings</a> that are <a>pre-bound</a> or, in the case of <code>$PATH</code>, <a>substituted</a> in the SPARQL query before execution (as explained in <a href="#constraint-components-validation"></a>).
 				</p>
 				
 				<p>
@@ -525,230 +536,6 @@
 					Nodes that violate none of these rules are called <dfn>well-formed</dfn>.
 					A <a>shapes graph</a> is ill-formed if it contains at least one ill-formed node.
 				</p>
-				<p><em>The remainder of this section is informative.</em></p>
-				<p>
-					SHACL Core processors that do not also support SHACL-SPARQL ignore any SHACL-SPARQL constructs
-					such as <code>sh:sparql</code> <a>triples</a>.
-				</p>
-			</section>
-
-			<section class="informative">
-				<h3>SHACL Example</h3>
-				<p>
-					The following example <a>data graph</a> contains three <a>SHACL instances</a> of the <a>class</a> <code>ex:Person</code>.
-				</p>
-				<pre class="example-data">
-ex:Alice
-	a ex:Person ;
-	ex:ssn "987-65-432A" .
-  
-ex:Bob
-	a ex:Person ;
-	ex:ssn "123-45-6789" ;
-	ex:ssn "124-35-6789" .
-  
-ex:Calvin
-	a ex:Person ;
-	ex:birthDate "1971-07-07"^^xsd:date ;
-	ex:worksFor ex:UntypedCompany .</pre>
-				<p>
-					The following conditions are shown in the example:
-				<p>
-				<ul>
-					<li>
-						A <a>SHACL instance</a> of <code>ex:Person</code> can have at most one <a>value</a> for the property <code>ex:ssn</code>,
-						and this <a>value</a> is a <a>literal</a> with the datatype <code>xsd:string</code> that matches
-						a specified regular expression.
-					</li>
-					<li>
-						A <a>SHACL instance</a> of <code>ex:Person</code> can have unlimited <a>values</a> for the property <code>ex:worksFor</code>,
-						and these <a>values</a> are <a>IRIs</a> and <a>SHACL instances</a> of <code>ex:Company</code>.
-					</li>
-					<li>
-						A <a>SHACL instance</a> of <code>ex:Person</code> cannot have <a>values</a> for any other property apart from
-						<code>ex:ssn</code>, <code>ex:worksFor</code> and <code>rdf:type</code>.
-					</li>
-				</ul>
-				<p>
-					The aforementioned conditions can be represented as <a>shapes</a> and <a>constraints</a> in the following <a>shapes graph</a>:
-				</p>
-				<pre class="example-shapes ttl">
-ex:PersonShape
-	a sh:NodeShape ;
-	sh:targetClass ex:Person ;    # Applies to all persons
-	sh:property [                 # _:b1
-		sh:path ex:ssn ;           # constrains the values of ex:ssn
-		sh:maxCount 1 ;
-		sh:datatype xsd:string ;
-		sh:pattern "^\\d{3}-\\d{2}-\\d{4}$" ;
-	] ;
-	sh:property [                 # _:b2
-		sh:path ex:worksFor ;
-		sh:class ex:Company ;
-		sh:nodeKind sh:IRI ;
-	] ;
-	sh:closed true ;
-	sh:ignoredProperties ( rdf:type ) .</pre>
-				<p>
-					The example below shows the same shape definition as a possible JSON-LD [[json-ld]] fragment.
-					Note that we have left out a <code>@context</code> declaration, and depending on the
-					<code>@context</code> the rendering may look quite different.
-					Therefore this example should be understood as an illustration only.
-				</p>
-				<pre class="example-shapes jsonld">
-{
-	"@id" : "ex:PersonShape",
-	"@type" : "NodeShape",
-	"targetClass" : "ex:Person",
-	"property" : [
-		{
-			"path" : "ex:ssn",
-			"maxCount" : 1,
-			"datatype" : "xsd:string" ,
-			"pattern" : "^\\d{3}-\\d{2}-\\d{4}$"
-		},
-		{
-			"path" : "ex:worksFor",
-			"class" : "ex:Company",
-			"nodeKind" : "sh:IRI"
-		}
-	],
-	"closed" : true,
-	"ignoredProperties" : [ "rdf:type" ]
-}</pre>
-				<p>
-					We can use the shape declaration above to illustrate some of the key terminology used by SHACL.
-					The <a>target</a> for the <a>shape</a> <code>ex:PersonShape</code> is the set of all <a>SHACL instances</a> of the <a>class</a> <code>ex:Person</code>.
-					This is specified using the property <code>sh:targetClass</code>.
-					During the validation, these target nodes become <a>focus nodes</a> for the shape.
-					The <a>shape</a> <code>ex:PersonShape</code> is a <a>node shape</a>, which means that it applies to the focus nodes.
-					It declares <a>constraints</a> on the <a>focus nodes</a>, for example using the <a>parameters</a> <code>sh:closed</code> and <code>sh:ignoredProperties</code>.
-					The <a>node shape</a> also declares two other constraints with the property <code>sh:property</code>,
-					and each of these is backed by a <a>property shape</a>. 
-					These <a>property shapes</a> declare additional <a>constraints</a> using <a>parameters</a> such as <code>sh:datatype</code> and <code>sh:maxCount</code>.
-				</p>
-				<p>
-					Some of the <a>property shapes</a> specify parameters from multiple <a>constraint components</a> in order to
-					restrict multiple aspects of the <a>property values</a>.
-					For example, in the <a>property shape</a> for <code>ex:ssn</code>, parameters from three <a>constraint components</a> are used.
-					The <a>parameters</a> of these <a>constraint components</a> are <code>sh:datatype</code>, <code>sh:pattern</code> and <code>sh:maxCount</code>.
-					For each <a>focus node</a> the <a>property values</a> of <code>ex:ssn</code> will be validated against all three components.
-				</p>
-				<p>
-					SHACL <a>validation</a> based on the provided <a>data graph</a> and <a>shapes graph</a> would produce the following <a>validation report</a>.
-					See the section <a href="#validation-report">Validation Report</a> for details on the format.
-				</p>
-				<pre class="example-results">
-[	a sh:ValidationReport ;
-	sh:conforms false ;
-	sh:result
-	[	a sh:ValidationResult ;
-		sh:resultSeverity sh:Violation ;
-		sh:focusNode ex:Alice ;
-		sh:resultPath ex:ssn ;
-		sh:value "987-65-432A" ;
-		sh:sourceConstraintComponent sh:RegexConstraintComponent ;
-		sh:sourceShape ... blank node _:b1 on ex:ssn above ... ;
-	] ,
-	[	a sh:ValidationResult ;
-		sh:resultSeverity sh:Violation ;
-		sh:focusNode ex:Bob ;
-		sh:resultPath ex:ssn ;
-		sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
-		sh:sourceShape ... blank node _:b1 on ex:ssn above ... ;
-	] ,
-	[	a sh:ValidationResult ;
-		sh:resultSeverity sh:Violation ;
-		sh:focusNode ex:Calvin ;
-		sh:resultPath ex:worksFor ;
-		sh:value ex:UntypedCompany ;
-		sh:sourceConstraintComponent sh:ClassConstraintComponent ;
-		sh:sourceShape ... blank node _:b2 on ex:worksFor above ... ;
-	] ,
-	[	a sh:ValidationResult ;
-		sh:resultSeverity sh:Violation ;
-		sh:focusNode ex:Calvin ;
-		sh:resultPath ex:birthDate ;
-		sh:value "1971-07-07"^^xsd:date ;
-		sh:sourceConstraintComponent sh:ClosedConstraintComponent ;
-		sh:sourceShape sh:PersonShape ;
-	] 
-] .</pre>
-				<p>
-					The <a>validation results</a> are enclosed in a <a>validation report</a>.
-					The first <a>validation result</a> is produced because <code>ex:Alice</code> has a <a>value</a> for <code>ex:ssn</code>
-					that does not match the regular expression specified by the property <code>sh:regex</code>.
-					The second <a>validation result</a> is produced because <code>ex:Bob</code> has more than the permitted number of <a>values</a>
-					for the property <code>ex:ssn</code> as specified by the <code>sh:maxCount</code> of 1.
-					The third <a>validation result</a> is produced because <code>ex:Calvin</code> has a <a>value</a> for <code>ex:worksFor</code>
-					that does not have an <code>rdf:type</code> triple that makes it a <a>SHACL instance</a> of <code>ex:Company</code>.
-					The forth <a>validation result</a> is produced because the <a>shape</a> <code>ex:PersonShape</code> has the	property <code>sh:closed</code> set to <code>true</code>
-					but <code>ex:Calvin</code> uses the property <code>ex:birthDate</code> which is neither one of the predicates from any of the 
-					<a>property shapes</a> of the shape, nor one of the properties listed using <code>sh:ignoredProperties</code>.
-				</p>
-			</section>
-			
-			<section id="shacl-rdfs">
-				<h3>Relationship between SHACL and RDFS inferencing</h3>
-				<p>
-					SHACL uses the RDF and RDFS vocabularies, but full RDFS inferencing is not required.
-				</p>
-				<p>
-					However, SHACL processors MAY operate on RDF graphs that include entailments [[!sparql11-entailment]] -
-					either pre-computed before being submitted to a SHACL processor or performed on the fly as
-					part of SHACL processing (without modifying either <a>data graph</a> or <a>shapes graph</a>).
-					To support processing of entailments, SHACL includes the property
-					<code>sh:entailment</code> to indicate what inferencing is required
-					by a given <a>shapes graph</a>.
-				</p>
-				<p class="syntax">
-					<span data-syntax-rule="entailment-nodeKind">The <a>values</a> of the property <code>sh:entailment</code> are IRIs.</span>
-					Common values for this property are covered by [[!sparql11-entailment]].
-				</p>
-				<p>
-					SHACL implementations MAY, but are not required to, support entailment regimes.
-					If a <a>shapes graph</a> contains any <a>triple</a> with the <a>predicate</a> <code>sh:entailment</code> and <a>object</a> <code>E</code>
-					and the SHACL processor does not support <code>E</code> as an entailment regime for the given <a>data graph</a>
-					then the processor MUST signal a <a>failure</a>.
-					Otherwise, the SHACL processor MUST provide the entailments for all of the values of <code>sh:entailment</code> in the <a>shapes graph</a>,
-					and any inferred triples MUST be returned by all queries against the <a>data graph</a> during the <a>validation</a> process.
-				</p>
-			</section>
-			
-			<section id="shacl-sparql" class="informative">
-				<h3>Relationship between SHACL and SPARQL</h3>
-				<p>
-					For <a>SHACL Core</a> this specification uses parts of SPARQL 1.1 in non-normative alternative definitions of the semantics of <a>constraint components</a> and <a>targets</a>.
-					While these may help some implementers, SPARQL is not required for the implementation of the SHACL Core language.
-				</p>
-				<p>
-					<a>SHACL-SPARQL</a> is based on SPARQL 1.1 and uses it as a mechanism to declare constraints and constraint components.
-					Implementations that cover only the SHACL Core features are not required to implement these mechanisms.
-				</p>
-				<p>
-					SPARQL variables using the <code>$</code> marker represent external <a>bindings</a> that are <a>pre-bound</a> or, in the case of <code>$PATH</code>, <a>substituted</a> in the SPARQL query before execution (as explained in <a href="#constraint-components-validation"></a>).
-				</p>
-				<p>
-					The definition of some <a>constraints</a> requires or is simplified through access to the <a>shapes graph</a> during query execution.
-					SHACL-SPARQL processors MAY <a>pre-bind</a> the variable <code>shapesGraph</code> to provide access to the <a>shapes graph</a>.
-					Access to the <a>shapes graph</a> is not a requirement for supporting the SHACL Core language.
-					The variable <code>shapesGraph</code> can also be used in <a href="#sparql-constraints">SPARQL-based constraints</a> and <a href="#sparql-constraint-components">SPARQL-based constraint components</a>.
-					However, such <a>constraints</a> may not be interoperable across different SHACL-SPARQL processors or not applicable to remote RDF datasets.
-				</p>
-				<p>
-					Note that at the time of writing, SPARQL EXISTS has been imperfectly defined and implementations vary.
-					While a <a href="https://www.w3.org/community/sparql-exists/">W3C Community Group</a> is working on improving this situation,
-					users of SPARQL are advised that the use of EXISTS may have inconsistent results and should be approached with care.
-				</p>
-				<div class="syntaxmenu">
-					<p>The button below can be used to show or hide the SPARQL definitions.</p>
-					<form>
-						<p>
-							<input id="hide-sparql" onclick="$('.def-sparql').css('display', 'none'); $('#hide-sparql').css('display', 'none'); $('#show-sparql').css('display', '');" type="button" value="Hide SPARQL Definitions" />
-							<input id="show-sparql" onclick="$('.def-sparql').css('display', '');     $('#show-sparql').css('display', 'none'); $('#hide-sparql').css('display', '');" style="display:none" type="button" value="Show SPARQL Definitions" />
-						</p>
-					</form>
-				</div>
 			</section>
 			
 		</section>
@@ -782,13 +569,10 @@ ex:PersonShape
 				<p>
 					The following example illustrates the syntax of a <a>SPARQL-based constraint</a>.
 				</p>
-				<pre class="example-data">
-ex:ValidCountry a ex:Country ;
-	ex:germanLabel "Spanien"@de .
-  
-<span class="focus-node-error">ex:InvalidCountry</span> a ex:Country ;
-	ex:germanLabel "Spain"@en .</pre>
-				<pre class="example-shapes" id="example-sparql-constraint">
+
+				<aside class="example" id="example-sparql-constraint" title="A SPARQL-based constraint">
+					<div class="shapes-graph">
+						<div class="turtle">
 ex:LanguageExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetClass ex:Country ;</span>
@@ -803,14 +587,26 @@ ex:LanguageExampleShape
 				FILTER (!isLiteral(?value) || !langMatches(lang(?value), "de"))
 			}
 			""" ;
-	] .</pre>
-				<p>
-					The target of the shape above includes all <a>SHACL instances</a> of <code>ex:Country</code>.
-					For those nodes (represented by the variable <code>this</code>), the SPARQL query walks through the values of <code>ex:germanLabel</code>
-					and verifies that they are literals with a German language code.
-					The validation results for the aforementioned data graph is shown below:
-				</p>
-				<pre class="example-results">
+	] .
+						</div>
+					</div>
+					<p>
+						The target of the shape above includes all <a>SHACL instances</a> of <code>ex:Country</code>.
+						For those nodes (represented by the variable <code>this</code>), the SPARQL query walks through the values of <code>ex:germanLabel</code>
+						and verifies that they are literals with a German language code.
+					</p>
+					<div class="data-graph">
+						<div class="turtle">
+ex:ValidCountry a ex:Country ;
+	ex:germanLabel "Spanien"@de .
+	  
+<span class="focus-node-error">ex:InvalidCountry</span> a ex:Country ;
+	ex:germanLabel "Spain"@en .
+						</div>
+					</div>
+	
+					<div class="results-graph">
+						<div class="turtle">
 [	a sh:ValidationReport ;
 	sh:conforms false ;
 	sh:result [
@@ -823,7 +619,10 @@ ex:LanguageExampleShape
 		sh:sourceShape ex:LanguageExampleShape ;
 		# ...
 	]
-] .</pre>
+] .
+						</div>
+					</div>
+				</aside>
 				<p>
 					The SPARQL query returns result set <a>solutions</a> for all bindings of the variable <code>value</code> that violate the constraint.
 					There is a validation result for each <a>solution</a> in that result set, applying the <a href="#sparql-constraints-validation">mapping rules</a> explained later.
@@ -833,7 +632,9 @@ ex:LanguageExampleShape
 				<p>
 					The following example illustrates a similar scenario as above, but with a <a>property shape</a>.
 				</p>
-				<pre class="example-shapes" id="example-sparql-constraint-in-property-shape">
+				<aside class="example" id="example-sparql-constraint-in-property-shape">
+					<div class="shapes-graph">
+						<div class="turtle">
 ex:LanguageExamplePropertyShape
 	a sh:PropertyShape ;
 	<span class="target-can-be-skipped">sh:targetClass ex:Country ;</span>
@@ -849,7 +650,10 @@ ex:LanguageExamplePropertyShape
 				FILTER (!isLiteral(?value) || !langMatches(lang(?value), "de"))
 			}
 			""" ;
-	] .</pre>
+	] .
+						</div>
+					</div>
+				</aside>
 			</section>
 			
 			<section id="sparql-constraints-syntax">
@@ -862,7 +666,7 @@ ex:LanguageExamplePropertyShape
 					<span data-syntax-rule="SPARQLConstraint-select-count"><a>SPARQL-based constraints</a> have exactly one <a>value</a> for the property <code>sh:select</code></span>.
 					<span data-syntax-rule="SPARQLConstraint-select-datatype">The value of <code>sh:select</code> is a <a>literal</a> of datatype <code>xsd:string</code>.</span>
 					The class <code>sh:SPARQLConstraint</code> is defined in the SHACL vocabulary and may be used as the <a>type</a> of these constraints (although no type is required).
-					<span data-syntax-rule="select-query-valid">Using the <a href="#sparql-prefixes">prefix handling rules</a>, the value of <code>sh:select</code> is a valid SPARQL 1.1 SELECT query.</span>
+					<span data-syntax-rule="select-query-valid">Using the <a href="#sparql-prefixes">prefix handling rules</a>, the value of <code>sh:select</code> is a valid SPARQL 1.2 SELECT query.</span>
 					<span data-syntax-rule="select-query-this">The SPARQL query derived from the value of <code>sh:select</code> <a href="https://www.w3.org/TR/sparql11-query/#selectproject">projects</a> the variable <code>this</code> in the SELECT clause.</span>
 				</p>
 				<p>
@@ -888,7 +692,9 @@ ex:LanguageExamplePropertyShape
 						A <a>shapes graph</a> may include declarations of namespace prefixes so that these prefixes can be used to abbreviate the SPARQL queries derived from the same shapes graph.
 						The syntax of such prefix declarations is illustrated by the following example.
 					</p>
-					<pre class="example-shapes">
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:
 	a owl:Ontology ;
 	owl:imports sh: ;
@@ -899,7 +705,10 @@ ex:
 	sh:declare [
 		sh:prefix "schema" ;
 		sh:namespace "http://schema.org/"^^xsd:anyURI ;
-	] .</pre>
+	] .
+							</div>
+						</div>
+					</aside>
 					<p class="syntax">
 						<span data-syntax-rule="declare-nodeKind">The <a>values</a> of the property <code>sh:declare</code> are <a>IRIs</a> or <a>blank nodes</a></span>,
 						and these values are called <dfn data-lt="prefix declaration">prefix declarations</dfn>.
@@ -939,7 +748,7 @@ ex:
 						Each value of <code>sh:prefix</code> is turned into the <code>PNAME_NS</code>, while each value of <code>sh:namespace</code> is turned
 						into the <code>IRIREF</code> in the <code>PREFIX</code> declaration.
 						For the example shapes graph above, a SHACL-SPARQL processor would produce lines such as <code>PREFIX ex: &lt;http://example.com/ns#&gt;</code>.
-						The SHACL-SPARQL processor MUST produce a <a>failure</a> if the resulting query string cannot be parsed into a valid SPARQL 1.1 query.
+						The SHACL-SPARQL processor MUST produce a <a>failure</a> if the resulting query string cannot be parsed into a valid SPARQL 1.2 query.
 					</p>
 					<p>
 						In the rest of this document, the <code>sh:prefixes</code> statements may have been omitted for brevity.
@@ -975,7 +784,7 @@ ex:
 					<h4>Pre-bound Variables in SPARQL Constraints ($this, $shapesGraph, $currentShape)</h4>
 					<p>
 						When the SPARQL queries of <a>SPARQL-based constraints</a> and the <a>validators</a>
-						of <a>SPARQL-based constraint components</a> are <a href="#validation-definition">processed</a>,
+						of <a>SPARQL-based constraint components</a> are <a href="https://www.w3.org/TR/shacl/#validation-definition">processed</a>,
 						the SHACL-SPARQL processor <a>pre-binds</a> values for the variables in the following table.
 					</p>
 					<table class="term-table">
@@ -1085,7 +894,7 @@ ex:
 				<a>SPARQL-based constraints</a> provide a lot of flexibility
 				but may be hard to understand for some people or lead to repetition.
 				This section introduces <a>SPARQL-based constraint components</a> as a way to abstract the complexity of SPARQL
-				and to declare high-level reusable components similar to the <a href="#core-components">Core constraint components</a>.
+				and to declare high-level reusable components similar to the <a href="https://www.w3.org/TR/shacl/#core-components">Core constraint components</a>.
 				Such constraint components can be declared using the SHACL RDF vocabulary and thus shared and reused.
 			</p>
 
@@ -1093,11 +902,13 @@ ex:
 				<h3>An Example SPARQL-based Constraint Component</h3>
 				<p>
 					The following example demonstrates how SPARQL can be used to specify new constraint components using the SHACL-SPARQL language.
-					The example implements <a href="#PatternConstraintComponent"><code>sh:pattern</code> and <code>sh:flags</code></a> using a
+					The example implements <a href="https://www.w3.org/TR/shacl/#PatternConstraintComponent"><code>sh:pattern</code> and <code>sh:flags</code></a> using a
 					<a href="#SPARQLAskValidator">SPARQL ASK</a> query to validate that each <a>value node</a> matches a given regular expression.
 					Note that this is only an example implementation and should not be considered normative.
 				</p>
-				<pre class="example-shapes" title="Constraint component based on SPARQL">
+				<aside class="example" title="Constraint component based on SPARQL">
+					<div class="shapes-graph">
+						<div class="turtle">
 sh:PatternConstraintComponent
 	a sh:ConstraintComponent ;
 	sh:parameter [
@@ -1116,7 +927,10 @@ shimpl:hasPattern
 		ASK { 
 			FILTER (!isBlank($value) &amp;&amp; 
 				IF(bound($flags), regex(str($value), $pattern, $flags), regex(str($value), $pattern)))
-		}""" .</pre>
+		}""" .
+						</div>
+					</div>
+				</aside>
 				<p>
 					Constraint components provide instructions to validation engines on how to identify and validate <a>constraints</a> within a <a>shape</a>.
 					In general, if a <a>shape</a> <code>S</code> has a <a>value</a> for a property <code>p</code>, and there is a <a>constraint component</a>
@@ -1229,7 +1043,9 @@ shimpl:hasPattern
 							Constraint components make it possible to generalize such scenarios, so that constants get <a>pre-bound</a> with <a>parameters</a>.
 							This allows the query logic to be reused in multiple places, without having to write any new SPARQL.
 						</p>
-						<pre class="example-shapes" title="Constraint component based on SPARQL">
+						<aside class="example" title="Constraint component based on SPARQL">
+							<div class="shapes-graph">
+								<div class="turtle">
 ex:LanguageConstraintComponentUsingSELECT
 	a sh:ConstraintComponent ;
 	rdfs:label "Language constraint component" ;
@@ -1251,11 +1067,16 @@ ex:LanguageConstraintComponentUsingSELECT
 				FILTER (!isLiteral(?value) || !langMatches(lang(?value), $lang))
 			}
 			"""
-	] .</pre>
+	] .
+								</div>
+							</div>
+						</aside>
 						<p>
 							Once a constraint component has been declared (in a <a>shapes graph</a>), its parameters can be used as illustrated in the following example.
 						</p>
-						<pre class="example-shapes" title="Shape declaration using ex:LanguageConstraintComponent">
+						<aside class="example" title="Shape declaration using ex:LanguageConstraintComponent">
+							<div class="shapes-graph">
+								<div class="turtle">
 ex:LanguageExampleShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetClass ex:Country ;</span>
@@ -1266,7 +1087,10 @@ ex:LanguageExampleShape
 	sh:property [
 		sh:path ex:englishLabel ;
 		ex:lang "en" ;
-	] .</pre>
+	] .
+								</div>
+							</div>
+						</aside>
 						<p>
 							The example shape above specifies the condition that all values of <code>ex:germanLabel</code> carry the language tag <code>de</code>
 							while all values of <code>ex:englishLabel</code> have <code>en</code> as their language.
@@ -1296,7 +1120,9 @@ ex:LanguageExampleShape
 						<p>
 							The following example declares a constraint component using an ASK query.
 						</p>
-						<pre class="example-shapes" title="Constraint component based on SPARQL">
+						<aside class="example" title="Constraint component based on SPARQL">
+							<div class="shapes-graph">
+								<div class="turtle">
 ex:LanguageConstraintComponentUsingASK
 	a sh:ConstraintComponent ;
 	rdfs:label "Language constraint component" ;
@@ -1317,7 +1143,10 @@ ex:hasLang
 		ASK {
 			FILTER (isLiteral($value) &amp;&amp; langMatches(lang($value), $lang))
 		}
-		""" .</pre>
+		""" .
+								</div>
+							</div>
+						</aside>
 						<p>
 							Note that the validation condition implemented by an ASK query is "in the inverse direction" from its SELECT counterpart:
 							ASK queries return <code>true</code> for value nodes that conform to the constraint, while SELECT queries return those value nodes that do not conform.
@@ -1461,7 +1290,7 @@ ex:hasLang
 				<code>owl:imports</code> and <code>sh:shapesGraph</code>.
 			</p>
 			<p>
-				SHACL-SPARQL includes all the <a href="https://www.w3.org/TR/sparql11-query/#security">security issues of SPARQL</a>.
+				SHACL-SPARQL includes all the <a href="https://www.w3.org/TR/sparql12-query/#security">security issues of SPARQL</a>.
 			</p>
 		</section>
 		
@@ -1484,15 +1313,5 @@ ex:hasLang
 		</section>
 		  
 	</body>
-
-	<script type="text/javascript">
-
-		tooltip = "Targets are not the only way to initiate validation, SHACL also allows specific nodes to be validated against specific shapes.";
-		var t = document.getElementsByClassName("target-can-be-skipped");
-		for (var i = 0; i < t.length; i++) {
-			t[i].title = tooltip;
-		}
-		
-	</script>
 
 </html>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -414,7 +414,7 @@
 				<div class="def">
 					<div class="term-def-header">Binding, Solution</div>
 					<div>
-						A <dfn data-lt="bindings">binding</dfn> is a pair (<a href="https://www.w3.org/TR/sparql11-query/#defn_QueryVariable">variable</a>, <a>RDF term</a>), consistent with the term's use in <a href="https://www.w3.org/TR/sparql11-query/">SPARQL</a>.
+						A <dfn data-lt="bindings">binding</dfn> is a pair (<a data-cite="sparql12-query/#defn_QueryVariable">variable</a>, <a>RDF term</a>), consistent with the term's use in [[!sparql12-query]].
 					    A <dfn data-lt="solutions">solution</dfn> is a set of bindings, informally often understood as one row in the body of the result table of a SPARQL query.
 					    Variables are not required to be bound in a solution.
 					</div>
@@ -667,7 +667,7 @@ ex:LanguageExamplePropertyShape
 					<span data-syntax-rule="SPARQLConstraint-select-datatype">The value of <code>sh:select</code> is a <a>literal</a> of datatype <code>xsd:string</code>.</span>
 					The class <code>sh:SPARQLConstraint</code> is defined in the SHACL vocabulary and may be used as the <a>type</a> of these constraints (although no type is required).
 					<span data-syntax-rule="select-query-valid">Using the <a href="#sparql-prefixes">prefix handling rules</a>, the value of <code>sh:select</code> is a valid SPARQL 1.2 SELECT query.</span>
-					<span data-syntax-rule="select-query-this">The SPARQL query derived from the value of <code>sh:select</code> <a href="https://www.w3.org/TR/sparql11-query/#selectproject">projects</a> the variable <code>this</code> in the SELECT clause.</span>
+					<span data-syntax-rule="select-query-this">The SPARQL query derived from the value of <code>sh:select</code> <a data-cite="sparql12-query/#selectproject">projects</a> the variable <code>this</code> in the SELECT clause.</span>
 				</p>
 				<p>
 					The following two properties are similar to their use in <a>shapes</a>:
@@ -683,7 +683,7 @@ ex:LanguageExamplePropertyShape
 				<p class="syntax">
 					<span data-syntax-rule="PATH-position">The only legal use of the variable <code>PATH</code> in the SPARQL queries of <a>SPARQL-based constraints</a>
 					and <a>SELECT-based validators</a> is in the
-					<a>predicate</a> position of a <a href="https://www.w3.org/TR/sparql11-query/#QSynTriples">triple pattern</a>.</span>
+					<a>predicate</a> position of a <a data-cite="sparql12-query/#QSynTriples">triple pattern</a>.</span>
 					A query that uses the variable <code>PATH</code> in any other position is <a>ill-formed</a>.
 				</p>
 				<section id="sparql-prefixes">
@@ -743,7 +743,7 @@ ex:
 					</p>
 					<p>
 						A SHACL processor transforms the values of <code>sh:select</code> (and similar properties such as <code>sh:ask</code>)
-						into SPARQL by prepending <a href="https://www.w3.org/TR/sparql11-query/#rPrefixDecl"><code>PREFIX</code></a> declarations
+						into SPARQL by prepending <a data-cite="sparql12-query/#rPrefixDecl"><code>PREFIX</code></a> declarations
 						for all prefix mappings.
 						Each value of <code>sh:prefix</code> is turned into the <code>PNAME_NS</code>, while each value of <code>sh:namespace</code> is turned
 						into the <code>IRIREF</code> in the <code>PREFIX</code> declaration.
@@ -772,7 +772,7 @@ ex:
 						<code>shapesGraph</code> and <code>currentShape</code> as described in <a href="#sparql-constraints-prebound"></a>. 
 						If the <a>shape</a> is a <a>property shape</a>, then prior to execution
 						<dfn data-lt="substituted">substitute</dfn> the variable <code>PATH</code> where it appears in the <a>predicate</a>
-						position of a <a href="https://www.w3.org/TR/sparql11-query/#QSynTriples">triple pattern</a>
+						position of a <a data-cite="sparql12-query/#QSynTriples">triple pattern</a>
 						with a valid SPARQL surface syntax string of the <a>SHACL property path</a>
 						specified via <code>sh:path</code> at the <a>property shape</a>.
 						<span id="sparql-constraints-validation-rule">There is one validation result for each <a>solution</a> that does not have <code>true</code> as the <a>binding</a> for the variable <code>failure</code>.
@@ -784,7 +784,7 @@ ex:
 					<h4>Pre-bound Variables in SPARQL Constraints ($this, $shapesGraph, $currentShape)</h4>
 					<p>
 						When the SPARQL queries of <a>SPARQL-based constraints</a> and the <a>validators</a>
-						of <a>SPARQL-based constraint components</a> are <a href="https://www.w3.org/TR/shacl/#validation-definition">processed</a>,
+						of <a>SPARQL-based constraint components</a> are <a data-cite="shacl12-core/#validation-definition">processed</a>,
 						the SHACL-SPARQL processor <a>pre-binds</a> values for the variables in the following table.
 					</p>
 					<table class="term-table">
@@ -894,7 +894,7 @@ ex:
 				<a>SPARQL-based constraints</a> provide a lot of flexibility
 				but may be hard to understand for some people or lead to repetition.
 				This section introduces <a>SPARQL-based constraint components</a> as a way to abstract the complexity of SPARQL
-				and to declare high-level reusable components similar to the <a href="https://www.w3.org/TR/shacl/#core-components">Core constraint components</a>.
+				and to declare high-level reusable components similar to the <a data-cite="shacl12-core/#core-components">Core constraint components</a>.
 				Such constraint components can be declared using the SHACL RDF vocabulary and thus shared and reused.
 			</p>
 
@@ -902,7 +902,7 @@ ex:
 				<h3>An Example SPARQL-based Constraint Component</h3>
 				<p>
 					The following example demonstrates how SPARQL can be used to specify new constraint components using the SHACL-SPARQL language.
-					The example implements <a href="https://www.w3.org/TR/shacl/#PatternConstraintComponent"><code>sh:pattern</code> and <code>sh:flags</code></a> using a
+					The example implements <a data-cite="shacl12-core/#PatternConstraintComponent"><code>sh:pattern</code> and <code>sh:flags</code></a> using a
 					<a href="#SPARQLAskValidator">SPARQL ASK</a> query to validate that each <a>value node</a> matches a given regular expression.
 					Note that this is only an example implementation and should not be considered normative.
 				</p>
@@ -964,13 +964,13 @@ shimpl:hasPattern
 						<span data-syntax-rule="Parameter">At <a>parameter declarations</a>, the <a>value</a> of <code>sh:path</code> is an <a>IRI</a>.</span>
 					</p>
 					<p>
-						The <dfn data-lt="local names">local name</dfn> of an <a>IRI</a> is defined as the longest <a href="http://www.w3.org/TR/REC-xml-names/#NT-NCName">NCNAME</a>
+						The <dfn data-lt="local names">local name</dfn> of an <a>IRI</a> is defined as the longest <a data-cite="REC-xml-names/#NT-NCName">NCNAME</a>
 						at the end of the <a>IRI</a>, not immediately preceded by the first colon in the <a>IRI</a>.
 						The <dfn data-lt="parameter names">parameter name</dfn> of a <a>parameter declaration</a> is defined as the <a>local name</a> of the <a>value</a> of <code>sh:path</code>.
 						To ensure that a correct mapping from parameters into SPARQL variables is possible, the following syntax rules apply:
 					</p>
 					<p class="syntax">
-						<span data-syntax-rule="parameter-name-VARNAME">Every <a>parameter name</a> is a valid <a href="http://www.w3.org/TR/sparql11-query/#rVARNAME">SPARQL VARNAME</a>.</span>
+						<span data-syntax-rule="parameter-name-VARNAME">Every <a>parameter name</a> is a valid <a data-cite="sparql12-query/#rVARNAME">SPARQL VARNAME</a>.</span>
 						<span data-syntax-rule="parameter-name-not-in"><a>Parameter names</a> must not be one of the following: <code>this</code>, <code>shapesGraph</code>, <code>currentShape</code>, <code>path</code>, <code>PATH</code>, <code>value</code>.</span>
 						<span data-syntax-rule="parameter-name-unique">A constraint component where two or more <a>parameter declarations</a> use the same <a>parameter names</a> is <a>ill-formed</a>.</span>
 					</p>
@@ -1033,7 +1033,7 @@ shimpl:hasPattern
 							<span data-syntax-rule="propertyValidator-class">The values of <code>sh:propertyValidator</code> must be <a>SELECT-based validators</a>.</span>
 							<span data-syntax-rule="SPARQLSelectValidator-select-count"><a>SELECT-based validators</a> have exactly one <a>value</a> for the property <code>sh:select</code>.</span>
 							The value of <code>sh:select</code> is a valid SPARQL SELECT query using the aforementioned <a href="#sparql-prefixes">prefix handling rules</a>.
-							The SPARQL query derived from the value of <code>sh:select</code> <a href="https://www.w3.org/TR/sparql11-query/#selectproject">projects</a> the variable <code>this</code> in its SELECT clause.
+							The SPARQL query derived from the value of <code>sh:select</code> <a data-cite="sparql12-query/#selectproject">projects</a> the variable <code>this</code> in its SELECT clause.
 						</p>
 						<p><em>The remainder of this section is informative.</em></p>
 						<p>
@@ -1179,7 +1179,7 @@ ex:hasLang
 						For <a>SELECT-based validators</a>:
 						If the <a>shape</a> is a <a>property shape</a>, then prior to execution
 						<a>substitute</a> the variable <code>PATH</code> where it appears in the <a>predicate</a>
-						position of a <a href="https://www.w3.org/TR/sparql11-query/#QSynTriples">triple pattern</a>
+						position of a <a data-cite="sparql12-query/#QSynTriples">triple pattern</a>
 						with a valid SPARQL surface syntax string of the <a>SHACL property path</a>
 						specified via <code>sh:path</code> at the <a>property shape</a>.
 						Let <code>QS</code> be the <a>solutions</a> produced by executing the SPARQL query.
@@ -1223,7 +1223,7 @@ ex:hasLang
 					<li>SPARQL queries must not contain a federated query (<code>SERVICE</code>)</li>
 					<li>SPARQL queries must not contain a <code>VALUES</code> clause</li>
 					<li>SPARQL queries must not use the syntax form ​​<code>AS ?var</code> for any potentially pre-bound variable</li>
-					<li><a href="https://www.w3.org/TR/sparql11-query/#subqueries">Subqueries</a> must return all potentially pre-bound variables, except <code>shapesGraph</code> and <code>currentShape</code> which are optional as already mentioned in <a href="#sparql-constraints-prebound"></a></li> 
+					<li><a data-cite="sparql12-query/#subqueries">Subqueries</a> must return all potentially pre-bound variables, except <code>shapesGraph</code> and <code>currentShape</code> which are optional as already mentioned in <a href="#sparql-constraints-prebound"></a></li> 
 				</ul>
 			</div>
 
@@ -1240,9 +1240,9 @@ ex:hasLang
 					<p>
 						Define the <em>Values Insertion</em> function <code>Replace(X, μ)</code> to
 						replace each occurence <code>Y</code> of a 
-						<a href="https://www.w3.org/TR/sparql11-query/#sparqlTranslateBasicGraphPatterns">Basic Graph Pattern</a>,
-						<a href="https://www.w3.org/TR/sparql11-query/#sparqlTranslatePathExpressions">Property Path Expression</a>,
-						<a href="https://www.w3.org/TR/sparql11-query/#sparqlTranslateGraphPatterns"><code>Graph(Var, pattern)</code></a>
+						<a data-cite="sparql12-query/#sparqlTranslateBasicGraphPatterns">Basic Graph Pattern</a>,
+						<a data-cite="sparql12-query/#sparqlTranslatePathExpressions">Property Path Expression</a>,
+						<a data-cite="sparql12-query/#sparqlTranslateGraphPatterns"><code>Graph(Var, pattern)</code></a>
 						in <code>X</code> with <code>join(Y, Table(μ))</code>.
 					</p>
 				</div>
@@ -1252,7 +1252,7 @@ ex:hasLang
 				<div class="def-header">DEFINITION: <dfn data-lt="pre-binding|pre-bind|pre-bound|pre-bound variables|pre-binds">Pre-binding of variables</dfn></div>
 				<div class="def-text-body">
 					<p>
-						The evaluation of the <a href="https://www.w3.org/TR/sparql11-query/#idp2427544">SPARQL Query</a>
+						The evaluation of the <a data-cite="sparql12-query/#idp2427544">SPARQL Query</a>
 						<code>Q = (E, DS, QF)</code> with <em>pre-bound</em> variables <code>μ</code>
 						is defined as the evaluation of SPARQL query <code>Q' = (Replace(E, μ), DS, QF)</code>.
 					</p>
@@ -1290,7 +1290,7 @@ ex:hasLang
 				<code>owl:imports</code> and <code>sh:shapesGraph</code>.
 			</p>
 			<p>
-				SHACL-SPARQL includes all the <a href="https://www.w3.org/TR/sparql12-query/#security">security issues of SPARQL</a>.
+				SHACL-SPARQL includes all the <a data-cite="sparql12-query/#security">security issues of SPARQL</a>.
 			</p>
 		</section>
 		


### PR DESCRIPTION
- Editorial clean up to resolve and update references between the two new shacl docs.
- Changed RDF/SPARQL/TTL references to 1.2
- New CSS for all samples so that formatting and hyperlinks work again
- No normative changes (from what I can tell)
- Clean up of outdated stuff such as jQuery usage

Sorry this is large PR due to the many formatting and reference changes. Won't be perfect but hopefully an improvement.