### PR TITLE
#276: Unify `ex` namespace usage in tests - redo

### DIFF
--- a/data-shapes-test-suite/tests/core/complex/personexample.ttl
+++ b/data-shapes-test-suite/tests/core/complex/personexample.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/complex/personexample.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/misc/deactivated-001.ttl
+++ b/data-shapes-test-suite/tests/core/misc/deactivated-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/deactivated-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/misc/deactivated-002.ttl
+++ b/data-shapes-test-suite/tests/core/misc/deactivated-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/deactivated-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/misc/message-001.ttl
+++ b/data-shapes-test-suite/tests/core/misc/message-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/message-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/misc/severity-001.ttl
+++ b/data-shapes-test-suite/tests/core/misc/severity-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/severity-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/misc/severity-002.ttl
+++ b/data-shapes-test-suite/tests/core/misc/severity-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/severity-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/and-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/and-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/and-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/and-002.ttl
+++ b/data-shapes-test-suite/tests/core/node/and-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/and-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/class-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/class-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/class-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/class-002.ttl
+++ b/data-shapes-test-suite/tests/core/node/class-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/class-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/class-003.ttl
+++ b/data-shapes-test-suite/tests/core/node/class-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/class-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/closed-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/closed-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/closed-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/closed-002.ttl
+++ b/data-shapes-test-suite/tests/core/node/closed-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/closed-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/datatype-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/datatype-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/datatype-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/datatype-002.ttl
+++ b/data-shapes-test-suite/tests/core/node/datatype-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/datatype-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/disjoint-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/disjoint-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/disjoint-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/equals-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/equals-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/equals-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/hasValue-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/hasValue-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/hasValue-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/in-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/in-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/in-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/languageIn-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/languageIn-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/languageIn-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/maxExclusive-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/maxExclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/maxExclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/maxInclusive-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/maxInclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/maxInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/maxLength-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/maxLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/maxLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/minExclusive-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/minExclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minExclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/minInclusive-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/minInclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/minInclusive-002.ttl
+++ b/data-shapes-test-suite/tests/core/node/minInclusive-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/minInclusive-003.ttl
+++ b/data-shapes-test-suite/tests/core/node/minInclusive-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/minLength-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/minLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/node-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/node-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/node-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/nodeKind-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/nodeKind-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/nodeKind-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/not-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/not-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/not-001#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/not-002.ttl
+++ b/data-shapes-test-suite/tests/core/node/not-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/not-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/or-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/or-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/or-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/pattern-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/pattern-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/pattern-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/pattern-002.ttl
+++ b/data-shapes-test-suite/tests/core/node/pattern-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/pattern-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/qualified-001-data.ttl
+++ b/data-shapes-test-suite/tests/core/node/qualified-001-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i a ex:C1 .
 ex:j a ex:C1 , ex:C2 .

--- a/data-shapes-test-suite/tests/core/node/qualified-001-shapes.ttl
+++ b/data-shapes-test-suite/tests/core/node/qualified-001-shapes.ttl
@@ -1,6 +1,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s1 a sh:NodeShape ;
   sh:targetClass ex:C1 ;

--- a/data-shapes-test-suite/tests/core/node/qualified-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/qualified-001.ttl
@@ -6,7 +6,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 <> a mf:Manifest ;
   mf:entries (

--- a/data-shapes-test-suite/tests/core/node/xone-001.ttl
+++ b/data-shapes-test-suite/tests/core/node/xone-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/xone-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/node/xone-duplicate-data.ttl
+++ b/data-shapes-test-suite/tests/core/node/xone-duplicate-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i a ex:C1 .
 ex:j a ex:C1 , ex:C2 .

--- a/data-shapes-test-suite/tests/core/node/xone-duplicate-shapes.ttl
+++ b/data-shapes-test-suite/tests/core/node/xone-duplicate-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s1 a sh:NodeShape ;
   sh:targetClass ex:C1 ;

--- a/data-shapes-test-suite/tests/core/node/xone-duplicate.ttl
+++ b/data-shapes-test-suite/tests/core/node/xone-duplicate.ttl
@@ -6,7 +6,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 <> a mf:Manifest ;
   mf:entries (

--- a/data-shapes-test-suite/tests/core/path/path-alternative-001.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-alternative-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-alternative-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/path/path-complex-001.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-complex-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-complex-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/path/path-complex-002-data.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-complex-002-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:j ex:p ex:i .
 

--- a/data-shapes-test-suite/tests/core/path/path-complex-002-shapes.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-complex-002-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s1 a sh:PropertyShape ;
  sh:targetNode ex:i ;

--- a/data-shapes-test-suite/tests/core/path/path-complex-002.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-complex-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/path/path-inverse-001.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-inverse-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-inverse-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/path/path-oneOrMore-001.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-oneOrMore-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-oneOrMore-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/path/path-sequence-001.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-sequence-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-sequence-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/path/path-sequence-002.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-sequence-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-sequence-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/path/path-sequence-duplicate-001.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-sequence-duplicate-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-sequence-duplicate-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/path/path-strange-001.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-strange-001.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/data-shapes-test-suite/tests/core/path/path-strange-002.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-strange-002.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/data-shapes-test-suite/tests/core/path/path-unused-001-data.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-unused-001-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i a ex:C .
 

--- a/data-shapes-test-suite/tests/core/path/path-unused-001-shapes.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-unused-001-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 

--- a/data-shapes-test-suite/tests/core/path/path-unused-001.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-unused-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/path/path-zeroOrMore-001.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-zeroOrMore-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-zeroOrMore-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/path/path-zeroOrOne-001.ttl
+++ b/data-shapes-test-suite/tests/core/path/path-zeroOrOne-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-zeroOrOne-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/and-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/and-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/and-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/class-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/class-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/class-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/datatype-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/datatype-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/datatype-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/datatype-002.ttl
+++ b/data-shapes-test-suite/tests/core/property/datatype-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/datatype-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/datatype-003.ttl
+++ b/data-shapes-test-suite/tests/core/property/datatype-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/datatype-003.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/datatype-ill-formed-data.ttl
+++ b/data-shapes-test-suite/tests/core/property/datatype-ill-formed-data.ttl
@@ -1,5 +1,5 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i ex:p "300"^^xsd:byte .
 ex:i ex:p "55"^^xsd:integer .

--- a/data-shapes-test-suite/tests/core/property/datatype-ill-formed-shapes.ttl
+++ b/data-shapes-test-suite/tests/core/property/datatype-ill-formed-shapes.ttl
@@ -1,6 +1,6 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s a sh:PropertyShape ;
   sh:targetNode ex:i ;

--- a/data-shapes-test-suite/tests/core/property/datatype-ill-formed.ttl
+++ b/data-shapes-test-suite/tests/core/property/datatype-ill-formed.ttl
@@ -6,7 +6,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 <> rdf:type mf:Manifest ;
    mf:entries (

--- a/data-shapes-test-suite/tests/core/property/disjoint-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/disjoint-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/disjoint-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/equals-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/equals-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/equals-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/hasValue-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/hasValue-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/hasValue-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/in-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/in-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/in-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/languageIn-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/languageIn-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/languageIn-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/lessThan-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/lessThan-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/lessThan-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/lessThan-002.ttl
+++ b/data-shapes-test-suite/tests/core/property/lessThan-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/lessThan-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/lessThanOrEquals-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/lessThanOrEquals-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/lessThanOrEquals-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/maxCount-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/maxCount-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxCount-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/maxCount-002.ttl
+++ b/data-shapes-test-suite/tests/core/property/maxCount-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxCount-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/maxExclusive-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/maxExclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxExclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/maxInclusive-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/maxInclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/maxLength-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/maxLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/minCount-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/minCount-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minCount-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/minCount-002.ttl
+++ b/data-shapes-test-suite/tests/core/property/minCount-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minCount-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/minExclusive-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/minExclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minExclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/minExclusive-002.ttl
+++ b/data-shapes-test-suite/tests/core/property/minExclusive-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minExclusive-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/minLength-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/minLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/node-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/node-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/node-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/node-002.ttl
+++ b/data-shapes-test-suite/tests/core/property/node-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/node-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/nodeKind-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/nodeKind-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/nodeKind-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/not-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/not-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/not-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/or-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/or-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/or-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/or-datatypes-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/or-datatypes-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/or-datatypes-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/pattern-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/pattern-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/pattern-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/pattern-002.ttl
+++ b/data-shapes-test-suite/tests/core/property/pattern-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/pattern-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/property-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/property-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/property-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/qualifiedMinCountDisjoint-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/qualifiedMinCountDisjoint-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/qualifiedMinCountDisjoint-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/qualifiedValueShape-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/qualifiedValueShape-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/qualifiedValueShape-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/qualifiedValueShapesDisjoint-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/qualifiedValueShapesDisjoint-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/qualifiedValueShapesDisjoint-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/uniqueLang-001.ttl
+++ b/data-shapes-test-suite/tests/core/property/uniqueLang-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/uniqueLang-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/property/uniqueLang-002-data.ttl
+++ b/data-shapes-test-suite/tests/core/property/uniqueLang-002-data.ttl
@@ -1,3 +1,3 @@
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i ex:message "HI"@en, "Hi"@en .

--- a/data-shapes-test-suite/tests/core/property/uniqueLang-002-shapes.ttl
+++ b/data-shapes-test-suite/tests/core/property/uniqueLang-002-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:s1 a sh:PropertyShape ;

--- a/data-shapes-test-suite/tests/core/property/uniqueLang-002.ttl
+++ b/data-shapes-test-suite/tests/core/property/uniqueLang-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-complex-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/targets/multipleTargets-001.ttl
+++ b/data-shapes-test-suite/tests/core/targets/multipleTargets-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/multipleTargets-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/targets/targetClass-001.ttl
+++ b/data-shapes-test-suite/tests/core/targets/targetClass-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetClass-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/targets/targetClassImplicit-001.ttl
+++ b/data-shapes-test-suite/tests/core/targets/targetClassImplicit-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetClassImplicit-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/targets/targetNode-001.ttl
+++ b/data-shapes-test-suite/tests/core/targets/targetNode-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetNode-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/targets/targetObjectsOf-001.ttl
+++ b/data-shapes-test-suite/tests/core/targets/targetObjectsOf-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetObjectsOf-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/targets/targetSubjectsOf-001.ttl
+++ b/data-shapes-test-suite/tests/core/targets/targetSubjectsOf-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/targets/targetSubjectsOf-002.ttl
+++ b/data-shapes-test-suite/tests/core/targets/targetSubjectsOf-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/core/validation-reports/shared-data.ttl
+++ b/data-shapes-test-suite/tests/core/validation-reports/shared-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 ex:i ex:p ex:j .
 ex:i ex:q ex:j .
 ex:j ex:r ex:k .

--- a/data-shapes-test-suite/tests/core/validation-reports/shared-shapes.ttl
+++ b/data-shapes-test-suite/tests/core/validation-reports/shared-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s1 a sh:NodeShape ;
   sh:targetNode ex:i ;

--- a/data-shapes-test-suite/tests/core/validation-reports/shared.ttl
+++ b/data-shapes-test-suite/tests/core/validation-reports/shared.ttl
@@ -6,7 +6,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 # This test case is under discussion, as there are different interpretations
 # on whether the nested sh:property constraint that is reached twice should

--- a/data-shapes-test-suite/tests/sparql/component/nodeValidator-001.ttl
+++ b/data-shapes-test-suite/tests/sparql/component/nodeValidator-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/component/nodeValidator-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -11,7 +11,7 @@
 <http://datashapes.org/sh/tests/sparql/component/nodeValidator-001.test>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
-      sh:namespace "http://datashapes.org/sh/tests/sparql/component/nodeValidator-001.test#"^^xsd:anyURI ;
+      sh:namespace "http://example.com/ns#"^^xsd:anyURI ;
       sh:prefix "ex" ;
     ] ;
 .

--- a/data-shapes-test-suite/tests/sparql/component/optional-001.ttl
+++ b/data-shapes-test-suite/tests/sparql/component/optional-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/component/optional-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -11,7 +11,7 @@
 <http://datashapes.org/sh/tests/sparql/component/optional-001.test>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
-      sh:namespace "http://datashapes.org/sh/tests/sparql/component/optional-001.test#"^^xsd:anyURI ;
+      sh:namespace "http://example.com/ns#"^^xsd:anyURI ;
       sh:prefix "ex" ;
     ] ;
 .

--- a/data-shapes-test-suite/tests/sparql/component/propertyValidator-select-001.ttl
+++ b/data-shapes-test-suite/tests/sparql/component/propertyValidator-select-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/component/propertyValidator-select-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/component/validator-001.ttl
+++ b/data-shapes-test-suite/tests/sparql/component/validator-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/component/validator-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/node/prefixes-001.ttl
+++ b/data-shapes-test-suite/tests/sparql/node/prefixes-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/node/prefixes-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -11,7 +11,7 @@
 <http://datashapes.org/sh/tests/sparql/node/prefixes-001.test>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
-      sh:namespace "http://datashapes.org/sh/tests/sparql/node/prefixes-001.test#"^^xsd:anyURI ;
+      sh:namespace "http://example.com/ns#"^^xsd:anyURI ;
       sh:prefix "ex" ;
     ] ;
 .

--- a/data-shapes-test-suite/tests/sparql/node/sparql-001.ttl
+++ b/data-shapes-test-suite/tests/sparql/node/sparql-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/node/sparql-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/node/sparql-002.ttl
+++ b/data-shapes-test-suite/tests/sparql/node/sparql-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/node/sparql-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -11,7 +11,7 @@
 <http://datashapes.org/sh/tests/sparql/node/sparql-002.test>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
-      sh:namespace "http://datashapes.org/sh/tests/sparql/node/sparql-002.test#"^^xsd:anyURI ;
+      sh:namespace "http://example.com/ns#"^^xsd:anyURI ;
       sh:prefix "ex" ;
     ] ;
 .

--- a/data-shapes-test-suite/tests/sparql/node/sparql-003.ttl
+++ b/data-shapes-test-suite/tests/sparql/node/sparql-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/node/sparql-003.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -11,7 +11,7 @@
 <http://datashapes.org/sh/tests/sparql/node/sparql-003.test>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
-      sh:namespace "http://datashapes.org/sh/tests/sparql/node/sparql-003.test#"^^xsd:anyURI ;
+      sh:namespace "http://example.com/ns#"^^xsd:anyURI ;
       sh:prefix "ex" ;
     ] ;
 .

--- a/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-001.ttl
+++ b/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-002.ttl
+++ b/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-003.ttl
+++ b/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-003.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-004.ttl
+++ b/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-004.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-004.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-005.ttl
+++ b/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-005.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-005.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-006.ttl
+++ b/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-006.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-006.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-007.ttl
+++ b/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-007.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-007.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/pre-binding/shapesGraph-001.ttl
+++ b/data-shapes-test-suite/tests/sparql/pre-binding/shapesGraph-001.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/shapesGraph-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-001.ttl
+++ b/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-001.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-002.ttl
+++ b/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-002.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-003.ttl
+++ b/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-003.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-003.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-004.ttl
+++ b/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-004.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-004.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-005.ttl
+++ b/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-005.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-005.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-006.ttl
+++ b/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-006.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-006.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/data-shapes-test-suite/tests/sparql/property/sparql-001.ttl
+++ b/data-shapes-test-suite/tests/sparql/property/sparql-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/property/sparql-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl-compact-syntax/tests/valid/array-in.ttl
+++ b/shacl-compact-syntax/tests/valid/array-in.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/array-in> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/basic-shape-with-target.ttl
+++ b/shacl-compact-syntax/tests/valid/basic-shape-with-target.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/basic-shape-with-target> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/basic-shape-with-targets.ttl
+++ b/shacl-compact-syntax/tests/valid/basic-shape-with-targets.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/basic-shape-with-targets> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/basic-shape.ttl
+++ b/shacl-compact-syntax/tests/valid/basic-shape.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/basic-shape> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/class.ttl
+++ b/shacl-compact-syntax/tests/valid/class.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/class> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/comment.ttl
+++ b/shacl-compact-syntax/tests/valid/comment.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/comment> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/count-0-1.ttl
+++ b/shacl-compact-syntax/tests/valid/count-0-1.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/count-0-1> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/count-0-unlimited.ttl
+++ b/shacl-compact-syntax/tests/valid/count-0-unlimited.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/count-0-unlimited> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/count-1-2.ttl
+++ b/shacl-compact-syntax/tests/valid/count-1-2.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/count-1-2> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/count-1-unlimited.ttl
+++ b/shacl-compact-syntax/tests/valid/count-1-unlimited.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/count-1-unlimited> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/datatype.ttl
+++ b/shacl-compact-syntax/tests/valid/datatype.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/datatype> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/directives.ttl
+++ b/shacl-compact-syntax/tests/valid/directives.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/directives> .
-@prefix ex: <http://example.org/directives#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/nestedShape.ttl
+++ b/shacl-compact-syntax/tests/valid/nestedShape.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/nestedShape> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/node-or-2.ttl
+++ b/shacl-compact-syntax/tests/valid/node-or-2.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/node-or-2> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/node-or-3-not.ttl
+++ b/shacl-compact-syntax/tests/valid/node-or-3-not.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/node-or-3-not> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/nodeKind.ttl
+++ b/shacl-compact-syntax/tests/valid/nodeKind.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/nodeKind> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/path-alternative.ttl
+++ b/shacl-compact-syntax/tests/valid/path-alternative.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/path-alternative> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/path-complex.ttl
+++ b/shacl-compact-syntax/tests/valid/path-complex.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/path-complex> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/path-inverse.ttl
+++ b/shacl-compact-syntax/tests/valid/path-inverse.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/path-inverse> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/path-oneOrMore.ttl
+++ b/shacl-compact-syntax/tests/valid/path-oneOrMore.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/path-oneOrMore> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/path-sequence.ttl
+++ b/shacl-compact-syntax/tests/valid/path-sequence.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/path-sequence> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/path-zeroOrMore.ttl
+++ b/shacl-compact-syntax/tests/valid/path-zeroOrMore.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/path-zeroOrMore> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/path-zeroOrOne.ttl
+++ b/shacl-compact-syntax/tests/valid/path-zeroOrOne.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/path-zeroOrOne> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/property-empty.ttl
+++ b/shacl-compact-syntax/tests/valid/property-empty.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/property-empty> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/property-not.ttl
+++ b/shacl-compact-syntax/tests/valid/property-not.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/property-not> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/property-or-2.ttl
+++ b/shacl-compact-syntax/tests/valid/property-or-2.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/property-or-2> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/property-or-3.ttl
+++ b/shacl-compact-syntax/tests/valid/property-or-3.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/property-or-3> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl-compact-syntax/tests/valid/shapeRef.ttl
+++ b/shacl-compact-syntax/tests/valid/shapeRef.ttl
@@ -1,5 +1,5 @@
 @base <http://example.org/shapeRef> .
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl12-test-suite/tests/core/complex/personexample.ttl
+++ b/shacl12-test-suite/tests/core/complex/personexample.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/complex/personexample.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/misc/deactivated-001.ttl
+++ b/shacl12-test-suite/tests/core/misc/deactivated-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/deactivated-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/misc/deactivated-002.ttl
+++ b/shacl12-test-suite/tests/core/misc/deactivated-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/deactivated-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/misc/message-001.ttl
+++ b/shacl12-test-suite/tests/core/misc/message-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/message-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/misc/severity-001.ttl
+++ b/shacl12-test-suite/tests/core/misc/severity-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/severity-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/misc/severity-002.ttl
+++ b/shacl12-test-suite/tests/core/misc/severity-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/severity-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/and-001.ttl
+++ b/shacl12-test-suite/tests/core/node/and-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/and-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/and-002.ttl
+++ b/shacl12-test-suite/tests/core/node/and-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/and-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/class-001.ttl
+++ b/shacl12-test-suite/tests/core/node/class-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/class-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/class-002.ttl
+++ b/shacl12-test-suite/tests/core/node/class-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/class-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/class-003.ttl
+++ b/shacl12-test-suite/tests/core/node/class-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/class-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/closed-001.ttl
+++ b/shacl12-test-suite/tests/core/node/closed-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/closed-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/closed-002.ttl
+++ b/shacl12-test-suite/tests/core/node/closed-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/closed-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/datatype-001.ttl
+++ b/shacl12-test-suite/tests/core/node/datatype-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/datatype-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/datatype-002.ttl
+++ b/shacl12-test-suite/tests/core/node/datatype-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/datatype-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/disjoint-001.ttl
+++ b/shacl12-test-suite/tests/core/node/disjoint-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/disjoint-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/equals-001.ttl
+++ b/shacl12-test-suite/tests/core/node/equals-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/equals-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/expression-001.ttl
+++ b/shacl12-test-suite/tests/core/node/expression-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/expression-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/hasValue-001.ttl
+++ b/shacl12-test-suite/tests/core/node/hasValue-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/hasValue-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/in-001.ttl
+++ b/shacl12-test-suite/tests/core/node/in-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/in-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/languageIn-001.ttl
+++ b/shacl12-test-suite/tests/core/node/languageIn-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/languageIn-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/maxExclusive-001.ttl
+++ b/shacl12-test-suite/tests/core/node/maxExclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/maxExclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/maxInclusive-001.ttl
+++ b/shacl12-test-suite/tests/core/node/maxInclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/maxInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/maxLength-001.ttl
+++ b/shacl12-test-suite/tests/core/node/maxLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/maxLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/minExclusive-001.ttl
+++ b/shacl12-test-suite/tests/core/node/minExclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minExclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/minInclusive-001.ttl
+++ b/shacl12-test-suite/tests/core/node/minInclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/minInclusive-002.ttl
+++ b/shacl12-test-suite/tests/core/node/minInclusive-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/minInclusive-003.ttl
+++ b/shacl12-test-suite/tests/core/node/minInclusive-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/minLength-001.ttl
+++ b/shacl12-test-suite/tests/core/node/minLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/node-001.ttl
+++ b/shacl12-test-suite/tests/core/node/node-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/node-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/nodeKind-001.ttl
+++ b/shacl12-test-suite/tests/core/node/nodeKind-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/nodeKind-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/not-001.ttl
+++ b/shacl12-test-suite/tests/core/node/not-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/not-001#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/not-002.ttl
+++ b/shacl12-test-suite/tests/core/node/not-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/not-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/or-001.ttl
+++ b/shacl12-test-suite/tests/core/node/or-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/or-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/pattern-001.ttl
+++ b/shacl12-test-suite/tests/core/node/pattern-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/pattern-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/pattern-002.ttl
+++ b/shacl12-test-suite/tests/core/node/pattern-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/pattern-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/qualified-001-data.ttl
+++ b/shacl12-test-suite/tests/core/node/qualified-001-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i a ex:C1 .
 ex:j a ex:C1 , ex:C2 .

--- a/shacl12-test-suite/tests/core/node/qualified-001-shapes.ttl
+++ b/shacl12-test-suite/tests/core/node/qualified-001-shapes.ttl
@@ -1,6 +1,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s1 a sh:NodeShape ;
   sh:targetClass ex:C1 ;

--- a/shacl12-test-suite/tests/core/node/qualified-001.ttl
+++ b/shacl12-test-suite/tests/core/node/qualified-001.ttl
@@ -6,7 +6,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 <> a mf:Manifest ;
   mf:entries (

--- a/shacl12-test-suite/tests/core/node/xone-001.ttl
+++ b/shacl12-test-suite/tests/core/node/xone-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/xone-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/xone-duplicate-data.ttl
+++ b/shacl12-test-suite/tests/core/node/xone-duplicate-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i a ex:C1 .
 ex:j a ex:C1 , ex:C2 .

--- a/shacl12-test-suite/tests/core/node/xone-duplicate-shapes.ttl
+++ b/shacl12-test-suite/tests/core/node/xone-duplicate-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s1 a sh:NodeShape ;
   sh:targetClass ex:C1 ;

--- a/shacl12-test-suite/tests/core/node/xone-duplicate.ttl
+++ b/shacl12-test-suite/tests/core/node/xone-duplicate.ttl
@@ -6,7 +6,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 <> a mf:Manifest ;
   mf:entries (

--- a/shacl12-test-suite/tests/core/path/path-alternative-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-alternative-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-alternative-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-complex-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-complex-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-complex-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-complex-002-data.ttl
+++ b/shacl12-test-suite/tests/core/path/path-complex-002-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:j ex:p ex:i .
 

--- a/shacl12-test-suite/tests/core/path/path-complex-002-shapes.ttl
+++ b/shacl12-test-suite/tests/core/path/path-complex-002-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s1 a sh:PropertyShape ;
  sh:targetNode ex:i ;

--- a/shacl12-test-suite/tests/core/path/path-complex-002.ttl
+++ b/shacl12-test-suite/tests/core/path/path-complex-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-inverse-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-inverse-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-inverse-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-oneOrMore-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-oneOrMore-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-oneOrMore-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-sequence-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-sequence-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-sequence-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-sequence-002.ttl
+++ b/shacl12-test-suite/tests/core/path/path-sequence-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-sequence-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-sequence-duplicate-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-sequence-duplicate-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-sequence-duplicate-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-strange-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-strange-001.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl12-test-suite/tests/core/path/path-strange-002.ttl
+++ b/shacl12-test-suite/tests/core/path/path-strange-002.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/shacl12-test-suite/tests/core/path/path-unused-001-data.ttl
+++ b/shacl12-test-suite/tests/core/path/path-unused-001-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i a ex:C .
 

--- a/shacl12-test-suite/tests/core/path/path-unused-001-shapes.ttl
+++ b/shacl12-test-suite/tests/core/path/path-unused-001-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 

--- a/shacl12-test-suite/tests/core/path/path-unused-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-unused-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-zeroOrMore-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-zeroOrMore-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-zeroOrMore-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-zeroOrOne-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-zeroOrOne-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-zeroOrOne-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/and-001.ttl
+++ b/shacl12-test-suite/tests/core/property/and-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/and-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/class-001.ttl
+++ b/shacl12-test-suite/tests/core/property/class-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/class-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/datatype-001.ttl
+++ b/shacl12-test-suite/tests/core/property/datatype-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/datatype-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/datatype-002.ttl
+++ b/shacl12-test-suite/tests/core/property/datatype-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/datatype-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/datatype-003.ttl
+++ b/shacl12-test-suite/tests/core/property/datatype-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/datatype-003.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/datatype-ill-formed-data.ttl
+++ b/shacl12-test-suite/tests/core/property/datatype-ill-formed-data.ttl
@@ -1,5 +1,5 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i ex:p "300"^^xsd:byte .
 ex:i ex:p "55"^^xsd:integer .

--- a/shacl12-test-suite/tests/core/property/datatype-ill-formed-shapes.ttl
+++ b/shacl12-test-suite/tests/core/property/datatype-ill-formed-shapes.ttl
@@ -1,6 +1,6 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s a sh:PropertyShape ;
   sh:targetNode ex:i ;

--- a/shacl12-test-suite/tests/core/property/datatype-ill-formed.ttl
+++ b/shacl12-test-suite/tests/core/property/datatype-ill-formed.ttl
@@ -6,7 +6,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 <> rdf:type mf:Manifest ;
    mf:entries (

--- a/shacl12-test-suite/tests/core/property/disjoint-001.ttl
+++ b/shacl12-test-suite/tests/core/property/disjoint-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/disjoint-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/equals-001.ttl
+++ b/shacl12-test-suite/tests/core/property/equals-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/equals-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/hasValue-001.ttl
+++ b/shacl12-test-suite/tests/core/property/hasValue-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/hasValue-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/in-001.ttl
+++ b/shacl12-test-suite/tests/core/property/in-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/in-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/languageIn-001.ttl
+++ b/shacl12-test-suite/tests/core/property/languageIn-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/languageIn-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/lessThan-001.ttl
+++ b/shacl12-test-suite/tests/core/property/lessThan-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/lessThan-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/lessThan-002.ttl
+++ b/shacl12-test-suite/tests/core/property/lessThan-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/lessThan-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/lessThanOrEquals-001.ttl
+++ b/shacl12-test-suite/tests/core/property/lessThanOrEquals-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/lessThanOrEquals-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/maxCount-001.ttl
+++ b/shacl12-test-suite/tests/core/property/maxCount-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxCount-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/maxCount-002.ttl
+++ b/shacl12-test-suite/tests/core/property/maxCount-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxCount-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/maxExclusive-001.ttl
+++ b/shacl12-test-suite/tests/core/property/maxExclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxExclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/maxInclusive-001.ttl
+++ b/shacl12-test-suite/tests/core/property/maxInclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/maxLength-001.ttl
+++ b/shacl12-test-suite/tests/core/property/maxLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/minCount-001.ttl
+++ b/shacl12-test-suite/tests/core/property/minCount-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minCount-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/minCount-002.ttl
+++ b/shacl12-test-suite/tests/core/property/minCount-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minCount-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/minExclusive-001.ttl
+++ b/shacl12-test-suite/tests/core/property/minExclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minExclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/minExclusive-002.ttl
+++ b/shacl12-test-suite/tests/core/property/minExclusive-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minExclusive-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/minLength-001.ttl
+++ b/shacl12-test-suite/tests/core/property/minLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/node-001.ttl
+++ b/shacl12-test-suite/tests/core/property/node-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/node-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/node-002.ttl
+++ b/shacl12-test-suite/tests/core/property/node-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/node-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/nodeKind-001.ttl
+++ b/shacl12-test-suite/tests/core/property/nodeKind-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/nodeKind-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/not-001.ttl
+++ b/shacl12-test-suite/tests/core/property/not-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/not-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/or-001.ttl
+++ b/shacl12-test-suite/tests/core/property/or-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/or-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/or-datatypes-001.ttl
+++ b/shacl12-test-suite/tests/core/property/or-datatypes-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/or-datatypes-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/pattern-001.ttl
+++ b/shacl12-test-suite/tests/core/property/pattern-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/pattern-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/pattern-002.ttl
+++ b/shacl12-test-suite/tests/core/property/pattern-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/pattern-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/property-001.ttl
+++ b/shacl12-test-suite/tests/core/property/property-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/property-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/qualifiedMinCountDisjoint-001.ttl
+++ b/shacl12-test-suite/tests/core/property/qualifiedMinCountDisjoint-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/qualifiedMinCountDisjoint-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/qualifiedValueShape-001.ttl
+++ b/shacl12-test-suite/tests/core/property/qualifiedValueShape-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/qualifiedValueShape-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/qualifiedValueShapesDisjoint-001.ttl
+++ b/shacl12-test-suite/tests/core/property/qualifiedValueShapesDisjoint-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/qualifiedValueShapesDisjoint-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/singleLine-001.ttl
+++ b/shacl12-test-suite/tests/core/property/singleLine-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/singleLine-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/uniqueLang-001.ttl
+++ b/shacl12-test-suite/tests/core/property/uniqueLang-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/uniqueLang-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/uniqueLang-002-data.ttl
+++ b/shacl12-test-suite/tests/core/property/uniqueLang-002-data.ttl
@@ -1,3 +1,3 @@
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i ex:message "HI"@en, "Hi"@en .

--- a/shacl12-test-suite/tests/core/property/uniqueLang-002-shapes.ttl
+++ b/shacl12-test-suite/tests/core/property/uniqueLang-002-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:s1 a sh:PropertyShape ;

--- a/shacl12-test-suite/tests/core/property/uniqueLang-002.ttl
+++ b/shacl12-test-suite/tests/core/property/uniqueLang-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-complex-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/multipleTargets-001.ttl
+++ b/shacl12-test-suite/tests/core/targets/multipleTargets-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/multipleTargets-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/targetClass-001.ttl
+++ b/shacl12-test-suite/tests/core/targets/targetClass-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetClass-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/targetClassImplicit-001.ttl
+++ b/shacl12-test-suite/tests/core/targets/targetClassImplicit-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetClassImplicit-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/targetClassImplicit-002.ttl
+++ b/shacl12-test-suite/tests/core/targets/targetClassImplicit-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetClassImplicit-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/targetNode-001.ttl
+++ b/shacl12-test-suite/tests/core/targets/targetNode-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetNode-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/targetObjectsOf-001.ttl
+++ b/shacl12-test-suite/tests/core/targets/targetObjectsOf-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetObjectsOf-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/targetSubjectsOf-001.ttl
+++ b/shacl12-test-suite/tests/core/targets/targetSubjectsOf-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/targetSubjectsOf-002.ttl
+++ b/shacl12-test-suite/tests/core/targets/targetSubjectsOf-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/validation-reports/shared-data.ttl
+++ b/shacl12-test-suite/tests/core/validation-reports/shared-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 ex:i ex:p ex:j .
 ex:i ex:q ex:j .
 ex:j ex:r ex:k .

--- a/shacl12-test-suite/tests/core/validation-reports/shared-shapes.ttl
+++ b/shacl12-test-suite/tests/core/validation-reports/shared-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s1 a sh:NodeShape ;
   sh:targetNode ex:i ;

--- a/shacl12-test-suite/tests/core/validation-reports/shared.ttl
+++ b/shacl12-test-suite/tests/core/validation-reports/shared.ttl
@@ -6,7 +6,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 # This test case is under discussion, as there are different interpretations
 # on whether the nested sh:property constraint that is reached twice should

--- a/shacl12-test-suite/tests/sparql/component/nodeValidator-001.ttl
+++ b/shacl12-test-suite/tests/sparql/component/nodeValidator-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/component/nodeValidator-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -11,7 +11,7 @@
 <http://datashapes.org/sh/tests/sparql/component/nodeValidator-001.test>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
-      sh:namespace "http://datashapes.org/sh/tests/sparql/component/nodeValidator-001.test#"^^xsd:anyURI ;
+      sh:namespace "http://example.com/ns#"^^xsd:anyURI ;
       sh:prefix "ex" ;
     ] ;
 .

--- a/shacl12-test-suite/tests/sparql/component/optional-001.ttl
+++ b/shacl12-test-suite/tests/sparql/component/optional-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/component/optional-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -11,7 +11,7 @@
 <http://datashapes.org/sh/tests/sparql/component/optional-001.test>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
-      sh:namespace "http://datashapes.org/sh/tests/sparql/component/optional-001.test#"^^xsd:anyURI ;
+      sh:namespace "http://example.com/ns#"^^xsd:anyURI ;
       sh:prefix "ex" ;
     ] ;
 .

--- a/shacl12-test-suite/tests/sparql/component/propertyValidator-select-001.ttl
+++ b/shacl12-test-suite/tests/sparql/component/propertyValidator-select-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/component/propertyValidator-select-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/component/validator-001.ttl
+++ b/shacl12-test-suite/tests/sparql/component/validator-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/component/validator-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/node/prefixes-001.ttl
+++ b/shacl12-test-suite/tests/sparql/node/prefixes-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/node/prefixes-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -11,7 +11,7 @@
 <http://datashapes.org/sh/tests/sparql/node/prefixes-001.test>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
-      sh:namespace "http://datashapes.org/sh/tests/sparql/node/prefixes-001.test#"^^xsd:anyURI ;
+      sh:namespace "http://example.com/ns#"^^xsd:anyURI ;
       sh:prefix "ex" ;
     ] ;
 .

--- a/shacl12-test-suite/tests/sparql/node/sparql-001.ttl
+++ b/shacl12-test-suite/tests/sparql/node/sparql-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/node/sparql-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/node/sparql-002.ttl
+++ b/shacl12-test-suite/tests/sparql/node/sparql-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/node/sparql-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -11,7 +11,7 @@
 <http://datashapes.org/sh/tests/sparql/node/sparql-002.test>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
-      sh:namespace "http://datashapes.org/sh/tests/sparql/node/sparql-002.test#"^^xsd:anyURI ;
+      sh:namespace "http://example.com/ns#"^^xsd:anyURI ;
       sh:prefix "ex" ;
     ] ;
 .

--- a/shacl12-test-suite/tests/sparql/node/sparql-003.ttl
+++ b/shacl12-test-suite/tests/sparql/node/sparql-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/node/sparql-003.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -11,7 +11,7 @@
 <http://datashapes.org/sh/tests/sparql/node/sparql-003.test>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
-      sh:namespace "http://datashapes.org/sh/tests/sparql/node/sparql-003.test#"^^xsd:anyURI ;
+      sh:namespace "http://example.com/ns#"^^xsd:anyURI ;
       sh:prefix "ex" ;
     ] ;
 .

--- a/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-001.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-002.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-003.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-003.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-004.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-004.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-004.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-005.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-005.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-005.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-006.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-006.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-006.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-007.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-007.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-007.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/shapesGraph-001.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/shapesGraph-001.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/shapesGraph-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-001.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-001.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-002.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-002.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-003.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-003.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-003.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-004.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-004.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-004.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-005.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-005.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-005.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-006.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-006.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-006.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/property/property-select-001.ttl
+++ b/shacl12-test-suite/tests/sparql/property/property-select-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://example.org/ns#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/property/property-sparqlExpr-001.ttl
+++ b/shacl12-test-suite/tests/sparql/property/property-sparqlExpr-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://example.org/ns#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/property/sparql-001.ttl
+++ b/shacl12-test-suite/tests/sparql/property/sparql-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/property/sparql-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/targets/targetNode-select-001.ttl
+++ b/shacl12-test-suite/tests/sparql/targets/targetNode-select-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://example.org/ns#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/unmaintained/data-shapes-primer/ldomsquare.ldom.ttl
+++ b/unmaintained/data-shapes-primer/ldomsquare.ldom.ttl
@@ -7,7 +7,7 @@
 # Contact: Holger Knublauch (holger@topquadrant.com)
 
 @prefix arg: <http://www.w3.org/ns/ldom/arg#> .
-@prefix ex: <http://topbraid.org/examples/ldomsquare#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix ldom: <http://www.w3.org/ns/ldom/core#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .


### PR DESCRIPTION
Use <http://example.com/ns#> for ex: everywhere but without changing line endings.

This PR is a direct replacement for PR #362 and, if merged, #362 can be closed.

Closes #276 

Closes #362 