### PR TITLE
#393 clean up shacl shacl shape

### DIFF
--- a/shacl/shacl-shacl.ttl
+++ b/shacl/shacl-shacl.ttl
@@ -260,7 +260,6 @@ shsh:ShapeShape
 		sh:path sh:qualifiedValueShape ;
 		sh:maxCount 1 ;                 # multiple-parameters
 		sh:node shsh:ShapeShape ;       # qualifiedValueShape-node
-		sh:class sh:NodeShape ;         # qualifiedValueShape-class
 	] ;
 	sh:property [
 		sh:path sh:qualifiedValueShapesDisjoint ;

--- a/shacl/shacl-shacl.ttl
+++ b/shacl/shacl-shacl.ttl
@@ -110,7 +110,6 @@ shsh:ShapeShape
 		sh:path sh:severity ;
 		sh:maxCount 1 ;                 # severity-maxCount
 		sh:nodeKind sh:IRI ;            # severity-nodeKind
-		sh:in ( sh:Error sh:Warning sh:Info ) ; # severity-in
 	] ;
 	sh:property [
 		sh:path sh:message ;

--- a/shacl/shacl-shacl.ttl
+++ b/shacl/shacl-shacl.ttl
@@ -132,7 +132,6 @@ shsh:ShapeShape
 	sh:property [
 		sh:path sh:closed ;
 		sh:datatype xsd:boolean ;       # closed-datatype
-		sh:in ( true false ) ;          # closed-in
 		sh:maxCount 1 ;                 # multiple-parameters
 	] ;
 	sh:property [

--- a/shacl/shacl-shacl.ttl
+++ b/shacl/shacl-shacl.ttl
@@ -119,7 +119,6 @@ shsh:ShapeShape
 		sh:path sh:deactivated ;
 		sh:maxCount 1 ;                 # deactivated-maxCount
 		sh:datatype xsd:boolean ;       # deactivated-datatype
-		sh:in ( true false ) ;          # deactivated-in
 	] ;
 
 	sh:property [

--- a/shacl/shacl-shacl.ttl
+++ b/shacl/shacl-shacl.ttl
@@ -110,6 +110,7 @@ shsh:ShapeShape
 		sh:path sh:severity ;
 		sh:maxCount 1 ;                 # severity-maxCount
 		sh:nodeKind sh:IRI ;            # severity-nodeKind
+		sh:in ( sh:Error sh:Warning sh:Info ) ; # severity-in
 	] ;
 	sh:property [
 		sh:path sh:message ;
@@ -118,7 +119,8 @@ shsh:ShapeShape
 	sh:property [
 		sh:path sh:deactivated ;
 		sh:maxCount 1 ;                 # deactivated-maxCount
-		sh:in ( true false ) ;          # deactivated-datatype
+		sh:datatype xsd:boolean ;       # deactivated-datatype
+		sh:in ( true false ) ;          # deactivated-in
 	] ;
 
 	sh:property [
@@ -132,6 +134,7 @@ shsh:ShapeShape
 	sh:property [
 		sh:path sh:closed ;
 		sh:datatype xsd:boolean ;       # closed-datatype
+		sh:in ( true false ) ;          # closed-in
 		sh:maxCount 1 ;                 # multiple-parameters
 	] ;
 	sh:property [
@@ -182,6 +185,7 @@ shsh:ShapeShape
 		sh:path sh:maxCount ;
 		sh:datatype xsd:integer ;       # maxCount-datatype
 		sh:maxCount 1 ;                 # maxCount-maxCount
+		sh:minInclusive 0 ;              # maxCount-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:maxExclusive ;
@@ -197,11 +201,13 @@ shsh:ShapeShape
 		sh:path sh:maxLength ;
 		sh:datatype xsd:integer ;       # maxLength-datatype
 		sh:maxCount 1 ;                 # maxLength-maxCount
+		sh:minInclusive 0 ;             # maxLength-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:minCount ;
 		sh:datatype xsd:integer ;       # minCount-datatype
 		sh:maxCount 1 ;                 # minCount-maxCount
+		sh:minInclusive 0 ;             # minCount-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:minExclusive ;
@@ -217,6 +223,7 @@ shsh:ShapeShape
 		sh:path sh:minLength ;
 		sh:datatype xsd:integer ;       # minLength-datatype
 		sh:maxCount 1 ;                 # minLength-maxCount
+		sh:minInclusive 0 ;             # minLength-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:nodeKind ;
@@ -242,15 +249,19 @@ shsh:ShapeShape
 		sh:path sh:qualifiedMaxCount ;
 		sh:datatype xsd:integer ;       # qualifiedMaxCount-datatype
 		sh:maxCount 1 ;                 # multiple-parameters
+		sh:minInclusive 0 ;             # qualifiedMaxCount-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:qualifiedMinCount ;
 		sh:datatype xsd:integer ;       # qualifiedMinCount-datatype
 		sh:maxCount 1 ;                 # multiple-parameters
+		sh:minInclusive 0 ;             # qualifiedMinCount-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:qualifiedValueShape ;
 		sh:maxCount 1 ;                 # multiple-parameters
+		sh:node shsh:ShapeShape ;       # qualifiedValueShape-node
+		sh:class sh:NodeShape ;         # qualifiedValueShape-class
 	] ;
 	sh:property [
 		sh:path sh:qualifiedValueShapesDisjoint ;


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

~Closes #393 by `sh:in ( sh:Error sh:Warning sh:Info )` of the `sh:severity` property.~

Makes the following changes:
 - Applies `sh:minInclusive` constraint to appropriate properties such as `sh:minCount`
 - Makes the target class of `sh:qualifiedValueShape` a `sh:NodeShape` and sets `sh:node shsh:ShapeShape` 
