### PR TITLE
#314: Made focusNode an explicit param of exprEval, SPARQL-based expressions now pre-bind all scope vars

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2412,9 +2412,9 @@ ex:SomeClass-alternativePathExample
 					<li><code>expr</code> is a <a>node expression</a> in a <a>shapes graph</a>.
 					During evaluation, the engine can access <a>triples</a> related to <code>expr</code> in the <a>shapes graph</a>.</li>
 					<li><code>activeGraph</code> is a <a>graph</a>, called the <dfn>active graph</dfn>.</li>
-					<li><code>focusNode</code> is a <a>node</a> in the data graph, called the <dfn>input focus node</dfn>. This variable may have no value.</li>
+					<li><code>focusNode</code> is a <a>node</a>, called the <dfn>input focus node</dfn>. This variable may have no value.</li>
 					<li><code>scope</code> is a map from <a href="https://www.w3.org/TR/sparql12-query/#defn_QueryVariable">variable names</a> to individual <a>nodes</a>.
-					In this document, the empty map is written as <code>{}</code>.
+					The empty map is written as <code>{}</code>.
 					</li>
 				</ul>
 				The result of the evaluation of a node expression is a list of <a>nodes</a> (possibly empty and with duplicates) called the <dfn>output nodes</dfn>.

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2411,7 +2411,7 @@ ex:SomeClass-alternativePathExample
 				<ul>
 					<li><code>expr</code> is a <a>node expression</a> in a <a>shapes graph</a>.
 					During evaluation, the engine can access <a>triples</a> related to <code>expr</code> in the <a>shapes graph</a>.</li>
-					<li><code>activeGraph</code> is a <a>graph</a>, called the <dfn>active graph</dfn>.</li>
+					<li><code>activeGraph</code> is a <a>graph</a>, called the <dfn>active graph</dfn>. This is the default query graph for the evaluation of the node expression.</li>
 					<li><code>focusNode</code> is a <a>node</a>, called the <dfn>input focus node</dfn>. This variable may have no value.</li>
 					<li><code>scope</code> is a map from <a href="https://www.w3.org/TR/sparql12-query/#defn_QueryVariable">variable names</a> to individual <a>nodes</a>.
 					The empty map is written as <code>{}</code>.

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2406,14 +2406,15 @@ ex:SomeClass-alternativePathExample
 			</div>
 			<div class="def" id="node-expression-evaluation">
 				<div class="def-header">EVALUATION OF NODE EXPRESSIONS</div>
-				The <dfn>evaluation</dfn> of a node expression is defined as a function <code>evalExpr(expr, activeGraph, scope) -> outputNodes</code>
+				The <dfn>evaluation</dfn> of a node expression is defined as a function <code>evalExpr(expr, activeGraph, focusNode, scope) -> outputNodes</code>
 				where
 				<ul>
 					<li><code>expr</code> is a <a>node expression</a> in a <a>shapes graph</a>.
 					During evaluation, the engine can access <a>triples</a> related to <code>expr</code> in the <a>shapes graph</a>.</li>
 					<li><code>activeGraph</code> is a <a>graph</a>, called the <dfn>active graph</dfn>.</li>
+					<li><code>focusNode</code> is a <a>node</a> in the data graph, called the <dfn>input focus node</dfn>. This variable may have no value.</li>
 					<li><code>scope</code> is a map from <a href="https://www.w3.org/TR/sparql12-query/#defn_QueryVariable">variable names</a> to individual <a>nodes</a>.
-						The value of the variable <code>focusNode</code> (if it exists) is called the <dfn>input focus node</dfn>.
+					In this document, the empty map is written as <code>{}</code>.
 					</li>
 				</ul>
 				The result of the evaluation of a node expression is a list of <a>nodes</a> (possibly empty and with duplicates) called the <dfn>output nodes</dfn>.
@@ -2440,7 +2441,7 @@ ex:SomeClass-alternativePathExample
 						The <a>output nodes</a> of an <a>IRI expression</a> are the list consisting of exactly the <a>node expression</a> itself:
 						<br/>
 						<br/>
-						<code>evalExpr(expr, activeGraph, scope) -> [expr]</code>
+						<code>evalExpr(expr, activeGraph, focusNode, scope) -> [expr]</code>
 					</p>
 				</div>
 			</section>
@@ -2459,7 +2460,7 @@ ex:SomeClass-alternativePathExample
 						The <a>output nodes</a> of a <a>literal expression</a> are the list consisting of exactly the <a>node expression</a> itself:
 						<br/>
 						<br/>
-						<code>evalExpr(expr, activeGraph, scope) -> [expr]</code>
+						<code>evalExpr(expr, activeGraph, focusNode, scope) -> [expr]</code>
 					</p>
 				</div>
 			</section>
@@ -2919,13 +2920,11 @@ ex:SomeClass-alternativePathExample
 						</li>
 						<li>
 							If <code>e</code> is the <a>value</a> of <code>sh:values</code> at the <a>property shape</a>,
-							then add the <a>output nodes</a> of <code>evalExpr(e, <a>data graph</a>, scope)</code> where <code>scope</code>
-							contains the <a>focus node</a> as the value of the variable <code>focusNode</code>.
+							then add the <a>output nodes</a> of <code>evalExpr(e, <a>data graph</a>, <a>focus node</a>, {})</code>.
 						</li>
 						<li>
 							If the set is still empty and <code>d</code> is the <a>value</a> of <code>sh:defaultValue</code> at the <a>property shape</a>,
-							then add the <a>output nodes</a> of <code>evalExpr(d, <a>data graph</a>, scope)</code> where <code>scope</code>
-							contains the <a>focus node</a> as the value of the variable <code>focusNode</code>.
+							then add the <a>output nodes</a> of <code>evalExpr(d, <a>data graph</a>, <a>focus node</a>, {})</code>.
 						</li>
 					</ol>
 				</section>
@@ -6031,8 +6030,7 @@ ex:RainbowPony ex:color ex:Pink .
 						<div class="def-text-body" data-validator="Expression">
 							Let <code>expr</code> be the <a>value</a> of <code>sh:expression</code>.
 							For each <a>value node</a> <code>v</code> 
-							and <code>scope</code> contains <code>v</code> as the value of <code>focusNode</code>
-							where <code>evalExpr(expr, activeGraph, scope)</code>
+							where <code>evalExpr(expr, activeGraph, v, {})</code>
 							does not return <code>true</code> as one of its <a>output nodes</a>,
 							there is a <a>validation result</a> that has <code>v</code> as its <code>sh:value</code>
 							and a <a>deep copy</a> of <code>expr</code> in the results graph as its <code>sh:sourceConstraint</code>.

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -1359,7 +1359,7 @@ ex:MultiplePatternsShape
 							If <code>s</code> is a <a>shape</a> in a <a>shapes graph</a> <code>SG</code> and <code>s</code> has
 							<a>value</a> <code>expr</code> for <code>sh:targetNode</code> in <code>SG</code>,
 							then the <a>output nodes</a> of <code>expr</code> are <a>targets</a>
-							for the data graph <code>DG</code> as <a>active graph</a>.
+							for the data graph <code>DG</code> as <a>focus graph</a>.
 						</div>
 						<p><em>The remainder of this section is informative.</em></p>
 						<p>
@@ -2406,12 +2406,12 @@ ex:SomeClass-alternativePathExample
 			</div>
 			<div class="def" id="node-expression-evaluation">
 				<div class="def-header">EVALUATION OF NODE EXPRESSIONS</div>
-				The <dfn>evaluation</dfn> of a node expression is defined as a function <code>evalExpr(expr, activeGraph, focusNode, scope) -> outputNodes</code>
+				The <dfn>evaluation</dfn> of a node expression is defined as a function <code>evalExpr(expr, focusGraph, focusNode, scope) -> outputNodes</code>
 				where
 				<ul>
 					<li><code>expr</code> is a <a>node expression</a> in a <a>shapes graph</a>.
 					During evaluation, the engine can access <a>triples</a> related to <code>expr</code> in the <a>shapes graph</a>.</li>
-					<li><code>activeGraph</code> is a <a>graph</a>, called the <dfn>active graph</dfn>. This is the default query graph for the evaluation of the node expression.</li>
+					<li><code>focusGraph</code> is a <a>graph</a>, called the <dfn>focus graph</dfn>. This is the default query graph for the evaluation of the node expression.</li>
 					<li><code>focusNode</code> is a <a>node</a>, called the <dfn>input focus node</dfn>. This variable may have no value.</li>
 					<li><code>scope</code> is a map from <a href="https://www.w3.org/TR/sparql12-query/#defn_QueryVariable">variable names</a> to individual <a>nodes</a>.
 					The empty map is written as <code>{}</code>.
@@ -2441,7 +2441,7 @@ ex:SomeClass-alternativePathExample
 						The <a>output nodes</a> of an <a>IRI expression</a> are the list consisting of exactly the <a>node expression</a> itself:
 						<br/>
 						<br/>
-						<code>evalExpr(expr, activeGraph, focusNode, scope) -> [expr]</code>
+						<code>evalExpr(expr, focusGraph, focusNode, scope) -> [expr]</code>
 					</p>
 				</div>
 			</section>
@@ -2460,7 +2460,7 @@ ex:SomeClass-alternativePathExample
 						The <a>output nodes</a> of a <a>literal expression</a> are the list consisting of exactly the <a>node expression</a> itself:
 						<br/>
 						<br/>
-						<code>evalExpr(expr, activeGraph, focusNode, scope) -> [expr]</code>
+						<code>evalExpr(expr, focusGraph, focusNode, scope) -> [expr]</code>
 					</p>
 				</div>
 			</section>
@@ -6030,7 +6030,7 @@ ex:RainbowPony ex:color ex:Pink .
 						<div class="def-text-body" data-validator="Expression">
 							Let <code>expr</code> be the <a>value</a> of <code>sh:expression</code>.
 							For each <a>value node</a> <code>v</code> 
-							where <code>evalExpr(expr, activeGraph, v, {})</code>
+							where <code>evalExpr(expr, <a>data graph</a>>, v, {})</code>
 							does not return <code>true</code> as one of its <a>output nodes</a>,
 							there is a <a>validation result</a> that has <code>v</code> as its <code>sh:value</code>
 							and a <a>deep copy</a> of <code>expr</code> in the results graph as its <code>sh:sourceConstraint</code>.

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -6002,7 +6002,7 @@ ex:RainbowPony ex:color ex:Pink .
 						Based on <a>node expressions</a>, this section introduces a <a>constraint component</a> called
 						<dfn data-lt="expression constraint">expression constraints</dfn>.
 						Expression constraints can be used in any <a>shape</a> to declare the condition that the
-						<a>node expression</a> specified via <code>sh:expression</code> has <code>true</code> as one of its output nodes.
+						<a>node expression</a> specified via <code>sh:expression</code> has <code>true</code> as its only output node.
 						The evaluation of these node expressions is repeated for all <a>value nodes</a> of the <a>shape</a>
 						as the <a>focus node</a>.
 					</p>
@@ -6031,7 +6031,7 @@ ex:RainbowPony ex:color ex:Pink .
 							Let <code>expr</code> be the <a>value</a> of <code>sh:expression</code>.
 							For each <a>value node</a> <code>v</code> 
 							where <code>evalExpr(expr, <a>data graph</a>>, v, {})</code>
-							does not return <code>true</code> as one of its <a>output nodes</a>,
+							does not return the list consisting of exactly <code>true</code> as its <a>output nodes</a>,
 							there is a <a>validation result</a> that has <code>v</code> as its <code>sh:value</code>
 							and a <a>deep copy</a> of <code>expr</code> in the results graph as its <code>sh:sourceConstraint</code>.
 							If the <code>expr</code> has <a>values</a> for <code>sh:message</code> in the <a>shapes graph</a>,

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -1230,10 +1230,12 @@ ex:hasLang
 					<p>
 						The <a>output nodes</a> of a <a>select expression</a> are the list <code>resultNodes</code> consisting of exactly the bindings of the (only)
 						variable that is projected from the SELECT clause.
-						If present in the <a>scope</a>, the value of the scope variable <code>focusNode</code> MUST be <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
+						The value of <code>focusNode</code> is <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
+						The values of each scope variable is <a>pre-bound</a> as a SPARQL variable with the same name and value.
+						A <a>failure</a> is produced when one of the scope variables is called <code>this</code>.
 						<br/>
 						<br/>
-						<code>evalExpr(expr, activeGraph, scope) -> resultNodes</code>
+						<code>evalExpr(expr, activeGraph, focusNode, scope) -> resultNodes</code>
 					</p>
 				</div>
 				<p><em>The remainder of this section is informative.</em></p>
@@ -1341,10 +1343,12 @@ ex:Bernd
 					<p>
 						The <a>output nodes</a> of an <a>SPARQL expr expression</a> are the list <code>resultNodes</code> consisting of exactly the bindings of the (only)
 						variable that is projected from the SELECT clause of the <code>select</code> query as defined <a href="#syntax-rule-SPARQLExprExpression-template">above</a>.
-						If present in the <a>scope</a>, the value of the scope variable <code>focusNode</code> MUST be <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
+						The value of <code>focusNode</code> is <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
+						The values of each scope variable is <a>pre-bound</a> as a SPARQL variable with the same name and value.
+						A <a>failure</a> is produced when one of the scope variables is called <code>this</code>.
 						<br/>
 						<br/>
-						<code>evalExpr(expr, activeGraph, scope) -> resultNodes</code>
+						<code>evalExpr(expr, activeGraph, focusNode, scope) -> resultNodes</code>
 					</p>
 				</div>
 				<p><em>The remainder of this section is informative.</em></p>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -408,7 +408,7 @@
 						<dfn data-cite="shacl12-core#dfn-function-name" data-lt="node expression function name">function name</dfn>,
 						<dfn data-cite="shacl12-core#dfn-key-parameter" data-lt="key parameter">key parameter</dfn>,
 						<dfn data-cite="shacl12-core#dfn-output-nodes" data-lt="output nodes">output nodes</dfn>,
-						<dfn data-cite="shacl12-core#dfn-active-graph" data-lt="active graph">active graph</dfn>,
+						<dfn data-cite="shacl12-core#dfn-focus-graph" data-lt="focus graph">focus graph</dfn>,
 						<dfn data-cite="shacl12-core#dfn-conform" data-lt="conform|conforms">conform</dfn>,
 						<dfn data-cite="shacl12-core#dfn-failure" data-lt="failure|failures">failure</dfn>,
 						<dfn data-cite="shacl12-core#dfn-shacl-instance" data-lt="shacl instance">SHACL instance</dfn>,
@@ -1230,13 +1230,13 @@ ex:hasLang
 					<div class="def-header">EVALUATION OF SELECT EXPRESSIONS</div>
 					<p>
 						The <a>output nodes</a> of a <a>select expression</a> are the list <code>resultNodes</code> consisting of exactly the bindings of the (only)
-						variable that is projected from the SELECT clause when the query is evaluated against the <a>active graph</a>.
+						variable that is projected from the SELECT clause when the query is evaluated against the <a>focus graph</a>.
 						The value of <code>focusNode</code> is <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
 						The value of each scope variable is <a>pre-bound</a> as a SPARQL variable with the same name and value.
 						A <a>failure</a> is produced when one of the scope variables is called <code>this</code>.
 						<br/>
 						<br/>
-						<code>evalExpr(expr, activeGraph, focusNode, scope) -> resultNodes</code>
+						<code>evalExpr(expr, focusGraph, focusNode, scope) -> resultNodes</code>
 					</p>
 				</div>
 				<p><em>The remainder of this section is informative.</em></p>
@@ -1344,13 +1344,13 @@ ex:Bernd
 					<p>
 						The <a>output nodes</a> of an <a>SPARQL expr expression</a> are the list <code>resultNodes</code> consisting of exactly the bindings of the (only)
 						variable that is projected from the SELECT clause of the <code>select</code> query as defined <a href="#syntax-rule-SPARQLExprExpression-template">above</a>
-						when the query is evaluated against the <a>active graph</a>.
+						when the query is evaluated against the <a>focus graph</a>.
 						The value of <code>focusNode</code> is <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
 						The value of each scope variable is <a>pre-bound</a> as a SPARQL variable with the same name and value.
 						A <a>failure</a> is produced when one of the scope variables is called <code>this</code>.
 						<br/>
 						<br/>
-						<code>evalExpr(expr, activeGraph, focusNode, scope) -> resultNodes</code>
+						<code>evalExpr(expr, focusGraph, focusNode, scope) -> resultNodes</code>
 					</p>
 				</div>
 				<p><em>The remainder of this section is informative.</em></p>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -408,6 +408,7 @@
 						<dfn data-cite="shacl12-core#dfn-function-name" data-lt="node expression function name">function name</dfn>,
 						<dfn data-cite="shacl12-core#dfn-key-parameter" data-lt="key parameter">key parameter</dfn>,
 						<dfn data-cite="shacl12-core#dfn-output-nodes" data-lt="output nodes">output nodes</dfn>,
+						<dfn data-cite="shacl12-core#dfn-active-graph" data-lt="active graph">active graph</dfn>,
 						<dfn data-cite="shacl12-core#dfn-conform" data-lt="conform|conforms">conform</dfn>,
 						<dfn data-cite="shacl12-core#dfn-failure" data-lt="failure|failures">failure</dfn>,
 						<dfn data-cite="shacl12-core#dfn-shacl-instance" data-lt="shacl instance">SHACL instance</dfn>,
@@ -1229,7 +1230,7 @@ ex:hasLang
 					<div class="def-header">EVALUATION OF SELECT EXPRESSIONS</div>
 					<p>
 						The <a>output nodes</a> of a <a>select expression</a> are the list <code>resultNodes</code> consisting of exactly the bindings of the (only)
-						variable that is projected from the SELECT clause.
+						variable that is projected from the SELECT clause when the query is evaluated against the <a>active graph</a>.
 						The value of <code>focusNode</code> is <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
 						The value of each scope variable is <a>pre-bound</a> as a SPARQL variable with the same name and value.
 						A <a>failure</a> is produced when one of the scope variables is called <code>this</code>.
@@ -1342,7 +1343,8 @@ ex:Bernd
 					<div class="def-header">EVALUATION OF SPARQL EXPR EXPRESSIONS</div>
 					<p>
 						The <a>output nodes</a> of an <a>SPARQL expr expression</a> are the list <code>resultNodes</code> consisting of exactly the bindings of the (only)
-						variable that is projected from the SELECT clause of the <code>select</code> query as defined <a href="#syntax-rule-SPARQLExprExpression-template">above</a>.
+						variable that is projected from the SELECT clause of the <code>select</code> query as defined <a href="#syntax-rule-SPARQLExprExpression-template">above</a>
+						when the query is evaluated against the <a>active graph</a>.
 						The value of <code>focusNode</code> is <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
 						The value of each scope variable is <a>pre-bound</a> as a SPARQL variable with the same name and value.
 						A <a>failure</a> is produced when one of the scope variables is called <code>this</code>.

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -1231,7 +1231,7 @@ ex:hasLang
 						The <a>output nodes</a> of a <a>select expression</a> are the list <code>resultNodes</code> consisting of exactly the bindings of the (only)
 						variable that is projected from the SELECT clause.
 						The value of <code>focusNode</code> is <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
-						The values of each scope variable is <a>pre-bound</a> as a SPARQL variable with the same name and value.
+						The value of each scope variable is <a>pre-bound</a> as a SPARQL variable with the same name and value.
 						A <a>failure</a> is produced when one of the scope variables is called <code>this</code>.
 						<br/>
 						<br/>
@@ -1344,7 +1344,7 @@ ex:Bernd
 						The <a>output nodes</a> of an <a>SPARQL expr expression</a> are the list <code>resultNodes</code> consisting of exactly the bindings of the (only)
 						variable that is projected from the SELECT clause of the <code>select</code> query as defined <a href="#syntax-rule-SPARQLExprExpression-template">above</a>.
 						The value of <code>focusNode</code> is <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
-						The values of each scope variable is <a>pre-bound</a> as a SPARQL variable with the same name and value.
+						The value of each scope variable is <a>pre-bound</a> as a SPARQL variable with the same name and value.
 						A <a>failure</a> is produced when one of the scope variables is called <code>this</code>.
 						<br/>
 						<br/>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -1230,7 +1230,7 @@ ex:hasLang
 					<div class="def-header">EVALUATION OF SELECT EXPRESSIONS</div>
 					<p>
 						The <a>output nodes</a> of a <a>select expression</a> are the list <code>resultNodes</code> consisting of exactly the bindings of the (only)
-						variable that is projected from the SELECT clause when the query is evaluated against the <a>focus graph</a>.
+						variable that is projected from the <code>SELECT</code> clause when the query is evaluated against the <a>focus graph</a>.
 						The value of <code>focusNode</code> is <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
 						The value of each scope variable is <a>pre-bound</a> as a SPARQL variable with the same name and value.
 						A <a>failure</a> is produced when one of the scope variables is called <code>this</code>.
@@ -1343,7 +1343,7 @@ ex:Bernd
 					<div class="def-header">EVALUATION OF SPARQL EXPR EXPRESSIONS</div>
 					<p>
 						The <a>output nodes</a> of an <a>SPARQL expr expression</a> are the list <code>resultNodes</code> consisting of exactly the bindings of the (only)
-						variable that is projected from the SELECT clause of the <code>select</code> query as defined <a href="#syntax-rule-SPARQLExprExpression-template">above</a>
+						variable that is projected from the <code>SELECT</code> clause of the <code>select</code> query as defined <a href="#syntax-rule-SPARQLExprExpression-template">above</a>
 						when the query is evaluated against the <a>focus graph</a>.
 						The value of <code>focusNode</code> is <a>pre-bound</a> as the value of the SPARQL variable <code>this</code>.
 						The value of each scope variable is <a>pre-bound</a> as a SPARQL variable with the same name and value.


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Two changes in this PR:

- Instead of having focusNode as part of the scope, I have pulled it out into an explicit special variable. This is cleaner because this variable really has a special status (e.g. it's called this in SPARQL) and it usually has a value (except in sh:targetNode).
- The SPARQL-based node expressions now accept the scope vars as parameters. This makes it possible to define user-defined (SPARQL) functions through custom node expression types. For map-based NEe, these would be simple name-value pairs for the input parameters. For list-based NEs, these could be arg1, arg2, arg3 etc. The NE document can specify the details, but the SPARQL document does not need to change further to accommodate the use cases.

Closes #314
