### PR TITLE
Issue 322: Node expressions base definition

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2157,46 +2157,32 @@ ex:ExamplePropertyShape
 			</section>
 		</section>
 
-		<section id="expressions">
-			<h2>SHACL Expressions</h2>
+		<section id="property-paths">
+			<h2>SHACL Property Paths</h2>
 			<p>
-				This section introduces the concepts of <a href="#property-paths">SHACL property paths</a>
-				and <a href="#node-expressions">node expressions</a>.
-				Each is a mechanism to produce a list of nodes, typically based on a given focus node as input.
+				Property paths can be used at <a href="#property-shapes"><code>sh:path</code></a> to derive the <a>value nodes</a> of a property shape.
 			</p>
 			<p>
-				SHACL Core supports such expressions in the following features:
+				SHACL includes RDF terms to represent the following subset of <a>SPARQL property paths</a>:
+				<code>PredicatePath</code>, <code>InversePath</code>, <code>SequencePath</code>, <code>AlternativePath</code>,
+				<code>ZeroOrMorePath</code>, <code>OneOrMorePath</code> and <code>ZeroOrOnePath</code>.
 			</p>
-			<ul>
-				<li>Property paths can be used at <a href="#property-shapes"><code>sh:path</code></a> to derive the value nodes of a property shape.</li>
-				<li>Node expressions can be used at <a href="#property-shapes"><code>sh:values</code> and <code>sh:defaultValue</code></a> to derive the value nodes of a property shape.</li>
-				<li>Node expressions can be used at <a href="#targetNode"><code>sh:targetNode</code></a> to dynamically compute the targets of a shape.</li>
-				<li>Node expressions can be used as parameter values of most <a href="#core-components">constraint components</a> to represent constraints that may be different depending on each focus node. <span class="todo">TODO: This change needs to be made still.</span></li>
-			</ul>
-
-			<section id="property-paths">
-				<h3>SHACL Property Paths</h3>
-				<p>
-					SHACL includes RDF terms to represent the following subset of <a>SPARQL property paths</a>:
-					<code>PredicatePath</code>, <code>InversePath</code>, <code>SequencePath</code>, <code>AlternativePath</code>,
-					<code>ZeroOrMorePath</code>, <code>OneOrMorePath</code> and <code>ZeroOrOnePath</code>.
-				</p>
-				<p>
-					The following sub-sections provide syntax rules of <a>well-formed</a> <a>SHACL property paths</a>
-					together with mapping rules to <a href="https://www.w3.org/TR/sparql12-query/#pp-language">SPARQL 1.2 property paths</a>.
-					These rules define the <dfn>path mapping</dfn> <code>path(p,G)</code> in an RDF graph <code>G</code> of an RDF term <code>p</code> that is a SHACL property path in <code>G</code>.
-					Two SHACL property paths are considered <dfn data-lt="equivalent path">equivalent paths</dfn> when they map to the exact same SPARQL property paths.
-				</p>
-				<p class="syntax">
-					<span data-syntax-rule="path-metarule">A node in an RDF graph is a <a>well-formed</a> <dfn data-lt="SHACL property paths">SHACL property path</dfn> <code>p</code> if it satisfies exactly one of the syntax rules in the following sub-sections.</span>
-					<span data-syntax-rule="path-non-recursive">A node <code>p</code> is not a <a>well-formed</a> SHACL property path if <code>p</code> is a blank node and any path mappings of <code>p</code> directly or transitively reference <code>p</code>.</span>
-				</p>
-				<p>
-					The following example illustrates some valid SHACL property paths, together with their SPARQL 1.2 equivalents.
-				</p>
-				<aside class="example" title="Some valid property path expressions and their SPARQL 1.2 equivalents">
-					<div class="shapes-graph">
-						<div class="turtle">
+			<p>
+				The following sub-sections provide syntax rules of <a>well-formed</a> <a>SHACL property paths</a>
+				together with mapping rules to <a href="https://www.w3.org/TR/sparql12-query/#pp-language">SPARQL 1.2 property paths</a>.
+				These rules define the <dfn>path mapping</dfn> <code>path(p,G)</code> in an RDF graph <code>G</code> of an RDF term <code>p</code> that is a SHACL property path in <code>G</code>.
+				Two SHACL property paths are considered <dfn data-lt="equivalent path">equivalent paths</dfn> when they map to the exact same SPARQL property paths.
+			</p>
+			<p class="syntax">
+				<span data-syntax-rule="path-metarule">A node in an RDF graph is a <a>well-formed</a> <dfn data-lt="SHACL property paths">SHACL property path</dfn> <code>p</code> if it satisfies exactly one of the syntax rules in the following sub-sections.</span>
+				<span data-syntax-rule="path-non-recursive">A node <code>p</code> is not a <a>well-formed</a> SHACL property path if <code>p</code> is a blank node and any path mappings of <code>p</code> directly or transitively reference <code>p</code>.</span>
+			</p>
+			<p>
+				The following example illustrates some valid SHACL property paths, together with their SPARQL 1.2 equivalents.
+			</p>
+			<aside class="example" title="Some valid property path expressions and their SPARQL 1.2 equivalents">
+				<div class="shapes-graph">
+					<div class="turtle">
 # SPARQL Property path: ex:parent
 ex:SomeClass-predicateExample
 	sh:path ex:parent .
@@ -2226,9 +2212,9 @@ ex:SomeClass-alternativePathExample
 	sh:path [ 
 		sh:alternativePath ( ex:father ex:mother  ) 
 	] .						
-						</div>
-						<div class="jsonld">
-							<pre class="jsonld">{
+					</div>
+					<div class="jsonld">
+						<pre class="jsonld">{
 	"@graph": [
 		{
 			"@id": "ex:SomeClass-alternativePathExample",
@@ -2289,219 +2275,179 @@ ex:SomeClass-alternativePathExample
 		}
 	]
 }</pre>
-						</div>
 					</div>
-				</aside>
-				<section id="property-path-predicate">
-					<h4>Predicate Paths</h4>
-					<p class="syntax">
-						A <dfn>predicate path</dfn> is an <a>IRI</a>.
-					</p>
-					<p>
-						If <code>p</code> is a <a>predicate path</a>, then <code>path(p,G)</code> is
-						a SPARQL <code>PredicatePath</code> with <code>p</code> as <code>iri</code>.
-					</p>
-				</section>
-				<section id="property-path-sequence">
-					<h4>Sequence Paths</h4>
-					<p class="syntax" data-syntax-rule="path-sequence">
-						A <dfn>sequence path</dfn> is a <a>blank node</a> that is a <a>SHACL list</a>
-						with at least two <a>members</a> and each member is a <a>well-formed</a> SHACL property path.
-					</p>
-					<p>
-						If <code>p</code> is a <a>sequence path</a> in <code>G</code> with list <a>members</a>
-						<code>v<sub>1</sub></code>, <code>v<sub>2</sub></code>, ..., <code>v<sub>n</sub></code>,
-						then <code>path(p,G)</code> is a SPARQL <code>SequencePath</code> of
-						<code>path(v<sub>1</sub>,G)</code> as <code>elt1</code>, and the results of the <a>path mapping</a>
-						of the list node of <code>v<sub>2</sub></code> as <code>elt2</code>.
-					</p>
-					<p>
-						Informal note: the <a>nodes</a> in such a <a>SHACL list</a> should not have <a>values</a> for
-						other properties beside <code>rdf:first</code> and <code>rdf:rest</code>.
-					</p>
-				</section>
-				<section id="property-path-alternative">
-					<h4>Alternative Paths</h4>
-					<p class="syntax" data-syntax-rule="path-alternative">
-						An <dfn>alternative path</dfn> is a <a>blank node</a> that is the subject of exactly one triple in <code>G</code>.
-						This triple has <code>sh:alternativePath</code> as predicate, <code>L</code> as object,
-						and <code>L</code> is a <a>SHACL list</a> with at least two <a>members</a>
-						and each member of <code>L</code> is a <a>well-formed</a> SHACL property path.
-					</p>
-					<p>
-						If <code>p</code> is an <a>alternative path</a> in <code>G</code>,
-						then, for the members of its SHACL list <code>L</code>:
-						<code>v<sub>1</sub></code>, <code>v<sub>2</sub></code>, ..., <code>v<sub>n</sub></code>,
-						<code>path(p,G)</code> is a SPARQL <code>AlternativePath</code> with
-						<code>path(v<sub>1</sub>,G)</code> as <code>elt1</code> followed by an <code>AlternativePath</code>
-						for <code>v<sub>2</sub></code> as <code>elt2</code>, ..., up to <code>path(v<sub>n</sub>,G)</code>.
-					</p>
-				</section>
-				<section id="property-path-inverse">
-					<h4>Inverse Paths</h4>
-					<p class="syntax" data-syntax-rule="path-inverse">
-						An <dfn>inverse path</dfn> is a <a>blank node</a> that is the <a>subject</a> of exactly one <a>triple</a> in <code>G</code>.
-						This triple has <code>sh:inversePath</code> as predicate, and the <a>object</a> <code>v</code> is a <a>well-formed</a> SHACL property path.
-					</p>
-					<p>
-						If <code>p</code> is an <a>inverse path</a> in <code>G</code>, then <code>path(p,G)</code> is a
-						SPARQL <code>InversePath</code> with <code>path(v,G)</code> as its <code>elt</code>.
-					</p>
-				</section>
-				<section id="property-path-zero-or-more">
-					<h4>Zero-Or-More Paths</h4>
-					<p class="syntax" data-syntax-rule="path-zero-or-more">
-						A <dfn>zero-or-more path</dfn> is a <a>blank node</a> that is the <a>subject</a> of exactly one <a>triple</a> in <code>G</code>.
-						This triple has <code>sh:zeroOrMorePath</code> as <a>predicate</a>, and the <a>object</a> <code>v</code> is a <a>well-formed</a> SHACL property path.
-					</p>
-					<p>
-						If <code>p</code> is a <a>zero-or-more path</a> in <code>G</code>, then <code>path(p,G)</code> is a
-						SPARQL <code>ZeroOrMorePath</code> with <code>path(v,G)</code> as its <code>elt</code>.
-					</p>
-				</section>
-				<section id="property-path-one-or-more">
-					<h4>One-Or-More Paths</h4>
-					<p class="syntax" data-syntax-rule="path-one-or-more">
-						A <dfn>one-or-more path</dfn> is a <a>blank node</a> that is the <a>subject</a> of exactly one <a>triple</a> in <code>G</code>.
-						This triple has <code>sh:oneOrMorePath</code> as <a>predicate</a>, and the <a>object</a> <code>v</code> is a <a>well-formed</a> SHACL property path.
-					</p>
-					<p>
-						If <code>p</code> is a <a>one-or-more path</a> in <code>G</code>, then <code>path(p,G)</code> is a
-						SPARQL <code>OneOrMorePath</code> with <code>path(v,G)</code> as its <code>elt</code>.
-					</p>
-				</section>
-				<section id="property-path-zero-or-one">
-					<h4>Zero-Or-One Paths</h4>
-					<p class="syntax" data-syntax-rule="path-zero-or-one">
-						A <dfn>zero-or-one path</dfn> is a <a>blank node</a> that is the <a>subject</a> of exactly one <a>triple</a> in <code>G</code>.
-						This triple has <code>sh:zeroOrOnePath</code> as <a>predicate</a>, and the <a>object</a> <code>v</code> is a <a>well-formed</a> SHACL property path.
-					</p>
-					<p>
-						If <code>p</code> is a <a>zero-or-one path</a> in <code>G</code>, then <code>path(p,G)</code> is a
-						SPARQL <code>ZeroOrOnePath</code> with <code>path(v,G)</code> as its <code>elt</code>.
-					</p>
-				</section>
+				</div>
+			</aside>
+			<section id="property-path-predicate">
+				<h3>Predicate Paths</h3>
+				<p class="syntax">
+					A <dfn>predicate path</dfn> is an <a>IRI</a>.
+				</p>
+				<p>
+					If <code>p</code> is a <a>predicate path</a>, then <code>path(p,G)</code> is
+					a SPARQL <code>PredicatePath</code> with <code>p</code> as <code>iri</code>.
+				</p>
 			</section>
+			<section id="property-path-sequence">
+				<h3>Sequence Paths</h3>
+				<p class="syntax" data-syntax-rule="path-sequence">
+					A <dfn>sequence path</dfn> is a <a>blank node</a> that is a <a>SHACL list</a>
+					with at least two <a>members</a> and each member is a <a>well-formed</a> SHACL property path.
+				</p>
+				<p>
+					If <code>p</code> is a <a>sequence path</a> in <code>G</code> with list <a>members</a>
+					<code>v<sub>1</sub></code>, <code>v<sub>2</sub></code>, ..., <code>v<sub>n</sub></code>,
+					then <code>path(p,G)</code> is a SPARQL <code>SequencePath</code> of
+					<code>path(v<sub>1</sub>,G)</code> as <code>elt1</code>, and the results of the <a>path mapping</a>
+					of the list node of <code>v<sub>2</sub></code> as <code>elt2</code>.
+				</p>
+				<p>
+					Informal note: the <a>nodes</a> in such a <a>SHACL list</a> should not have <a>values</a> for
+					other properties beside <code>rdf:first</code> and <code>rdf:rest</code>.
+				</p>
+			</section>
+			<section id="property-path-alternative">
+				<h3>Alternative Paths</h3>
+				<p class="syntax" data-syntax-rule="path-alternative">
+					An <dfn>alternative path</dfn> is a <a>blank node</a> that is the subject of exactly one triple in <code>G</code>.
+					This triple has <code>sh:alternativePath</code> as predicate, <code>L</code> as object,
+					and <code>L</code> is a <a>SHACL list</a> with at least two <a>members</a>
+					and each member of <code>L</code> is a <a>well-formed</a> SHACL property path.
+				</p>
+				<p>
+					If <code>p</code> is an <a>alternative path</a> in <code>G</code>,
+					then, for the members of its SHACL list <code>L</code>:
+					<code>v<sub>1</sub></code>, <code>v<sub>2</sub></code>, ..., <code>v<sub>n</sub></code>,
+					<code>path(p,G)</code> is a SPARQL <code>AlternativePath</code> with
+					<code>path(v<sub>1</sub>,G)</code> as <code>elt1</code> followed by an <code>AlternativePath</code>
+					for <code>v<sub>2</sub></code> as <code>elt2</code>, ..., up to <code>path(v<sub>n</sub>,G)</code>.
+				</p>
+			</section>
+			<section id="property-path-inverse">
+				<h3>Inverse Paths</h3>
+				<p class="syntax" data-syntax-rule="path-inverse">
+					An <dfn>inverse path</dfn> is a <a>blank node</a> that is the <a>subject</a> of exactly one <a>triple</a> in <code>G</code>.
+					This triple has <code>sh:inversePath</code> as predicate, and the <a>object</a> <code>v</code> is a <a>well-formed</a> SHACL property path.
+				</p>
+				<p>
+					If <code>p</code> is an <a>inverse path</a> in <code>G</code>, then <code>path(p,G)</code> is a
+					SPARQL <code>InversePath</code> with <code>path(v,G)</code> as its <code>elt</code>.
+				</p>
+			</section>
+			<section id="property-path-zero-or-more">
+				<h3>Zero-Or-More Paths</h3>
+				<p class="syntax" data-syntax-rule="path-zero-or-more">
+					A <dfn>zero-or-more path</dfn> is a <a>blank node</a> that is the <a>subject</a> of exactly one <a>triple</a> in <code>G</code>.
+					This triple has <code>sh:zeroOrMorePath</code> as <a>predicate</a>, and the <a>object</a> <code>v</code> is a <a>well-formed</a> SHACL property path.
+				</p>
+				<p>
+					If <code>p</code> is a <a>zero-or-more path</a> in <code>G</code>, then <code>path(p,G)</code> is a
+					SPARQL <code>ZeroOrMorePath</code> with <code>path(v,G)</code> as its <code>elt</code>.
+				</p>
+			</section>
+			<section id="property-path-one-or-more">
+				<h3>One-Or-More Paths</h3>
+				<p class="syntax" data-syntax-rule="path-one-or-more">
+					A <dfn>one-or-more path</dfn> is a <a>blank node</a> that is the <a>subject</a> of exactly one <a>triple</a> in <code>G</code>.
+					This triple has <code>sh:oneOrMorePath</code> as <a>predicate</a>, and the <a>object</a> <code>v</code> is a <a>well-formed</a> SHACL property path.
+				</p>
+				<p>
+					If <code>p</code> is a <a>one-or-more path</a> in <code>G</code>, then <code>path(p,G)</code> is a
+					SPARQL <code>OneOrMorePath</code> with <code>path(v,G)</code> as its <code>elt</code>.
+				</p>
+			</section>
+			<section id="property-path-zero-or-one">
+				<h3>Zero-Or-One Paths</h3>
+				<p class="syntax" data-syntax-rule="path-zero-or-one">
+					A <dfn>zero-or-one path</dfn> is a <a>blank node</a> that is the <a>subject</a> of exactly one <a>triple</a> in <code>G</code>.
+					This triple has <code>sh:zeroOrOnePath</code> as <a>predicate</a>, and the <a>object</a> <code>v</code> is a <a>well-formed</a> SHACL property path.
+				</p>
+				<p>
+					If <code>p</code> is a <a>zero-or-one path</a> in <code>G</code>, then <code>path(p,G)</code> is a
+					SPARQL <code>ZeroOrOnePath</code> with <code>path(v,G)</code> as its <code>elt</code>.
+				</p>
+			</section>
+		</section>
 
-			<section id="node-expressions">
-				<h3>Node Expressions</h3>
+		<section id="node-expressions">
+			<h2>Node Expressions</h2>
+			<p>
+				This section introduces the concept of <a>node expressions</a>.
+				SHACL Core supports node expressions in the following features:
+			</p>
+			<ul>
+				<li>At <a href="#property-shapes"><code>sh:values</code> and <code>sh:defaultValue</code></a> to derive the value nodes of a property shape.</li>
+				<li>At <a href="#targetNode"><code>sh:targetNode</code></a> to dynamically compute the targets of a shape.</li>
+				<li>As parameter values of most <a href="#core-components">constraint components</a> to represent constraints that may be different depending on each focus node. <span class="todo">TODO: This change needs to be made still, see ISSUE 311.</span></li>
+				<li>At <a href="#deactivated"><code>sh:deactivated</code></a> to deactivate certain shapes under specific conditions. <span class="todo">TODO: This change needs to be made still, see ISSUE 338.</span></li>
+			</ul>
+			<p>
+				Readers who are only interested in SHACL Core can typically skip this section.
+				Given that Core only supports constant IRIs and literals as node expressions, the use cases of node expressions
+				are identical to traditional use of SHACL Core.
+			</p>
+			<div class="def">
+				<div class="def-header">TEXTUAL DEFINITION</div>
+				A <dfn>node expression</dfn> is a <a>node</a> that follows the syntax rules of exactly one <dfn>node expression function</dfn>.
+				Each <a>node expression function</a> has an <a>IRI</a> as its <dfn>function name</dfn>.
+			</div>
+			<div class="def" id="node-expression-evaluation">
+				<div class="def-header">EVALUATION OF NODE EXPRESSIONS</div>
+				The <dfn>evaluation</dfn> of a node expression is defined as a function <code>evalExpr(expr, activeGraph, scope) -> outputNodes</code>
+				where
+				<ul>
+					<li><code>expr</code> is a <a>node expression</a>.</li>
+					<li><code>activeGraph</code> is a <a>graph</a>, called the <dfn>active graph</dfn>.</li>
+					<li><code>scope</code> is a map from <a href="https://www.w3.org/TR/sparql12-query/#defn_QueryVariable">variable names</a> to individual <a>nodes</a>.
+						The value of the variable <code>focusNode</code> (if it exists) is called the <dfn>input focus node</dfn>.
+					</li>
+				</ul>
+				The result of the evaluation of a node expression is a list of <a>nodes</a> (possibly empty and with duplicates) called the <dfn>output nodes</dfn>.
+				The evaluation may also result in an <dfn>evaluation failure</dfn>.
+			</div>
+			<p>
+				The SHACL Core specification only exactly defines the <a>node expression functions</a> based on the next two subsections.
+				Other specifications such as [[shacl12-sparql]] introduce additional functions, using <a>blank nodes</a>.
+				Therefore <a>node expressions</a> serve as an extension point of SHACL.
+				<span class="todo">TODO: Add link to shacl12-node-expr once that is stable.</span>
+			</p>
+			<section id="IRIExpression">
+				<h3>IRI Expressions</h3>
 				<p>
-					This section introduces the concept of <a>node expressions</a>.
+					A <a>node expression</a> that is a <a>IRI</a> is called an <dfn>IRI expression</dfn> with the <a>function name</a>
+					<code>sh:IRIExpression</code>.
 				</p>
-				<div class="def">
-					<div class="def-header">TEXTUAL DEFINITION</div>
-					A <dfn>node expression</dfn> is a <a>node</a> that follows the syntax rules of exactly one <dfn>node expression function</dfn>.
-					Each <a>node expression function</a> has an <a>IRI</a> as its <dfn>function name</dfn>.
-					Node expression functions can declare one or more <dfn>node expression parameters</dfn>.
-					Each of these parameters has an <a>IRI</a>.
-					One of these parameters can be the <dfn>key parameter</dfn> that uniquely identifies the <a>function name</a>.
+				<p class="syntax">
+					<span data-syntax-rule="IRIExpression-syntax">A node in an RDF graph is a <a>well-formed</a> <a>IRI expression</a> if it is an <a>IRI</a>.</span>
+				</p>
+				<div class="def" id="IRIExpression-evaluation">
+					<div class="def-header">EVALUATION OF IRI EXPRESSIONS</div>
+					<p>
+						The <a>output nodes</a> of an <a>IRI expression</a> are the list consisting of exactly the <a>node expression</a> itself:
+						<br/>
+						<br/>
+						<code>evalExpr(expr, activeGraph, scope) -> [expr]</code>
+					</p>
 				</div>
-				<div class="def" id="node-expression-evaluation">
-					<div class="def-header">EVALUATION OF NODE EXPRESSIONS</div>
-					The <dfn>evaluation</dfn> of a node expression is defined as a function <code>evalExpr(expr, activeGraph, scope) -> outputNodes</code>
-					where
-					<ul>
-						<li><code>expr</code> is a <a>node expression</a> that is the <a>subject</a> of <a>triples</a> where the <a>predicates</a> are the <a>node expression parameters</a>,
-							optional for any but the <a>key parameter</a> unless stated otherwise in the definition of the node expression function.</li>
-						<li><code>activeGraph</code> is a <a>graph</a>, called the <dfn>active graph</dfn>.</li>
-						<li><code>scope</code> is a map from <a href="https://www.w3.org/TR/sparql12-query/#defn_QueryVariable">variable names</a> to individual <a>nodes</a>.
-							The value of the variable <code>focusNode</code> (if it exists) is called the <dfn>input focus node</dfn>.
-						</li>
-					</ul>
-					The result of the evaluation of a node expression is a list of <a>nodes</a> (possibly empty and with duplicates) called the <dfn>output nodes</dfn>.
-					The evaluation may also result in an <dfn>evaluation failure</dfn>.
+			</section>
+			<section id="LiteralExpression">
+				<h3>Literal Expressions</h3>
+				<p>
+					A <a>node expression</a> that is a <a>literal</a> is called a <dfn>literal expression</dfn> with the <a>function name</a>
+					<code>sh:LiteralExpression</code>.
+				</p>
+				<p class="syntax">
+					<span data-syntax-rule="LiteralExpression-syntax">A node in an RDF graph is a <a>well-formed</a> <a>literal expression</a> if it is a <a>literal</a>.</span>
+				</p>
+				<div class="def" id="LiteralExpression-evaluation">
+					<div class="def-header">EVALUATION OF LITERAL EXPRESSIONS</div>
+					<p>
+						The <a>output nodes</a> of a <a>literal expression</a> are the list consisting of exactly the <a>node expression</a> itself:
+						<br/>
+						<br/>
+						<code>evalExpr(expr, activeGraph, scope) -> [expr]</code>
+					</p>
 				</div>
-				<p>
-					The following example illustrates the syntax of a node expression, used as a blank node value of <code>sh:values</code>:
-				</p>
-				<aside class="example" title="A dynamically computed property using a node expression based on a SPARQL query">
-					<p>
-						Here is an example use of a node expression based on <a data-cite="shacl12-sparql#SelectExpression">SHACL-SPARQL</a>, computing
-						the values of a property shape for the property "full name" as the concatenation of the <code>ex:firstName</code>,
-						a space, and the <code>ex:lastName</code>.
-					</p>
-					<div class="shapes-graph">
-						<div class="turtle">
-ex:Person-fullName
-	a sh:PropertyShape ;
-	sh:name "full name" ;
-	sh:path ex:fullName ;
-	sh:values <b>[
-		sh:select """
-			PREFIX ex: &lt;http://example.org/ns#&gt;
-			SELECT ?fullName
-			WHERE {
-				$this ex:firstName ?firstName .
-				$this ex:lastName ?lastName .
-				BIND (CONCAT(?firstName, " ", ?lastName) AS ?fullName) .
-			}
-		"""
-	]</b> ;
-	sh:datatype xsd:string .
-						</div>
-						<div class="jsonld">
-							<pre class="jsonld">{
-	"@id": "ex:Person-fullName",
-	"@type": "sh:PropertyShape",
-	"sh:datatype": {
-		"@id": "xsd:string"
-	},
-	"sh:name": "full name",
-	"sh:path": {
-		"sh:select": "\n\t\t\tPREFIX ex: &lt;http://example.org/ns#&gt;\n\t\t\tSELECT ?fullName\n\t\t\tWHERE {\n\t\t\t\t$this ex:firstName ?firstName .\n\t\t\t\t$this ex:lastName ?lastName .\n\t\t\t\tBIND (CONCAT(?firstName, \" \", ?lastName) AS ?fullName) .\n\t\t\t}\n\t\t"
-	}
-}</pre>
-						</div>
-					</div>
-					<p>
-						In this example, the <a>key parameter</a> is <code>sh:select</code>,
-						and the <a>function name</a> is (as defined by SHACL-SPARQL) is <code>sh:SelectExpression</code>.
-					</p>
-				</aside>
-				<p>
-					This SHACL Core specification only exactly defines the <a>node expression functions</a> from the following two subsections.
-					Other specifications such as [[shacl12-sparql]] introduce additional functions.
-					Therefore <a>node expressions</a> serve as an extension point of SHACL.
-					<span class="todo">TODO: Add link to shacl12-node-expr once that is stable.</span>
-				</p>
-				<section id="IRIExpression">
-					<h4>IRI Expressions</h4>
-					<p>
-						A <a>node expression</a> that is a <a>IRI</a> is called an <dfn>IRI expression</dfn> with the <a>function name</a>
-						<code>sh:IRIExpression</code>.
-					</p>
-					<p class="syntax">
-						<span data-syntax-rule="IRIExpression-syntax">A node in an RDF graph is a <a>well-formed</a> <a>IRI expression</a> if it is an <a>IRI</a>.</span>
-					</p>
-					<div class="def" id="IRIExpression-evaluation">
-						<div class="def-header">EVALUATION OF IRI EXPRESSIONS</div>
-						<p>
-							The <a>output nodes</a> of an <a>IRI expression</a> are the list consisting of exactly the <a>node expression</a> itself:
-							<br/>
-							<br/>
-							<code>evalExpr(expr, activeGraph, scope) -> [expr]</code>
-						</p>
-					</div>
-				</section>
-				<section id="LiteralExpression">
-					<h4>Literal Expressions</h4>
-					<p>
-						A <a>node expression</a> that is a <a>literal</a> is called a <dfn>literal expression</dfn> with the <a>function name</a>
-						<code>sh:LiteralExpression</code>.
-					</p>
-					<p class="syntax">
-						<span data-syntax-rule="LiteralExpression-syntax">A node in an RDF graph is a <a>well-formed</a> <a>literal expression</a> if it is a <a>literal</a>.</span>
-					</p>
-					<div class="def" id="LiteralExpression-evaluation">
-						<div class="def-header">EVALUATION OF LITERAL EXPRESSIONS</div>
-						<p>
-							The <a>output nodes</a> of a <a>literal expression</a> are the list consisting of exactly the <a>node expression</a> itself:
-							<br/>
-							<br/>
-							<code>evalExpr(expr, activeGraph, scope) -> [expr]</code>
-						</p>
-					</div>
-				</section>
 			</section>
 		</section>
 

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2396,7 +2396,8 @@ ex:SomeClass-alternativePathExample
 				The <dfn>evaluation</dfn> of a node expression is defined as a function <code>evalExpr(expr, activeGraph, scope) -> outputNodes</code>
 				where
 				<ul>
-					<li><code>expr</code> is a <a>node expression</a>.</li>
+					<li><code>expr</code> is a <a>node expression</a> in a <a>shapes graph</a>.
+					During evaluation, the engine can access <a>triples</a> related to <code>expr</code> in the <a>shapes graph</a>.</li>
 					<li><code>activeGraph</code> is a <a>graph</a>, called the <dfn>active graph</dfn>.</li>
 					<li><code>scope</code> is a map from <a href="https://www.w3.org/TR/sparql12-query/#defn_QueryVariable">variable names</a> to individual <a>nodes</a>.
 						The value of the variable <code>focusNode</code> (if it exists) is called the <dfn>input focus node</dfn>.

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2398,7 +2398,7 @@ ex:SomeClass-alternativePathExample
 				</div>
 				<div class="def" id="node-expression-evaluation">
 					<div class="def-header">EVALUATION OF NODE EXPRESSIONS</div>
-					The <dfn>evaluation</dfn> of a node expression is defined as a function <code>eval(expr, activeGraph, scope) -> outputNodes</code>
+					The <dfn>evaluation</dfn> of a node expression is defined as a function <code>evalExpr(expr, activeGraph, scope) -> outputNodes</code>
 					where
 					<ul>
 						<li><code>expr</code> is a <a>node expression</a> that is the <a>subject</a> of <a>triples</a> where the <a>predicates</a> are the <a>node expression parameters</a>,
@@ -2479,7 +2479,7 @@ ex:Person-fullName
 							The <a>output nodes</a> of an <a>IRI expression</a> are the list consisting of exactly the <a>node expression</a> itself:
 							<br/>
 							<br/>
-							<code>eval(expr, activeGraph, scope) -> [expr]</code>
+							<code>evalExpr(expr, activeGraph, scope) -> [expr]</code>
 						</p>
 					</div>
 				</section>
@@ -2498,7 +2498,7 @@ ex:Person-fullName
 							The <a>output nodes</a> of a <a>literal expression</a> are the list consisting of exactly the <a>node expression</a> itself:
 							<br/>
 							<br/>
-							<code>eval(expr, activeGraph, scope) -> [expr]</code>
+							<code>evalExpr(expr, activeGraph, scope) -> [expr]</code>
 						</p>
 					</div>
 				</section>
@@ -2962,12 +2962,12 @@ ex:Person-fullName
 						</li>
 						<li>
 							If <code>e</code> is the <a>value</a> of <code>sh:values</code> at the <a>property shape</a>,
-							then add the <a>output nodes</a> of <code>eval(e, <a>data graph</a>, scope)</code> where <code>scope</code>
+							then add the <a>output nodes</a> of <code>evalExpr(e, <a>data graph</a>, scope)</code> where <code>scope</code>
 							contains the <a>focus node</a> as the value of the variable <code>focusNode</code>.
 						</li>
 						<li>
 							If the set is still empty and <code>d</code> is the <a>value</a> of <code>sh:defaultValue</code> at the <a>property shape</a>,
-							then add the <a>output nodes</a> of <code>eval(d, <a>data graph</a>, scope)</code> where <code>scope</code>
+							then add the <a>output nodes</a> of <code>evalExpr(d, <a>data graph</a>, scope)</code> where <code>scope</code>
 							contains the <a>focus node</a> as the value of the variable <code>focusNode</code>.
 						</li>
 					</ol>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -1218,8 +1218,10 @@ ex:hasLang
 				</p>
 				<p class="syntax">
 					<span data-syntax-rule="SelectExpression-syntax">A node in an RDF graph is a <a>well-formed</a> <a>select expression</a> if it is a <a>blank node</a>
-					that is the <a>subject</a> of exactly one <a>triple</a> with <code>sh:select</code> as <a>predicate</a> and a <a>literal</a> as <a>object</a>
-					with <a>datatype</a> <code>xsd:string</code>.</span>
+					that has exactly one <a>value</a> for the <a>predicate</a> <code>sh:select</code>
+					and this <a>value</a> is <a>literal</a> with <a>datatype</a> <code>xsd:string</code>.</span>
+					<span data-syntax-rule="SelectExpression-syntax-prefixes">A <a>well-formed</a> <a>select expression</a> can have at most one <a>value</a> for the property
+					<code>sh:prefixes</code> and this value is an <a>IRI</a> or a <a>blank node</a>.</span><br/><br/>
 					<span data-syntax-rule="SelectExpression-query-valid">Using the <a href="#sparql-prefixes">prefix handling rules</a>, the value of <code>sh:select</code> is a valid SPARQL 1.2 SELECT query.</span>
 					<span data-syntax-rule="SelectExpression-query-output-nodes">The SPARQL query derived from the value of <code>sh:select</code> <a data-cite="sparql12-query/#selectproject">projects</a> exactly one variable in the SELECT clause.</span>
 				</p>
@@ -1324,11 +1326,9 @@ ex:Bernd
 				</p>
 				<p class="syntax">
 					<span data-syntax-rule="EvalExpression-syntax-eval">A node in an RDF graph
-					is a <a>well-formed</a> <a>eval expression</a>
-					if it is a <a>blank node</a>
-					that is the <a>subject</a> of exactly one <a>triple</a>
-					with <code>sh:eval</code> as <a>predicate</a>
-					and a <a>literal</a> with <a>datatype</a> <code>xsd:string</code> as <a>object</a>.</span>
+					is a <a>well-formed</a> <a>eval expression</a> if it is a <a>blank node</a>
+					that has exactly one <a>value</a> for the <a>predicate</a> <code>sh:eval</code>
+					and that <a>value</a> is a <a>literal</a> with <a>datatype</a> <code>xsd:string</code>.</span>
 					<span data-syntax-rule="EvalExpression-syntax-prefixes">A <a>well-formed</a> <a>eval expression</a> can have at most one <a>value</a> for the property
 					<code>sh:prefixes</code> and this value is an <a>IRI</a> or a <a>blank node</a>.</span><br/><br/>
 					<span data-syntax-rule="EvalExpression-template">Let <code>$EVAL$</code> be the <a>value</a> of <code>sh:eval</code> and <code>$PREFIXES$</code>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -1231,7 +1231,7 @@ ex:hasLang
 						If present in the <a>scope</a>, the value of the scope variable <code>focusNode</code> MUST be <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
 						<br/>
 						<br/>
-						<code>eval(expr, activeGraph, scope) -> resultNodes</code>
+						<code>evalExpr(expr, activeGraph, scope) -> resultNodes</code>
 					</p>
 				</div>
 				<p><em>The remainder of this section is informative.</em></p>
@@ -1341,7 +1341,7 @@ ex:Bernd
 						If present in the <a>scope</a>, the value of the scope variable <code>focusNode</code> MUST be <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
 						<br/>
 						<br/>
-						<code>eval(expr, activeGraph, scope) -> resultNodes</code>
+						<code>evalExpr(expr, activeGraph, scope) -> resultNodes</code>
 					</p>
 				</div>
 				<p><em>The remainder of this section is informative.</em></p>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -1219,9 +1219,9 @@ ex:hasLang
 				<p class="syntax">
 					<span data-syntax-rule="SelectExpression-syntax">A node in an RDF graph is a <a>well-formed</a> <a>select expression</a> if it is a <a>blank node</a>
 					that has exactly one <a>value</a> for the <a>predicate</a> <code>sh:select</code>
-					and this <a>value</a> is <a>literal</a> with <a>datatype</a> <code>xsd:string</code>.</span>
+					and this <a>value</a> is a <a>literal</a> with <a>datatype</a> <code>xsd:string</code>.</span>
 					<span data-syntax-rule="SelectExpression-syntax-prefixes">A <a>well-formed</a> <a>select expression</a> can have at most one <a>value</a> for the property
-					<code>sh:prefixes</code> and this value is an <a>IRI</a> or a <a>blank node</a>.</span><br/><br/>
+					<code>sh:prefixes</code> and this value can only be an <a>IRI</a> or a <a>blank node</a>.</span><br/><br/>
 					<span data-syntax-rule="SelectExpression-query-valid">Using the <a href="#sparql-prefixes">prefix handling rules</a>, the value of <code>sh:select</code> is a valid SPARQL 1.2 SELECT query.</span>
 					<span data-syntax-rule="SelectExpression-query-output-nodes">The SPARQL query derived from the value of <code>sh:select</code> <a data-cite="sparql12-query/#selectproject">projects</a> exactly one variable in the SELECT clause.</span>
 				</p>
@@ -1321,7 +1321,7 @@ ex:Bernd
 			<section id="SPARQLExprExpression">
 				<h3>SPARQL Expr Expressions</h3>
 				<p>
-					A <a>node expression</a> that has a <a>value</a> for <code>sh:sparqlExpr</code> is called an <dfn>SPARQL expr expression</dfn> with the <a>function name</a>
+					A <a>node expression</a> that has a <a>value</a> for <code>sh:sparqlExpr</code> is called a <dfn>SPARQL expr expression</dfn> with the <a>function name</a>
 					<code>sh:SPARQLExprExpression</code>.
 				</p>
 				<p class="syntax">
@@ -1332,7 +1332,7 @@ ex:Bernd
 					<span data-syntax-rule="SPARQLExprExpression-syntax-prefixes">A <a>well-formed</a> <a>SPARQL expr expression</a> can have at most one <a>value</a> for the property
 					<code>sh:prefixes</code> and this value is an <a>IRI</a> or a <a>blank node</a>.</span><br/><br/>
 					<span data-syntax-rule="SPARQLExprExpression-template">Let <code>$EXPR$</code> be the <a>value</a> of <code>sh:eval</code> and <code>$PREFIXES$</code>
-					be the SPARQL prefixes block resulting from the <a href="#sparql-prefixes">prefix handling rules</a> using the value of <code>sh:prefixes</code>,
+					be the SPARQL prefixes block resulting from the <a href="#sparql-prefixes">prefix handling rules</a> using the value of <code>sh:prefixes</code>;
 					then <code>select</code> is defined as the string where <code>$EXPR$</code> and <code>$PREFIXES$</code> are inserted as into <br/><br/><code>$PREFIXES$ SELECT ($EXPR$ AS ?result) WHERE {}</code><br/><br/></span>
 					<span data-syntax-rule="SPARQLExprExpression-query-valid"><code>select</code> is a valid SPARQL 1.2 SELECT query.</span>
 				</p>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -1323,11 +1323,14 @@ ex:Bernd
 					<code>sh:EvalExpression</code>.
 				</p>
 				<p class="syntax">
-					<span data-syntax-rule="EvalExpression-syntax-eval">A node in an RDF graph is a <a>well-formed</a> <a>eval expression</a> if it is a <a>blank node</a>
-					that is the <a>subject</a> of exactly one <a>triple</a> with <code>sh:eval</code> as <a>predicate</a> and a <a>literal</a> as <a>object</a>
-					with <a>datatype</a> <code>xsd:string</code>.</span>
+					<span data-syntax-rule="EvalExpression-syntax-eval">A node in an RDF graph
+					is a <a>well-formed</a> <a>eval expression</a>
+					if it is a <a>blank node</a>
+					that is the <a>subject</a> of exactly one <a>triple</a>
+					with <code>sh:eval</code> as <a>predicate</a>
+					and a <a>literal</a> with <a>datatype</a> <code>xsd:string</code> as <a>object</a>.</span>
 					<span data-syntax-rule="EvalExpression-syntax-prefixes">A <a>well-formed</a> <a>eval expression</a> can have at most one <a>value</a> for the property
-					<code>sh:prefixes</code> and this value is a <a>IRI</a> or a <a>blank node</a>.</span><br/><br/>
+					<code>sh:prefixes</code> and this value is an <a>IRI</a> or a <a>blank node</a>.</span><br/><br/>
 					<span data-syntax-rule="EvalExpression-template">Let <code>$EVAL$</code> be the <a>value</a> of <code>sh:eval</code> and <code>$PREFIXES$</code>
 					be the SPARQL prefixes block resulting from the <a href="#sparql-prefixes">prefix handling rules</a> using the value of <code>sh:prefixes</code>,
 					then <code>select</code> is defined as the string where <code>$EVAL$</code> and <code>$PREFIXES$</code> are inserted as into <br/><br/><code>$PREFIXES$ SELECT ($EVAL$ AS ?result) WHERE {}</code><br/><br/></span>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -1231,7 +1231,7 @@ ex:hasLang
 					<span data-syntax-rule="SelectExpression-query-valid">Using the <a href="#sparql-prefixes">prefix handling rules</a>, the value of <code>sh:select</code> is a valid SPARQL 1.2 SELECT query.</span>
 					<span data-syntax-rule="SelectExpression-query-output-nodes">The SPARQL query derived from the value of <code>sh:select</code> <a data-cite="sparql12-query/#selectproject">projects</a> exactly one variable in the SELECT clause.</span>
 				</p>
-				<div class="def" id="LiteralExpression-evaluation">
+				<div class="def" id="SelectExpression-evaluation">
 					<div class="def-header">EVALUATION OF SELECT EXPRESSIONS</div>
 					<p>
 						The <a>output nodes</a> of a <a>select expression</a> are the list <code>resultNodes</code> consisting of exactly the bindings of the (only)
@@ -1321,6 +1321,78 @@ ex:Bernd
 	a ex:Person .
 						</div>
 					</div>
+				</aside>
+			</section>
+
+			<section id="EvalExpression">
+				<h3>Eval Expressions</h3>
+				<p>
+					A <a>node expression</a> that has a <a>value</a> for <code>sh:eval</code> is called an <dfn>eval expression</dfn> with the <a>function name</a>
+					<code>sh:EvalExpression</code>.
+				</p>
+				<p class="syntax">
+					<span data-syntax-rule="EvalExpression-syntax-eval">A node in an RDF graph is a <a>well-formed</a> <a>eval expression</a> if it is a <a>blank node</a>
+					that is the <a>subject</a> of exactly one <a>triple</a> with <code>sh:eval</code> as <a>predicate</a> and a <a>literal</a> as <a>object</a>
+					with <a>datatype</a> <code>xsd:string</code>.</span>
+					<span data-syntax-rule="EvalExpression-syntax-prefixes">A <a>well-formed</a> <a>eval expression</a> can have at most one <a>value</a> for the property
+					<code>sh:prefixes</code> and this value is a <a>IRI</a> or a <a>blank node</a>.</span><br/><br/>
+					<span data-syntax-rule="EvalExpression-template">Let <code>$EVAL$</code> be the <a>value</a> of <code>sh:eval</code> and <code>$PREFIXES$</code>
+					be the SPARQL prefixes block resulting from the <a href="#sparql-prefixes">prefix handling rules</a> using the value of <code>sh:prefixes</code>,
+					then <code>select</code> is defined as the string where <code>$EVAL$</code> and <code>$PREFIXES$</code> are inserted as into <br/><br/><code>$PREFIXES$ SELECT ($EVAL$ AS ?result) WHERE {}</code><br/><br/></span>
+					<span data-syntax-rule="EvalExpression-query-valid"><code>select</code> is a valid SPARQL 1.2 SELECT query.</span>
+				</p>
+				<div class="def" id="EvalExpression-evaluation">
+					<div class="def-header">EVALUATION OF EVAL EXPRESSIONS</div>
+					<p>
+						The <a>output nodes</a> of an <a>eval expression</a> are the list <code>resultNodes</code> consisting of exactly the bindings of the (only)
+						variable that is projected from the SELECT clause of the <code>select</code> query as defined <a href="#syntax-rule-EvalExpression-template">above</a>.
+						If present in the <a>scope</a>, the value of the scope variable <code>focusNode</code> MUST be <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
+						<br/>
+						<br/>
+						<code>eval(expr, activeGraph, scope) -> resultNodes</code>
+					</p>
+				</div>
+				<p><em>The remainder of this section is informative.</em></p>
+				<aside class="example" title="A dynamically computed property using an eval expression">
+					<p>
+						Here is an example use of an <a>eval expression</a>, computing the values of a property shape for the property 
+						"uri length" as the length of the IRI of the focus node.
+					</p>
+					<div class="shapes-graph">
+						<div class="turtle">
+ex:Resource-uriLength
+	a sh:PropertyShape ;
+	sh:name "uri length" ;
+	sh:path ex:uriLength ;
+	sh:values <b>[
+		sh:eval "STRLEN(STR($this))" ;
+	]</b> ;
+	sh:datatype xsd:integer .
+						</div>
+					</div>
+					<p>
+						When applied to a focus node with URI <code>http://example.org/ns#Test</code> the result will be <code>26</code>.
+						This produces the same results as this variation:
+					</p>
+					<div class="shapes-graph">
+						<div class="turtle">
+ex:Resource-uriLength
+	a sh:PropertyShape ;
+	sh:name "uri length" ;
+	sh:path ex:uriLength ;
+	sh:values <b>[
+		sh:select """
+			SELECT (STRLEN(STR($this)) AS ?result)
+			WHERE {
+			}
+		""" ;
+	]</b> ;
+	sh:datatype xsd:integer .
+						</div>
+					</div>
+					<p>
+						Note that the query is executed with the current <a>focus node</a> <a>pre-bound</a> to the variable <code>this</code>.
+					</p>
 				</aside>
 			</section>
 		</section>
@@ -1659,6 +1731,7 @@ ASK {
 			<h2>Changes between SHACL 1.0 SPARQL and SHACL 1.2 SPARQL Extensions</h2>
 			<ul>
 				<li>Added the <a>node expression function</a> <a href="#SelectExpression"><code>sh:SelectExpression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/288">Issue 288</a></li>
+				<li>Added the <a>node expression function</a> <a href="#EvalExpression"><code>sh:EvalExpression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/315">Issue 315</a></li>
 			</ul>
 		</section>		
 		  

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -1318,29 +1318,29 @@ ex:Bernd
 				</aside>
 			</section>
 
-			<section id="EvalExpression">
-				<h3>Eval Expressions</h3>
+			<section id="SPARQLExprExpression">
+				<h3>SPARQL Expr Expressions</h3>
 				<p>
-					A <a>node expression</a> that has a <a>value</a> for <code>sh:eval</code> is called an <dfn>eval expression</dfn> with the <a>function name</a>
-					<code>sh:EvalExpression</code>.
+					A <a>node expression</a> that has a <a>value</a> for <code>sh:sparqlExpr</code> is called an <dfn>SPARQL expr expression</dfn> with the <a>function name</a>
+					<code>sh:SPARQLExprExpression</code>.
 				</p>
 				<p class="syntax">
-					<span data-syntax-rule="EvalExpression-syntax-eval">A node in an RDF graph
-					is a <a>well-formed</a> <a>eval expression</a> if it is a <a>blank node</a>
-					that has exactly one <a>value</a> for the <a>predicate</a> <code>sh:eval</code>
+					<span data-syntax-rule="SPARQLExprExpression-syntax-eval">A node in an RDF graph
+					is a <a>well-formed</a> <a>SPARQL expr expression</a> if it is a <a>blank node</a>
+					that has exactly one <a>value</a> for the <a>predicate</a> <code>sh:sparqlExpr</code>
 					and that <a>value</a> is a <a>literal</a> with <a>datatype</a> <code>xsd:string</code>.</span>
-					<span data-syntax-rule="EvalExpression-syntax-prefixes">A <a>well-formed</a> <a>eval expression</a> can have at most one <a>value</a> for the property
+					<span data-syntax-rule="SPARQLExprExpression-syntax-prefixes">A <a>well-formed</a> <a>SPARQL expr expression</a> can have at most one <a>value</a> for the property
 					<code>sh:prefixes</code> and this value is an <a>IRI</a> or a <a>blank node</a>.</span><br/><br/>
-					<span data-syntax-rule="EvalExpression-template">Let <code>$EVAL$</code> be the <a>value</a> of <code>sh:eval</code> and <code>$PREFIXES$</code>
+					<span data-syntax-rule="SPARQLExprExpression-template">Let <code>$EXPR$</code> be the <a>value</a> of <code>sh:eval</code> and <code>$PREFIXES$</code>
 					be the SPARQL prefixes block resulting from the <a href="#sparql-prefixes">prefix handling rules</a> using the value of <code>sh:prefixes</code>,
-					then <code>select</code> is defined as the string where <code>$EVAL$</code> and <code>$PREFIXES$</code> are inserted as into <br/><br/><code>$PREFIXES$ SELECT ($EVAL$ AS ?result) WHERE {}</code><br/><br/></span>
-					<span data-syntax-rule="EvalExpression-query-valid"><code>select</code> is a valid SPARQL 1.2 SELECT query.</span>
+					then <code>select</code> is defined as the string where <code>$EXPR$</code> and <code>$PREFIXES$</code> are inserted as into <br/><br/><code>$PREFIXES$ SELECT ($EXPR$ AS ?result) WHERE {}</code><br/><br/></span>
+					<span data-syntax-rule="SPARQLExprExpression-query-valid"><code>select</code> is a valid SPARQL 1.2 SELECT query.</span>
 				</p>
-				<div class="def" id="EvalExpression-evaluation">
-					<div class="def-header">EVALUATION OF EVAL EXPRESSIONS</div>
+				<div class="def" id="SPARQLExprExpression-evaluation">
+					<div class="def-header">EVALUATION OF SPARQL EXPR EXPRESSIONS</div>
 					<p>
-						The <a>output nodes</a> of an <a>eval expression</a> are the list <code>resultNodes</code> consisting of exactly the bindings of the (only)
-						variable that is projected from the SELECT clause of the <code>select</code> query as defined <a href="#syntax-rule-EvalExpression-template">above</a>.
+						The <a>output nodes</a> of an <a>SPARQL expr expression</a> are the list <code>resultNodes</code> consisting of exactly the bindings of the (only)
+						variable that is projected from the SELECT clause of the <code>select</code> query as defined <a href="#syntax-rule-SPARQLExprExpression-template">above</a>.
 						If present in the <a>scope</a>, the value of the scope variable <code>focusNode</code> MUST be <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
 						<br/>
 						<br/>
@@ -1348,9 +1348,9 @@ ex:Bernd
 					</p>
 				</div>
 				<p><em>The remainder of this section is informative.</em></p>
-				<aside class="example" title="A dynamically computed property using an eval expression">
+				<aside class="example" title="A dynamically computed property using a SPARQL expr expression">
 					<p>
-						Here is an example use of an <a>eval expression</a>, computing the values of a property shape for the property 
+						Here is an example use of an <a>SPARQL expr expression</a>, computing the values of a property shape for the property 
 						"uri length" as the length of the IRI of the focus node.
 					</p>
 					<div class="shapes-graph">
@@ -1360,7 +1360,7 @@ ex:Resource-uriLength
 	sh:name "uri length" ;
 	sh:path ex:uriLength ;
 	sh:values <b>[
-		sh:eval "STRLEN(STR($this))" ;
+		sh:sparqlExpr "STRLEN(STR($this))" ;
 	]</b> ;
 	sh:datatype xsd:integer .
 						</div>
@@ -1726,7 +1726,7 @@ ASK {
 			<h2>Changes between SHACL 1.0 SPARQL and SHACL 1.2 SPARQL Extensions</h2>
 			<ul>
 				<li>Added the <a>node expression function</a> <a href="#SelectExpression"><code>sh:SelectExpression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/288">Issue 288</a></li>
-				<li>Added the <a>node expression function</a> <a href="#EvalExpression"><code>sh:EvalExpression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/315">Issue 315</a></li>
+				<li>Added the <a>node expression function</a> <a href="#SPARQLExprExpression"><code>sh:SPARQLExprExpression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/315">Issue 315</a></li>
 			</ul>
 		</section>		
 		  

--- a/shacl12-test-suite/tests/sparql/property/manifest.ttl
+++ b/shacl12-test-suite/tests/sparql/property/manifest.ttl
@@ -4,7 +4,7 @@
 
 <>
 	a mf:Manifest ;
-	rdfs:label "Tests converted from http://datashapes.org/sh/tests/tests/sparql/property" ;
+	mf:include <property-eval-001.ttl> ;
 	mf:include <property-select-001.ttl> ;
 	mf:include <sparql-001.ttl> ;
 	.

--- a/shacl12-test-suite/tests/sparql/property/manifest.ttl
+++ b/shacl12-test-suite/tests/sparql/property/manifest.ttl
@@ -4,7 +4,7 @@
 
 <>
 	a mf:Manifest ;
-	mf:include <property-eval-001.ttl> ;
+	mf:include <property-sparqlExpr-001.ttl> ;
 	mf:include <property-select-001.ttl> ;
 	mf:include <sparql-001.ttl> ;
 	.

--- a/shacl12-test-suite/tests/sparql/property/property-eval-001.ttl
+++ b/shacl12-test-suite/tests/sparql/property/property-eval-001.ttl
@@ -9,10 +9,11 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:Resource-uriLength
-	a sh:PropertyShape ;
-  sh:targetNode ex:Invalid ;  # The URI of this has 29 chars
-  sh:targetNode ex:Valid ;    # The URI of this has 27 chars
-	sh:name "URI length" ;
+        a sh:PropertyShape ;
+        sh:targetNode ex:Invalid ;  # The URI of this has 29 chars
+        sh:targetNode ex:Valid ;    # The URI of this has 27 chars
+        sh:name "URI length" ;
+
 	sh:path ex:uriLength ;
 	sh:values [
     sh:eval "STRLEN(STR($this))" ;

--- a/shacl12-test-suite/tests/sparql/property/property-eval-001.ttl
+++ b/shacl12-test-suite/tests/sparql/property/property-eval-001.ttl
@@ -1,0 +1,57 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://example.org/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Resource-uriLength
+	a sh:PropertyShape ;
+  sh:targetNode ex:Invalid ;  # The URI of this has 29 chars
+  sh:targetNode ex:Valid ;    # The URI of this has 27 chars
+	sh:name "URI length" ;
+	sh:path ex:uriLength ;
+	sh:values [
+    sh:eval "STRLEN(STR($this))" ;
+		sh:prefixes <http://example.org/ns> ;
+	] ;
+	sh:datatype xsd:integer ;
+  sh:hasValue 27 .
+
+<http://example.org/ns>
+	a owl:Ontology ;
+	sh:declare [
+		sh:prefix "ex" ;
+		sh:namespace "http://example.org/ns#"^^xsd:anyURI ;
+	] .
+
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <property-eval-001>
+    ) ;
+.
+<property-eval-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of a sh:property with a sh:eval expression 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Invalid ;
+          sh:resultPath ex:uriLength ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:HasValueConstraintComponent ;
+          sh:sourceShape ex:Resource-uriLength ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl12-test-suite/tests/sparql/property/property-sparqlExpr-001.ttl
+++ b/shacl12-test-suite/tests/sparql/property/property-sparqlExpr-001.ttl
@@ -16,11 +16,11 @@ ex:Resource-uriLength
 
 	sh:path ex:uriLength ;
 	sh:values [
-    sh:eval "STRLEN(STR($this))" ;
+		sh:sparqlExpr "STRLEN(STR($this))" ;
 		sh:prefixes <http://example.org/ns> ;
 	] ;
 	sh:datatype xsd:integer ;
-  sh:hasValue 27 .
+	sh:hasValue 27 .
 
 <http://example.org/ns>
 	a owl:Ontology ;
@@ -32,12 +32,12 @@ ex:Resource-uriLength
 <>
   rdf:type mf:Manifest ;
   mf:entries (
-      <property-eval-001>
+      <property-sparqlExpr-001>
     ) ;
 .
-<property-eval-001>
+<property-sparqlExpr-001>
   rdf:type sht:Validate ;
-  rdfs:label "Test of a sh:property with a sh:eval expression 001" ;
+  rdfs:label "Test of a sh:property with a sh:sparqlExpr expression 001" ;
   mf:action [
       sht:dataGraph <> ;
       sht:shapesGraph <> ;

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -15,7 +15,7 @@
 # - Added support for sh:singleLine (see https://github.com/w3c/data-shapes/issues/177)
 # - Deleted any terms related to SHACL-JS (see https://github.com/w3c/data-shapes/issues/264)
 # - Added sh:NodeExpression and related infrastructure
-# - Added sh:SelectExpression and its parameters
+# - Added sh:SelectExpression, sh:EvalExpression and their parameters
 
 @prefix owl:  <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -1356,6 +1356,7 @@ sh:SelectExpression-select
 	sh:name "select"@en ;
 	sh:description "The SELECT query that is executed during evaluation of this node expression. The output nodes are the bindings of the first result variable."@en ;
 	sh:keyParameter true ;
+	sh:datatype xsd:string ;
 	rdfs:isDefinedBy sh: .
 
 sh:SelectExpression-prefixes
@@ -1363,6 +1364,34 @@ sh:SelectExpression-prefixes
 	sh:path sh:prefixes ;
 	sh:name "prefixes"@en ;
 	sh:description "The prefixes that shall be applied before parsing the associated SPARQL query. The object should define those prefixes using sh:declare."@en ;
+	sh:nodeKind sh:BlankNodeOrIRI ;
+	rdfs:isDefinedBy sh: .
+
+sh:EvalExpression
+	a rdfs:Class ;
+	rdfs:label "Eval expression"@en ;
+	rdfs:comment "The class of node expressions based on SPARQL expressions (sh:eval)."@en ;
+	rdfs:subClassOf sh:NodeExpression ;
+	rdfs:subClassOf sh:SPARQLExecutable ;
+	sh:parameter sh:EvalExpression-eval ;
+	sh:parameter sh:EvalExpression-prefixes ;
+	rdfs:isDefinedBy sh: .
+
+sh:EvalExpression-eval
+	a sh:Parameter ;
+	sh:path sh:eval ;
+	sh:name "eval"@en ;
+	sh:description "The SPARQL expression that is executed during evaluation of this node expression."@en ;
+	sh:keyParameter true ;
+	sh:datatype xsd:string ;
+	rdfs:isDefinedBy sh: .
+
+sh:EvalExpression-prefixes
+	a sh:Parameter ;
+	sh:path sh:prefixes ;
+	sh:name "prefixes"@en ;
+	sh:description "The prefixes that shall be applied before parsing the SPARQL query that gets derived from the sh:eval expression. The object should define those prefixes using sh:declare."@en ;
+	sh:nodeKind sh:BlankNodeOrIRI ;
 	rdfs:isDefinedBy sh: .
 
 

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -15,7 +15,7 @@
 # - Added support for sh:singleLine (see https://github.com/w3c/data-shapes/issues/177)
 # - Deleted any terms related to SHACL-JS (see https://github.com/w3c/data-shapes/issues/264)
 # - Added sh:NodeExpression and related infrastructure
-# - Added sh:SelectExpression, sh:EvalExpression and their parameters
+# - Added sh:SelectExpression, sh:SPARQLExprExpression and their parameters
 
 @prefix owl:  <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -1382,30 +1382,30 @@ sh:SelectExpression-prefixes
 	sh:nodeKind sh:BlankNodeOrIRI ;
 	rdfs:isDefinedBy sh: .
 
-sh:EvalExpression
+sh:SPARQLExprExpression
 	a rdfs:Class ;
-	rdfs:label "Eval expression"@en ;
-	rdfs:comment "The class of node expressions based on SPARQL expressions (sh:eval)."@en ;
+	rdfs:label "SPARQL expr expression"@en ;
+	rdfs:comment "The class of node expressions based on SPARQL expressions (sh:sparqlExpr)."@en ;
 	rdfs:subClassOf sh:NamedParameterExpression ;
 	rdfs:subClassOf sh:SPARQLExecutable ;
-	sh:parameter sh:EvalExpression-eval ;
-	sh:parameter sh:EvalExpression-prefixes ;
+	sh:parameter sh:SPARQLExprExpression-sparqlExpr ;
+	sh:parameter sh:SPARQLExprExpression-prefixes ;
 	rdfs:isDefinedBy sh: .
 
-sh:EvalExpression-eval
+sh:SPARQLExprExpression-sparqlExpr
 	a sh:Parameter ;
-	sh:path sh:eval ;
-	sh:name "eval"@en ;
+	sh:path sh:sparqlExpr ;
+	sh:name "SPARQL expr"@en ;
 	sh:description "The SPARQL expression that is executed during evaluation of this node expression."@en ;
 	sh:keyParameter true ;
 	sh:datatype xsd:string ;
 	rdfs:isDefinedBy sh: .
 
-sh:EvalExpression-prefixes
+sh:SPARQLExprExpression-prefixes
 	a sh:Parameter ;
 	sh:path sh:prefixes ;
 	sh:name "prefixes"@en ;
-	sh:description "The prefixes that shall be applied before parsing the SPARQL query that gets derived from the sh:eval expression. The object should define those prefixes using sh:declare."@en ;
+	sh:description "The prefixes that shall be applied before parsing the SPARQL query that gets derived from the sh:sparqlExpr expression. The object should define those prefixes using sh:declare."@en ;
 	sh:nodeKind sh:BlankNodeOrIRI ;
 	rdfs:isDefinedBy sh: .
 

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1189,15 +1189,30 @@ sh:xone
 sh:NodeExpression
 	a rdfs:Class ;
 	rdfs:label "Node expression"@en ;
-	rdfs:comment "The base class for the available node expression functions."@en ;
+	rdfs:comment "The base class of node expression functions."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:NamedParameterExpression
+	a rdfs:Class ;
+	rdfs:label "Named parameter expression"@en ;
+	rdfs:comment "The base class of node expression functions that take named parameters."@en ;
+	rdfs:subClassOf sh:NodeExpression ;
 	rdfs:subClassOf sh:Parameterizable ;
 	rdfs:isDefinedBy sh: .
 
 sh:keyParameter
     a rdf:Property ;
 	rdfs:label "key parameter"@en ;
-	rdfs:comment "Set to true for the parameter of a node expression function that uniquely identifies it."@en ;
+	rdfs:comment "Set to true for the parameter of a named parameter expression function that uniquely identifies it."@en ;
 	rdfs:range xsd:boolean ;
+	rdfs:isDefinedBy sh: .
+
+sh:ListParameterExpression
+	a rdfs:Class ;
+	rdfs:label "List parameter expression"@en ;
+	rdfs:comment "The base class of node expression functions that take a list of parameters."@en ;
+	rdfs:subClassOf sh:NodeExpression ;
 	rdfs:isDefinedBy sh: .
 
 
@@ -1344,7 +1359,7 @@ sh:SelectExpression
 	a rdfs:Class ;
 	rdfs:label "Select expression"@en ;
 	rdfs:comment "The class of node expressions based on SPARQL SELECT queries."@en ;
-	rdfs:subClassOf sh:NodeExpression ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
 	rdfs:subClassOf sh:SPARQLSelectExecutable ;
 	sh:parameter sh:SelectExpression-select ;
 	sh:parameter sh:SelectExpression-prefixes ;
@@ -1371,7 +1386,7 @@ sh:EvalExpression
 	a rdfs:Class ;
 	rdfs:label "Eval expression"@en ;
 	rdfs:comment "The class of node expressions based on SPARQL expressions (sh:eval)."@en ;
-	rdfs:subClassOf sh:NodeExpression ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
 	rdfs:subClassOf sh:SPARQLExecutable ;
 	sh:parameter sh:EvalExpression-eval ;
 	sh:parameter sh:EvalExpression-prefixes ;


### PR DESCRIPTION
This diff looks larger than it is, mainly because I moved the Property Path sections up one level.

I have simplified the definition of Node Expressions to simply define IRI and Literal expressions and then leave all other details to other documents - this is for blank nodes.

I have changed the TTL system ontology to roughly match what we had discussed, with the separation of Named and List Parameters, so that I could use sh:NamedParameterExpression in the definitions of sh:SelectExpression and sh:EvalExpression. But these details may change later as the Node Expr work starts in earnest.

The way that it's currently defined, SHACL-SPARQL does not really depend on the NodeExpr document, but Andy has suggested changes to the exprEval function that may go in there too.

Warning: This Diff also includes the not-yet-approved branch that introduced sh:eval.