### PR TITLE
#164: Added hint on execution order for sh:and and sh:or

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -4707,6 +4707,8 @@ ex:NotExampleShape
 					<p>
 						Note that although <code>sh:and</code> has a <a>SHACL list</a> of shapes as its value,
 						the order of those shapes does not impact the validation results.
+						For implementations that use shortcut evaluation semantics, the order may impact the efficiency of validation.
+						It is recommended to put earlier in the list constraints that are easier to evaluate, or are more likely to fail.
 					</p>
 					<p>
 						The following example illustrates the use of <code>sh:and</code> in a shape to specify the condition
@@ -4853,6 +4855,8 @@ ex:ValidInstance
 					<p>
 						Note that although <code>sh:or</code> has a <a>SHACL list</a> of shapes as its value,
 						the order of those shapes does not impact the validation results.
+						For implementations that use shortcut evaluation semantics, the order may impact the efficiency of validation.
+						It is recommended to put earlier in the list constraints that are easier to evaluate, or are more likely to succeed.
 					</p>
 					<p>
 						The following example illustrates the use of <code>sh:or</code> in a shape to specify the condition


### PR DESCRIPTION
I didn't do sh:xone because that's much less clear, and also much less used.

<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #164

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-164/shacl12-core/index.html)
