### PR TITLE
#128: Added links to prefix declaration

### DIFF
--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -593,6 +593,9 @@ ex:LanguageExampleShape
 			}
 			""" ;
 	] .
+
+ex:
+	sh:declare ...   # See <a href="#prefixes-example">prefix declarations</a>	
 						</div>
 					</div>
 					<p>
@@ -656,6 +659,9 @@ ex:LanguageExamplePropertyShape
 			}
 			""" ;
 	] .
+
+ex:
+	sh:declare ...   # See <a href="#prefixes-example">prefix declarations</a>	
 						</div>
 					</div>
 				</aside>
@@ -697,12 +703,10 @@ ex:LanguageExamplePropertyShape
 						A <a>shapes graph</a> may include declarations of namespace prefixes so that these prefixes can be used to abbreviate the SPARQL queries derived from the same shapes graph.
 						The syntax of such prefix declarations is illustrated by the following example.
 					</p>
-					<aside class="example">
+					<aside class="example" id="prefixes-example">
 						<div class="shapes-graph">
 							<div class="turtle">
 ex:
-	a owl:Ontology ;
-	owl:imports sh: ;
 	sh:declare [
 		sh:prefix "ex" ;
 		sh:namespace "http://example.com/ns#"^^xsd:anyURI ;
@@ -710,7 +714,9 @@ ex:
 	sh:declare [
 		sh:prefix "schema" ;
 		sh:namespace "http://schema.org/"^^xsd:anyURI ;
-	] .
+	] ;
+	a owl:Ontology ;    # Optional
+	owl:imports sh: .   # Optional
 							</div>
 						</div>
 					</aside>


### PR DESCRIPTION
This hopefully clarifies how ex: is used to declare prefixes indirectly, not as "ex:" itself.