### PR TITLE
#357: Added sh:expression

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -6023,7 +6023,7 @@ ex:RainbowPony ex:color ex:Pink .
 					</table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
-						<div class="def-text-body" data-validator="Filter">
+						<div class="def-text-body" data-validator="Expression">
 							Let <code>expr</code> be the <a>value</a> of <code>sh:expression</code>.
 							For each <a>value node</a> <code>v</code> 
 							and <code>scope</code> contains <code>v</code> as the value of <code>focusNode</code>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -578,12 +578,13 @@
 				<div class="def">
 					<div class="term-def-header">Deep Copy</div>
 					<div>
-						For a <a>node</a> <code>n</code> in a <a>graph</a> <code>sourceGraph</code>
+						For a <a>node</a> <code>n</code> in a <a>graph</a> <code>sourceGraph</code>,
 						the <dfn data-lt="deep copy">deep copy</dfn> of <code>n</code> in a <a>graph</a> <code>targetGraph</code>
-						is <code>n</code> in <code>targetGraph</code> plus (if <code>n</code> is a <a>blank node</a>)
-						any <a>triples</a> from <code>sourceGraph</code> that can be reached by transitively traversing the <a>blank nodes</a>
-						that appear in the <a>object</a> position of triple that can be reached starting with <code>n</code> as the <a>subject</a>.
-						This is similar to the <a href="https://www.w3.org/submissions/CBD/">Concise Bounded Description</a>, but without reification.
+						is <code>n</code> in <code>targetGraph</code> plus, if <code>n</code> is a <a>blank node</a>,
+						any <a>triples</a> from <code>sourceGraph</code> that can be reached by transitively traversing 
+						the <a>blank nodes</a> that appear in the <a>object</a> position of a triple that can be reached
+						starting with <code>n</code> as the <a>subject</a>. This is similar to
+						the <a href="https://www.w3.org/submissions/CBD/">Concise Bounded Description</a>, but without reification.
 					</div>
 				</div>
 
@@ -5999,7 +6000,7 @@ ex:RainbowPony ex:color ex:Pink .
 						<dfn data-lt="expression constraint">expression constraints</dfn>.
 						Expression constraints can be used in any <a>shape</a> to declare the condition that the
 						<a>node expression</a> specified via <code>sh:expression</code> has <code>true</code> as one of its output nodes.
-						In the evaluation of these node expressions is repeated for all <a>value nodes</a> of the <a>shape</a>
+						The evaluation of these node expressions is repeated for all <a>value nodes</a> of the <a>shape</a>
 						as the <a>focus node</a>.
 					</p>
 					<p>
@@ -6028,10 +6029,10 @@ ex:RainbowPony ex:color ex:Pink .
 							For each <a>value node</a> <code>v</code> 
 							and <code>scope</code> contains <code>v</code> as the value of <code>focusNode</code>
 							where <code>evalExpr(expr, activeGraph, scope)</code>
-							does not return <code>true</code> as one of its <a>output nodes</a>
+							does not return <code>true</code> as one of its <a>output nodes</a>,
 							there is a <a>validation result</a> that has <code>v</code> as its <code>sh:value</code>
 							and a <a>deep copy</a> of <code>expr</code> in the results graph as its <code>sh:sourceConstraint</code>.
-							If the <code>expr</code> has <a>values</a> for <code>sh:message</code> in the <a>shapes graph</a>
+							If the <code>expr</code> has <a>values</a> for <code>sh:message</code> in the <a>shapes graph</a>,
 							then these <a>values</a> become the (only) values for <code>sh:resultMessage</code> in the
 							<a>validation result</a>.
 						</div>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -583,7 +583,7 @@
 						is <code>n</code> in <code>targetGraph</code> plus (if <code>n</code> is a <a>blank node</a>)
 						any <a>triples</a> from <code>sourceGraph</code> that can be reached by transitively traversing the <a>blank nodes</a>
 						that appear in the <a>object</a> position of triple that can be reached starting with <code>n</code> as the <a>subject</a>.
-						See the <a href="https://www.w3.org/submissions/CBD/">Concise Bounded Description</a>.
+						This is similar to the <a href="https://www.w3.org/submissions/CBD/">Concise Bounded Description</a>, but without reification.
 					</div>
 				</div>
 
@@ -2835,7 +2835,7 @@ ex:SomeClass-alternativePathExample
 							Validation results may have a value for the property <code>sh:resultPath</code> pointing at a <a>well-formed</a> <a>SHACL property path</a>.
 							For results produced by a <a>property shape</a>, this <a>SHACL property path</a> is equivalent to the <a>value</a> of <code>sh:path</code> of the shape,
 							unless stated otherwise. <!-- sh:closed is an exception -->
-							If the <code>sh:path</code> <code>p</code> is a <a>blank node</a>, then the <code>sh:resultPath</code> is a <a>deep copy</a> of <code>p</code>.
+							If the <code>sh:path</code> <code>p</code> is a <a>blank node</a>, then the <code>sh:resultPath</code> is a <a>deep copy</a> of <code>p</code> in the results graph.
 						</p>
 					</section>
 					<section id="results-value">
@@ -6030,7 +6030,7 @@ ex:RainbowPony ex:color ex:Pink .
 							where <code>evalExpr(expr, activeGraph, scope)</code>
 							does not return <code>true</code> as one of its <a>output nodes</a>
 							there is a <a>validation result</a> that has <code>v</code> as its <code>sh:value</code>
-							and a <a>deep copy</a> of <code>expr</code> as its <code>sh:sourceConstraint</code>.
+							and a <a>deep copy</a> of <code>expr</code> in the results graph as its <code>sh:sourceConstraint</code>.
 							If the <code>expr</code> has <a>values</a> for <code>sh:message</code> in the <a>shapes graph</a>
 							then these <a>values</a> become the (only) values for <code>sh:resultMessage</code> in the
 							<a>validation result</a>.

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -575,6 +575,17 @@
 						if one of the <a>SHACL types</a> of <code>n</code> in <code>G</code> is <code>C</code>.
 					</div>
 				</div>
+				<div class="def">
+					<div class="term-def-header">Deep Copy</div>
+					<div>
+						For a <a>node</a> <code>n</code> in a <a>graph</a> <code>sourceGraph</code>
+						the <dfn data-lt="deep copy">deep copy</dfn> of <code>n</code> in a <a>graph</a> <code>targetGraph</code>
+						is <code>n</code> in <code>targetGraph</code> plus (if <code>n</code> is a <a>blank node</a>)
+						any <a>triples</a> from <code>sourceGraph</code> that can be reached by transitively traversing the <a>blank nodes</a>
+						that appear in the <a>object</a> position of triple that can be reached starting with <code>n</code> as the <a>subject</a>.
+						See the <a href="https://www.w3.org/submissions/CBD/">Concise Bounded Description</a>.
+					</div>
+				</div>
 
 			</section>
 
@@ -2378,6 +2389,7 @@ ex:SomeClass-alternativePathExample
 			<ul>
 				<li>At <a href="#property-shapes"><code>sh:values</code> and <code>sh:defaultValue</code></a> to derive the value nodes of a property shape.</li>
 				<li>At <a href="#targetNode"><code>sh:targetNode</code></a> to dynamically compute the targets of a shape.</li>
+				<li>At <a href="#ExpressionConstraintComponent"><code>sh:expression</code></a> to validate nodes against a condition.</li>
 				<li>As parameter values of most <a href="#core-components">constraint components</a> to represent constraints that may be different depending on each focus node. <span class="todo">TODO: This change needs to be made still, see ISSUE 311.</span></li>
 				<li>At <a href="#deactivated"><code>sh:deactivated</code></a> to deactivate certain shapes under specific conditions. <span class="todo">TODO: This change needs to be made still, see ISSUE 338.</span></li>
 			</ul>
@@ -2823,10 +2835,7 @@ ex:SomeClass-alternativePathExample
 							Validation results may have a value for the property <code>sh:resultPath</code> pointing at a <a>well-formed</a> <a>SHACL property path</a>.
 							For results produced by a <a>property shape</a>, this <a>SHACL property path</a> is equivalent to the <a>value</a> of <code>sh:path</code> of the shape,
 							unless stated otherwise. <!-- sh:closed is an exception -->
-							If the <code>sh:path</code> <code>p</code> is a <a>blank node</a>, then the <code>sh:resultPath</code> is a "deep copy"
-							of <code>p</code> and any <a>triples</a> that can be reached by transitively traversing the <a>blank nodes</a>
-							that appear in the <a>object</a> position of these triples.
-							See the <a href="https://www.w3.org/submissions/CBD/">Concise Bounded Description</a>.
+							If the <code>sh:path</code> <code>p</code> is a <a>blank node</a>, then the <code>sh:resultPath</code> is a <a>deep copy</a> of <code>p</code>.
 						</p>
 					</section>
 					<section id="results-value">
@@ -5982,6 +5991,52 @@ ex:RainbowPony ex:color ex:Pink .
 						</div>
 					</aside>
 				</section>
+		
+				<section id="ExpressionConstraintComponent">
+					<h4>sh:expression</h4>
+					<p>
+						Based on <a>node expressions</a>, this section introduces a <a>constraint component</a> called
+						<dfn data-lt="expression constraint">expression constraints</dfn>.
+						Expression constraints can be used in any <a>shape</a> to declare the condition that the
+						<a>node expression</a> specified via <code>sh:expression</code> has <code>true</code> as one of its output nodes.
+						In the evaluation of these node expressions is repeated for all <a>value nodes</a> of the <a>shape</a>
+						as the <a>focus node</a>.
+					</p>
+					<p>
+						<span class="component-class">Constraint Component IRI</span>: <code>sh:ExpressionConstraintComponent</code>
+					</p>
+		
+					<div class="parameters">Parameters:</div>
+					<table class="term-table">
+						<tr>
+							<th>Property</th>
+							<th>Summary and Syntax Rules</th>
+						</tr>
+						<tr>
+							<td><code>sh:expression</code></td>
+							<td>
+								The <a>node expression</a> that must return <code>true</code>.
+								<span data-syntax-rule="expression-scope">The <a>values</a> of <code>sh:expression</code> at a
+								<a>shape</a> must be well-formed <a>node expressions</a>.</span>
+							</td>
+						</tr>
+					</table>
+					<div class="def def-text">
+						<div class="def-header">TEXTUAL DEFINITION</div>
+						<div class="def-text-body" data-validator="Filter">
+							Let <code>expr</code> be the <a>value</a> of <code>sh:expression</code>.
+							For each <a>value node</a> <code>v</code> 
+							and <code>scope</code> contains <code>v</code> as the value of <code>focusNode</code>
+							where <code>evalExpr(expr, activeGraph, scope)</code>
+							does not return <code>true</code> as one of its <a>output nodes</a>
+							there is a <a>validation result</a> that has <code>v</code> as its <code>sh:value</code>
+							and a <a>deep copy</a> of <code>expr</code> as its <code>sh:sourceConstraint</code>.
+							If the <code>expr</code> has <a>values</a> for <code>sh:message</code> in the <a>shapes graph</a>
+							then these <a>values</a> become the (only) values for <code>sh:resultMessage</code> in the
+							<a>validation result</a>.
+						</div>
+					</div>
+				</section>
 			</section>
 		</section>
 				
@@ -6479,6 +6534,7 @@ ex:NameGroup
 				<li>Added the new constraint component <a href="#SingleLineConstraintComponent"><code>sh:singleLine</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/177">Issue 177</a></li>
 				<li>Added the new class <a href="#ShapeClass"><code>sh:ShapeClass</code></a> for implicit class targets, see <a href="https://github.com/w3c/data-shapes/issues/212">Issue 212</a></li>
 				<li>Moved SPARQL-based validators from Core to an Appendix of SHACL-SPARQL, see <a href="https://github.com/w3c/data-shapes/issues/271">Issue 271</a></li>
+				<li>Added the new constraint component <a href="#ExpressionConstraintComponent"><code>sh:expression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/357">Issue 357</a></li>
 			</ul>
 		</section>
 	</body>

--- a/shacl12-test-suite/tests/core/node/expression-001.ttl
+++ b/shacl12-test-suite/tests/core/node/expression-001.ttl
@@ -1,0 +1,48 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/expression-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance
+  rdf:type ex:TestShape ;
+  rdfs:label "Invalid instance" ;
+.
+ex:TestShape
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:expression false ;     # Only using constant false here because Core doesn't define interesting node expressions
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <expression-001>
+    ) ;
+.
+<expression-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:expression at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint false ;
+          sh:sourceConstraintComponent sh:ExpressionConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidInstance ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl12-test-suite/tests/core/node/manifest.ttl
+++ b/shacl12-test-suite/tests/core/node/manifest.ttl
@@ -16,6 +16,7 @@
 	mf:include <datatype-002.ttl> ;
 	mf:include <disjoint-001.ttl> ;
 	mf:include <equals-001.ttl> ;
+	mf:include <expression-001.ttl> ;
 	mf:include <hasValue-001.ttl> ;
 	mf:include <in-001.ttl> ;
 	mf:include <languageIn-001.ttl> ;


### PR DESCRIPTION
I had to make the definition of Deep Copy stand-alone so that I could reuse it in multiple places. I didn't add an example as Core doesn't define interesting enough node expression types. The test case shows the syntax.