### PR TITLE
#311: Don't support Node Expressions as constraint parameters in Core

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2949,7 +2949,7 @@ ex:SomeClass-alternativePathExample
 				i.e. the <a>object</a> of the <a>triple</a> in the <a>shapes graph</a> where the <a>subject</a> is the <a>shape</a>
 				and the <a>predicate</a> is the <a>parameter</a> (such as <code>sh:class</code>).
 			</p>
-			<p>
+			<p class="issue">
 				At the time of writing, the intent of the WG is to define a dialect of SHACL outside of SHACL Core in which the term
 				<a>parameter value</a> also allows <a>node expressions</a>.
 				Note that not all constraint components use the term <a>parameter value</a> but instead refer to the term <a>value</a>.

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2391,7 +2391,6 @@ ex:SomeClass-alternativePathExample
 				<li>At <a href="#property-shapes"><code>sh:values</code> and <code>sh:defaultValue</code></a> to derive the value nodes of a property shape.</li>
 				<li>At <a href="#targetNode"><code>sh:targetNode</code></a> to dynamically compute the targets of a shape.</li>
 				<li>At <a href="#ExpressionConstraintComponent"><code>sh:expression</code></a> to validate nodes against a condition.</li>
-				<li>As parameter values of most <a href="#core-components">constraint components</a> to represent constraints that may be different depending on each focus node. <span class="todo">TODO: This change needs to be made still, see ISSUE 311.</span></li>
 				<li>At <a href="#deactivated"><code>sh:deactivated</code></a> to deactivate certain shapes under specific conditions. <span class="todo">TODO: This change needs to be made still, see ISSUE 338.</span></li>
 			</ul>
 			<p>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2945,6 +2945,19 @@ ex:SomeClass-alternativePathExample
 				<code>$paramName</code> where <code>paramName</code> is the part of the parameter's <a>IRI</a> after the <code>sh:</code> namespace.
 				For example, the textual definition of <code>sh:ClassConstraintComponent</code> refers to the value of
 				<code>sh:class</code> using the variable <code>$class</code>.
+				In SHACL Core, the term <dfn data-lt="parameter value|parameter values">parameter value</dfn> means the <a>value</a> of a parameter,
+				i.e. the <a>object</a> of the <a>triple</a> in the <a>shapes graph</a> where the <a>subject</a> is the <a>shape</a>
+				and the <a>predicate</a> is the <a>parameter</a> (such as <code>sh:class</code>).
+			</p>
+			<p>
+				At the time of writing, the intent of the WG is to define a dialect of SHACL outside of SHACL Core in which the term
+				<a>parameter value</a> also allows <a>node expressions</a>.
+				Note that not all constraint components use the term <a>parameter value</a> but instead refer to the term <a>value</a>.
+				For example, the values of <code>sh:node</code> cannot ever be <a>node expressions</a>, because this would complicate
+				the handling of blank nodes.
+				<span class="todo">TODO: Add link to Node Expression spec in case it's ready, or clarify the sentences above otherwise.</span>
+			</p>
+			<p>
 				Note that these validators define the <em>only</em> validation results that are being produced by the component.
 				Furthermore, the validators always produce <em>new</em> result nodes, i.e. when the textual definition states that
 				&quot;...there is a validation result...&quot; then this refers to a distinct new node in a results graph.
@@ -2997,6 +3010,7 @@ ex:SomeClass-alternativePathExample
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Class">
+							Let <code>$class</code> be a <a>parameter value</a> for <code>sh:class</code>.
 							For each <a>value node</a>
 							that is either a <a>literal</a>, or a non-literal that is not a <a>SHACL instance</a> of <code>$class</code> in the <a>data graph</a>,
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
@@ -3108,6 +3122,7 @@ ex:Bob ex:address [ a ex:PostalAddress ; ex:city ex:Berlin ] .
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Datatype">
+							Let <code>$datatype</code> be a <a>parameter value</a> for <code>sh:datatype</code>.
 							For each <a>value node</a>
 							that is not a <a>literal</a>, or is a <a>literal</a> with a datatype that does not match <code>$datatype</code>,
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
@@ -3221,6 +3236,7 @@ ex:Alice ex:age "23"^^xsd:integer .
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="NodeKind">
+							Let <code>$nodeKind</code> be a <a>parameter value</a> for <code>sh:nodeKind</code>.
 							For each <a>value node</a>
 							that does not match <code>$nodeKind</code>,
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
@@ -3314,6 +3330,7 @@ ex:Bob ex:knows ex:Alice .
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MinCount">
+							Let <code>$minCount</code> be a <a>parameter value</a> for <code>sh:minCount</code>.
 							If the number of <a>value nodes</a> is less than <code>$minCount</code>,
 							there is a <a>validation result</a>.
 						</div>
@@ -3404,6 +3421,7 @@ ex:MinCountExampleShape
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MaxCount">
+							Let <code>$maxCount</code> be a <a>parameter value</a> for <code>sh:maxCount</code>.
 							If the number of <a>value nodes</a> is greater than <code>$maxCount</code>,
 							there is a <a>validation result</a>.
 						</div>
@@ -3561,6 +3579,7 @@ ex:Bob ex:age 23 .
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MinExclusive">
+							Let <code>$minExclusive</code> be a <a>parameter value</a> for <code>sh:minExclusive</code>.
 							For each <a>value node</a> <code>v</code>
 							where the SPARQL expression <code>$minExclusive &lt; v</code> does not return <code>true</code>,
 							there is a <a>validation result</a> with <code>v</code> as <code>sh:value</code>. 
@@ -3596,6 +3615,7 @@ ex:Bob ex:age 23 .
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MinInclusive">
+							Let <code>$minInclusive</code> be a <a>parameter value</a> for <code>sh:minInclusive</code>.
 							For each <a>value node</a> <code>v</code>
 							where the SPARQL expression <code>$minInclusive &lt;= v</code> does not return <code>true</code>,
 							there is a <a>validation result</a> with <code>v</code> as <code>sh:value</code>. 
@@ -3626,6 +3646,7 @@ ex:Bob ex:age 23 .
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MaxExclusive">
+							Let <code>$maxExclusive</code> be a <a>parameter value</a> for <code>sh:maxExclusive</code>.
 							For each <a>value node</a> <code>v</code>
 							where the SPARQL expression <code>$maxExclusive &gt; v</code> does not return <code>true</code>,
 							there is a <a>validation result</a> with <code>v</code> as <code>sh:value</code>. 
@@ -3656,6 +3677,7 @@ ex:Bob ex:age 23 .
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MaxInclusive">
+							Let <code>$maxInclusive</code> be a <a>parameter value</a> for <code>sh:maxInclusive</code>.
 							For each <a>value node</a> <code>v</code>
 							where the SPARQL expression <code>$maxInclusive &gt;= v</code> does not return <code>true</code>,
 							there is a <a>validation result</a> with <code>v</code> as <code>sh:value</code>. 
@@ -3698,6 +3720,7 @@ ex:Bob ex:age 23 .
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MinLength">
+							Let <code>$minLength</code> be a <a>parameter value</a> for <code>sh:minLength</code>.
 							For each <a>value node</a> <code>v</code>
 							where the length (as defined by the <a data-cite="sparql12-query/#func-strlen">SPARQL STRLEN function</a>)
 							of the string representation of <code>v</code> (as defined by the <a data-cite="sparql12-query/#func-str">SPARQL str function</a>)
@@ -3740,6 +3763,7 @@ ex:Bob ex:age 23 .
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MaxLength">
+							Let <code>$maxLength</code> be a <a>parameter value</a> for <code>sh:maxLength</code>.
 							For each <a>value node</a> <code>v</code>
 							where the length (as defined by the <a data-cite="sparql12-query/#func-strlen">SPARQL STRLEN function</a>)
 							of the string representation of <code>v</code> (as defined by the <a data-cite="sparql12-query/#func-str">SPARQL str function</a>)
@@ -3845,6 +3869,8 @@ ex:Bob ex:password "123456789" .
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Pattern">
+							Let <code>$pattern</code> be a <a>parameter value</a> for <code>sh:pattern</code>.
+							Let <code>$flags</code> be a <a>parameter value</a> for <code>sh:flags</code>.
 							For each <a>value node</a>
 							that is a blank node or
 							where the string representation (as defined by the <a data-cite="sparql12-query/#func-str">SPARQL str function</a>)
@@ -3952,6 +3978,7 @@ ex:Alice ex:bCode "B102" .
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="SingleLine">
+							Let <code>$singleLine</code> be a <a>parameter value</a> for <code>sh:singleLine</code>.
 							If <code>$singleLine</code> is <code>true</code>, then, for each <a>value node</a> that is a literal where the lexical form matches the
 							regular expression (as defined by the <a data-cite="sparql12-query/#func-regex">SPARQL REGEX function</a>) <code>[\f\r\n\v]</code>, there is a validation result.
 						</div>
@@ -4057,6 +4084,7 @@ ex:SingleLineExampleShape
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="LanguageIn">
+							Let <code>$languageIn</code> be a <a>value</a> of <code>sh:languageIn</code>.
 							For each <a>value node</a>
 							that is either not a <a>literal</a> or that does not have a language tag
 							matching any of the basic language ranges that are the <a>members</a> of <code>$languageIn</code>
@@ -4190,6 +4218,7 @@ ex:Mountain
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="UniqueLang">
+							Let <code>$uniqueLang</code> be a <a>parameter value</a> for <code>sh:uniqueLang</code>.
 							If <code>$uniqueLang</code> is <code>true</code>
 							then for each non-empty language tag that is used by at least two <a>value nodes</a>,
 							there is a <a>validation result</a>. 
@@ -4313,6 +4342,7 @@ ex:Alice
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Equals">
+							Let <code>$equals</code> be a <a>value</a> of <code>sh:equals</code>.
 							For each <a>value node</a> 
 							that does not exist as a <a>value</a> of the property <code>$equals</code> at the <a>focus node</a>,
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
@@ -4401,6 +4431,7 @@ ex:Bob
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Disjoint">
+							Let <code>$disjoint</code> be a <a>parameter value</a> of <code>sh:disjoint</code>.
 							For each <a>value node</a>
 							that also exists as a <a>value</a> of the property <code>$disjoint</code> at the <a>focus node</a>,
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>. 
@@ -4502,6 +4533,7 @@ ex:USA
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="LessThan">
+							Let <code>$lessThan</code> be a <a>value</a> of <code>sh:lessThan</code>.
 							For each pair of <a>value nodes</a> and the values of the property <code>$lessThan</code> at the given <a>focus node</a>
 							where the first <a>value</a> is not less than the second <a>value</a> (based on SPARQL's <code>&lt;</code> operator)
 							or where the two values cannot be compared,
@@ -4568,6 +4600,7 @@ ex:LessThanExampleShape
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="LessThanOrEquals">
+							Let <code>$lessThanOrEquals</code> be a <a>value</a> of <code>sh:lessThanOrEquals</code>.
 							For each pair of <a>value nodes</a> and the values of the property <code>$lessThanOrEquals</code> at the given <a>focus node</a>
 							where the first <a>value</a> is not less than or equal to the second <a>value</a> (based on SPARQL's <code>&lt;=</code> operator)
 							or where the two values cannot be compared,
@@ -4610,6 +4643,7 @@ ex:LessThanExampleShape
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Not">
+							Let <code>$not</code> be a <a>value</a> of <code>sh:not</code>.
 							For each <a>value node</a> <code>v</code>:
 							A <a>failure</a> MUST be reported if the <a>conformance checking</a> of <code>v</code> against
 							the shape <code>$not</code> produces a <a>failure</a>.
@@ -4696,6 +4730,7 @@ ex:NotExampleShape
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="And">
+							Let <code>$and</code> be a <a>value</a> of <code>sh:and</code>.
 							For each <a>value node</a> <code>v</code>:
 							A <a>failure</a> MUST be produced if the <a>conformance checking</a> of <code>v</code> against any of the <a>members</a> of <code>$and</code> produces a <a>failure</a>.
 							Otherwise, if <code>v</code> does not <a>conform</a> to each <a>member</a> of <code>$and</code>,
@@ -4842,6 +4877,7 @@ ex:ValidInstance
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Or">
+							Let <code>$or</code> be a <a>value</a> of <code>sh:or</code>.
 							For each <a>value node</a> <code>v</code>:
 							A <a>failure</a> MUST be produced if the <a>conformance checking</a> of <code>v</code> against any of the <a>members</a> produces a <a>failure</a>.
 							Otherwise, if <code>v</code> <a>conforms</a> to none of the <a>members</a> of <code>$or</code>
@@ -5012,6 +5048,7 @@ ex:Bob ex:address "123 Prinzengasse, Vaduz, Liechtenstein" .
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Xone">
+							Let <code>$xone</code> be a <a>value</a> of <code>sh:xone</code>.
 							For each <a>value node</a> <code>v</code>
 							let <code>N</code> be the number of the <a>shapes</a> that are <a>members</a> of <code>$xone</code> 
 							where <code>v</code> <a>conforms</a> to the shape.
@@ -5177,6 +5214,7 @@ ex:Carla a ex:Person ;
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Node">
+							Let <code>$node</code> be a <a>value</a> of <code>sh:node</code>.
 							For each <a>value node</a> <code>v</code>:
 							A <a>failure</a> MUST be produced if the <a>conformance checking</a> of <code>v</code> against <code>$node</code> produces a <a>failure</a>.
 							Otherwise, if <code>v</code> does not <a>conform</a> to <code>$node</code>,
@@ -5373,6 +5411,7 @@ ex:RetosAddress
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Property">
+							Let <code>$property</code> be a <a>value</a> of <code>sh:property</code>.
 							For each <a>value node</a> <code>v</code>:
 							A <a>failure</a> MUST be produced if the validation of <code>v</code> as <a>focus node</a> against the property shape <code>$property</code> produces a <a>failure</a>.
 							Otherwise, the validation results are the results of <a>validating</a> <code>v</code> as <a>focus node</a> against the property shape <code>$property</code>.
@@ -5459,6 +5498,8 @@ ex:RetosAddress
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION of sh:qualifiedMinCount</div>
 						<div class="def-text-body" data-validator="QualifiedMinCount">
+							Let <code>$qualifiedValueShape</code> be a <a>value</a> of <code>sh:qualifiedValueShape</code>.
+							Let <code>$qualifiedMinCount</code> be a <a>parameter value</a> for <code>sh:qualifiedMinCount</code>.
 							Let <code>C</code> be the number of <a>value nodes</a> <code>v</code> where
 							<code>v</code> <a>conforms</a> to <code>$qualifiedValueShape</code>
 							and where <code>v</code> does not <a>conform</a> to any of the <a>sibling shapes</a> for the <em>current</em> shape,
@@ -5472,6 +5513,7 @@ ex:RetosAddress
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION of sh:qualifiedMaxCount</div>
 						<div class="def-text-body" data-validator="QualifiedMaxCount">
+							Let <code>$qualifiedMaxCount</code> be a <a>parameter value</a> for <code>sh:qualifiedMaxCount</code>.
 							Let <code>C</code> be as defined for <code>sh:qualifiedMinCount</code> above.
 							A <a>failure</a> MUST be produced if any of the said conformance checks produces a <a>failure</a>.
 							Otherwise, there is a <a>validation result</a> if <code>C</code> is greater than <code>$qualifiedMaxCount</code>.
@@ -5725,6 +5767,8 @@ ex:HandShape
 					<div id="def-ClosedShape-text" class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Closed">
+							Let <code>$closed</code> be a <a>parameter value</a> for <code>sh:closed</code>.
+							Let <code>$ignoredProperties</code> be a <a>value</a> for <code>sh:ignoredProperties</code>.
 							If <code>$closed</code> is <code>true</code> then
 							there is a <a>validation result</a> for each <a>triple</a> that has a <a>value node</a> as its
 							<a>subject</a> and a <a>predicate</a> that is not explicitly enumerated as a <a>value</a> of <code>sh:path</code>
@@ -5847,6 +5891,7 @@ ex:Alice
 					<div id="def-hasValue-text" class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="HasValue">
+							Let <code>$hasValue</code> be a <a>parameter value</a> for <code>sh:hasValue</code>.
 							If the RDF term <code>$hasValue</code> is not among the <a>value nodes</a>,
 							there is a <a>validation result</a>. 
 						</div>
@@ -5931,6 +5976,7 @@ ex:Alice
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="In">
+							Let <code>$in</code> be a <a>value</a> of <code>sh:in</code>.
 							For each <a>value node</a>
 							that is not a <a>member</a> of <code>$in</code>,
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
@@ -6024,14 +6070,14 @@ ex:RainbowPony ex:color ex:Pink .
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Expression">
-							Let <code>expr</code> be the <a>value</a> of <code>sh:expression</code>.
+							Let <code>$expr</code> be a <a>value</a> of <code>sh:expression</code>.
 							For each <a>value node</a> <code>v</code> 
 							and <code>scope</code> contains <code>v</code> as the value of <code>focusNode</code>
-							where <code>evalExpr(expr, activeGraph, scope)</code>
+							where <code>evalExpr($expr, activeGraph, scope)</code>
 							does not return <code>true</code> as one of its <a>output nodes</a>,
 							there is a <a>validation result</a> that has <code>v</code> as its <code>sh:value</code>
-							and a <a>deep copy</a> of <code>expr</code> in the results graph as its <code>sh:sourceConstraint</code>.
-							If the <code>expr</code> has <a>values</a> for <code>sh:message</code> in the <a>shapes graph</a>,
+							and a <a>deep copy</a> of <code>$expr</code> in the results graph as its <code>sh:sourceConstraint</code>.
+							If the <code>$expr</code> has <a>values</a> for <code>sh:message</code> in the <a>shapes graph</a>,
 							then these <a>values</a> become the (only) values for <code>sh:resultMessage</code> in the
 							<a>validation result</a>.
 						</div>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -395,6 +395,7 @@
 						<dfn data-cite="shacl12-core#dfn-parameter" data-lt="parameter|parameters">parameter</dfn>,
 						<dfn data-cite="shacl12-core#dfn-mandatory-parameter" data-lt="mandatory parameter|mandatory parameters">mandatory parameter</dfn>,
 						<dfn data-cite="shacl12-core#dfn-optional-parameter" data-lt="optional parameter|optional parameters">optional parameter</dfn>,
+						<dfn data-cite="shacl12-core#dfn-parameter-value" data-lt="parameter value">parameter value</dfn>,
 						<dfn data-cite="shacl12-core#dfn-shape" data-lt="shape|shapes">shape</dfn>,
 						<dfn data-cite="shacl12-core#dfn-node-shape" data-lt="node shape|node shapes">node shape</dfn>,
 						<dfn data-cite="shacl12-core#dfn-property-shape" data-lt="property shape|property shapes">property shape</dfn>,
@@ -770,6 +771,7 @@ ex:
 				<div class="def def-text">
 					<div class="def-header">TEXTUAL DEFINITION</div>
 					<div class="def-text-body">
+						Let <code>$sparql</code> be a <a>value</a> of <code>sh:sparql</code>.
 						There are no validation results if the <a>SPARQL-based constraint</a> has <code>true</code>
 						as a <a>value</a> for the property <code>sh:deactivated</code>.
 						Otherwise, execute the SPARQL query specified by the <a>SPARQL-based constraint</a> <code>$sparql</code>


### PR DESCRIPTION
* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-311/shacl12-core/index.html)

This PR only covers Core - removing the previously suggested allowance of node expressions as constraint parameters. Several people had voiced concerns, while others were in general favour. The proposal here is to instead leave this to the Node Expressions document, as a more flexible optional dialect of SHACL.

(Even if this gets approved, I will wait until enough people had a chance to disagree).