### PR TITLE
#140: Replace confusing use of "blank node shape"

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -4712,7 +4712,7 @@ ex:NotExampleShape
 						The following example illustrates the use of <code>sh:and</code> in a shape to specify the condition
 						that certain focus nodes have exactly one value of <code>ex:property</code>.
 						This is achieved via the conjunction of a separate named shape (<code>ex:SuperShape</code>) which specifies
-						the minimum count, and a blank node shape that additionally specifies the maximum count.
+						the minimum count, and a property shape that additionally specifies the maximum count.
 						As shown here, <code>sh:and</code> can be used to implement a specialization mechanism between shapes.
 					</p>
 					<aside class="example">


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #140

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-140/shacl12-core/index.html)
