### PR TITLE
#173: Support `sh:message`, `sh:severity`, and `sh:deactivated` per constraint triple 

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2020,7 +2020,6 @@ ex:MyShape
 	a sh:NodeShape ;
 	<span class="target-can-be-skipped">sh:targetNode ex:MyInstance ;</span>
 	sh:property [
-		# The default severity here is sh:Violation
 		sh:path ex:myProperty ;
 		sh:maxLength 10 {|
 			sh:message "Too many characters"@en ;

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -1980,11 +1980,11 @@ ex:MyShape
 				</section>
 				
 				<section id="message">
-					<h4>Declaring Messages for a Shape</h4>
+					<h4>Declaring Messages for a Shape or Constraint</h4>
 					<p class="syntax">
 						Shapes can have values for the property <code>sh:message</code>.
-						<span data-syntax-rule="message-datatype">The values of <code>sh:message</code> in a shape are either <code>xsd:string</code> literals or literals with a language tag.</span>
-						A shape should not have more than one value for <code>sh:message</code> with the same language tag.
+						<span data-syntax-rule="message-datatype">The values of <code>sh:message</code> are either <code>xsd:string</code> literals or literals with a language tag.</span>
+						A subject should not have more than one value for <code>sh:message</code> with the same language tag.
 					</p>
 					<p>
 						If a shape has at least one value for <code>sh:message</code> in the shapes graph, then
@@ -1992,13 +1992,47 @@ ex:MyShape
 						as their value of <code>sh:resultMessage</code>, i.e. the values will be copied from the shapes graph
 						into the results graph.
 					</p>
+					<p>
+						In addition to declaring messages per shape, the property <code>sh:message</code> can also be used
+						on a <a>reifier</a> for a triple where the <a>shape</a> is the <a>subject</a> and one of the <a>parameters</a>
+						of the <a>constraint</a> is the <a>predicate</a>.
+					</p>
+					<p class="syntax">
+						<span data-syntax-rule="message-reifier-maxCount">
+						Let <code>T</code> be the set of <a>triples</a> that represent a <a>constraint</a> in a <a>shape</a>.
+						A <a>shapes graph</a> can specify at most one <a>value</a> for the property <code>sh:message</code>
+						in the <a>reifiers</a> of the <a>triples</a> in <code>T</code>.
+					</p>
 					<p><em>The remainder of this section is informative.</em></p>
 					<p>
-						The example from the previous section uses this mechanism to supply the second validation result
-						with two messages.
 						See the <a href="#results-message">section on <code>sh:resultMessage</code> in the validation results</a>
 						on further details on how the values of <code>sh:resultMessage</code> are populated.
 					</p>
+					<p>
+						The example from the previous section uses this mechanism to supply the second validation result
+						with two messages.
+						The following example is a variation where the message is declared using reification.
+					</p>
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
+ex:MyShape
+	a sh:NodeShape ;
+	<span class="target-can-be-skipped">sh:targetNode ex:MyInstance ;</span>
+	sh:property [
+		# The default severity here is sh:Violation
+		sh:path ex:myProperty ;
+		sh:maxLength 10 {|
+			sh:message "Too many characters"@en ;
+			sh:message "Zu viele Zeichen"@de ;
+		|}
+	] .
+							</div>
+							<div class="jsonld">
+								N/A
+							</div>
+						</div>
+					</aside>
 				</section>
 				
 				<section id="deactivated">
@@ -2982,6 +3016,7 @@ ex:SomeClass-alternativePathExample
 							While <code>sh:resultMessage</code> may have multiple values, there should not be two values with the same language tag.
 							These values are produced by a validation engine based on the values of <code>sh:message</code> of the constraints
 							in the shapes graph, see <a href="#message">Declaring Messages for a Shape</a>.
+							Messages declared using reification have precedence over those declared at the surrounding shape.
 							In cases where a constraint does not have any values for <code>sh:message</code> in the shapes graph the
 							SHACL processor MAY automatically generate other values for <code>sh:resultMessage</code>.
 						</p>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -1724,10 +1724,10 @@ ex:Bob ex:livesIn ex:NewYork .
 				</section>
 
 				<section id="severity">
-					<h4>Declaring the Severity of a Shape</h4>
+					<h4>Declaring the Severity of a Shape or Constraint</h4>
 					<p class="syntax">
 						<span data-syntax-rule="severity-maxCount">Shapes can specify one <a>value</a> for the property <code>sh:severity</code> in the <a>shapes graph</a>.</span>
-						<span data-syntax-rule="severity-nodeKind">Each value of <code>sh:severity</code> in a shape is an <a>IRI</a>.</span>
+						<span data-syntax-rule="severity-nodeKind">Each value of <code>sh:severity</code> is an <a>IRI</a>.</span>
 					</p>
 					<p>
 						The values of <code>sh:severity</code> are called <dfn data-lt="severity">severities</dfn>.
@@ -1752,6 +1752,17 @@ ex:Bob ex:livesIn ex:NewYork .
 							<td>A constraint violation.</td>
 						</tr>
 					</table>
+					<p>
+						In addition to declaring severities per shape, the property <code>sh:severity</code> can also be used
+						on a <a>reifier</a> for a triple where the <a>shape</a> is the <a>subject</a> and one of the <a>parameters</a>
+						of the <a>constraint</a> is the <a>predicate</a>.
+					</p>
+					<p class="syntax">
+						<span data-syntax-rule="severity-reifier-maxCount">
+						Let <code>T</code> be the set of <a>triples</a> that represent a <a>constraint</a> in a <a>shape</a>.
+						A <a>shapes graph</a> can specify at most one <a>value</a> for the property <code>sh:severity</code>
+						in the <a>reifiers</a> of the <a>triples</a> in <code>T</code>.
+					</p>
 					<p><em>The remainder of this section is informative.</em></p>
 					<p>
 						The specific values of <code>sh:severity</code> have no impact on the validation,
@@ -1761,7 +1772,7 @@ ex:Bob ex:livesIn ex:NewYork .
 						Any IRI can be used as a severity.
 					</p>
 					<p>
-						For every shape, <code>sh:Violation</code> is the default if <code>sh:severity</code> is unspecified.
+						For every shape and constraint, <code>sh:Violation</code> is the default if <code>sh:severity</code> is unspecified.
 						The following example illustrates this.
 					</p>
 					<aside class="example">
@@ -1935,6 +1946,34 @@ ex:MyInstance
 		}
 	]
 }</pre>
+							</div>
+						</div>
+					</aside>
+					<p>
+						The following example is a variation of the shapes graph above, but using reification to
+						specify the severity of individual constraints:
+					</p>
+					<aside class="example">
+						<div class="shapes-graph">
+							<div class="turtle">
+ex:MyShape
+	a sh:NodeShape ;
+	<span class="target-can-be-skipped">sh:targetNode ex:MyInstance ;</span>
+	sh:property [    # _:b1
+		sh:path ex:myProperty ;
+		sh:minCount 1 {| sh:severity sh:Info |} ;
+		sh:datatype xsd:string {| sh:severity sh:Warning |} ;
+	] ;
+	sh:property [    # _:b2
+		# The default severity here is sh:Violation
+		sh:path ex:myProperty ;
+		sh:maxLength 10 ;
+		sh:message "Too many characters"@en ;
+		sh:message "Zu viele Zeichen"@de ;
+	] .
+							</div>
+							<div class="jsonld">
+								N/A
 							</div>
 						</div>
 					</aside>
@@ -2951,9 +2990,13 @@ ex:SomeClass-alternativePathExample
 						<h4>Severity (sh:resultSeverity)</h4>
 						<p>
 							Each validation result has exactly one <a>value</a> for the property <code>sh:resultSeverity</code>, and this value is an <a>IRI</a>.
-							The value is equal to the <a>value</a> of <a href="#severity"><code>sh:severity</code></a> of the <a>shape</a> in the <a>shapes graph</a> that caused the result,
-							defaulting to <code>sh:Violation</code> if no <code>sh:severity</code> has been specified for the shape.
+							The value is determined by the following rules (in order):
 						</p>
+						<ol>
+							<li>the <a>value</a> of <a href="#severity"><code>sh:severity</code></a> at a <a>reifier</a> of any of the <a>triples</a> containing the <a>parameters</a> of the <a>constraint</a> that caused the result</li>
+							<li>the <a>value</a> of <a href="#severity"><code>sh:severity</code></a> of the <a>shape</a> in the <a>shapes graph</a> that caused the result</li>
+							<li>defaulting to <code>sh:Violation</code> if no <code>sh:severity</code> has been specified for the shape or constraint.</li>
+						</ol>
 					</section>
 				</section>
 			</section>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -503,6 +503,8 @@
 						<dfn data-cite="rdf12-concepts#dfn-literal" data-lt="literal|literals">literal</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-datatype" data-lt="datatype">datatype</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-blank-node" data-lt="blank node|blank nodes">blank node</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-triple-term" data-lt="triple term|triple terms">triple term</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-reifier" data-lt="reifier">reifier</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-node" data-lt="node|nodes">node</dfn> of an RDF graph,
 						<dfn data-cite="rdf12-concepts#dfn-rdf-term" data-lt="term|terms">RDF term</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-subject" data-lt="subject|subjects">subject</dfn>,
@@ -1961,10 +1963,10 @@ ex:MyInstance
 				</section>
 				
 				<section id="deactivated">
-					<h4>Deactivating a Shape</h4>
+					<h4>Deactivating Shapes and Constraints</h4>
 					<p class="syntax">
 						<span data-syntax-rule="deactivated-maxCount">Shapes can have at most one value for the property <code>sh:deactivated</code>.</span>
-						<span data-syntax-rule="deactivated-datatype">The value of <code>sh:deactivated</code> in a shape is a <a>node expression</a>
+						<span data-syntax-rule="deactivated-datatype">The value of <code>sh:deactivated</code> is a <a>node expression</a>
 						that must have either <code>true</code> or <code>false</code> as the (only) <a>output node</a>.</span>
 					</p>
 					<p>
@@ -1972,6 +1974,22 @@ ex:MyInstance
 						If <code>evalExpr(expr, <a>data graph</a>, <a>focus node</a>, {})</code> produces <code>true</code> as its only
 						<a>output node</a>, the shape is called <dfn data-lt="deactivate">deactivated</dfn>.
 						All RDF terms <a>conform</a> to a deactivated shape.
+					</p>
+					<p>
+						In addition to deactivating all constraints for a shape, it is also possible to deactivate individual constraints.
+						This is done using reification.
+					</p>
+					<p class="syntax">
+						<span data-syntax-rule="deactivated-reified-maxCount">A <a>triple</a> that has a <a>shape</a> as <a>subject</a>,
+						a <a>parameter</a> (such as <code>sh:minCount</code>) as <a>predicate</a> can have at most one
+						<a>reifier</a> with a <a>value</a> for the property <code>sh:deactivated</code>.</span>
+					</p>
+					<p>
+						Let <code>expr</code> be the <a>value</a> of <code>sh:deactivated</code> in a <a>reifier</a> on a <a>triple</a>
+						that has <a>shape</a> <a>subject</a> and a <a>parameter</a> as <a>predicate</a>.
+						If <code>evalExpr(expr, <a>data graph</a>, <a>focus node</a>, {})</code> produces <code>true</code> as its only
+						<a>output node</a>, the constraints that use the <a>triple</a> are called <dfn data-lt="deactivated constraint">deactivated constraints</dfn>.
+						Deactivated constraints do not produce any validation results.
 					</p>
 					<p><em>The remainder of this section is informative.</em></p>
 					<p>
@@ -1993,7 +2011,7 @@ ex:MyInstance
 						The following example illustrates the use of <code>sh:deactivated</code> to deactivate a shape.
 						In cases where shapes are imported from other graphs, the <code>sh:deactivated true</code> triple would be in the importing graph.
 					</p>
-					<aside class="example">
+					<aside class="example" title="Deactivating a property shape">
 						<div class="shapes-graph">
 							<div class="turtle">
 ex:PersonShape
@@ -2051,6 +2069,28 @@ ex:JohnDoe a ex:Person .
 	"@id": "ex:JohnDoe",
 	"@type": "ex:Person"
 }</pre>
+							</div>
+						</div>
+					</aside>
+					<p>
+						The following variation uses reification to deactivate just the <code>sh:minCount</code>
+						constraint without affecting other constraints at the same property shape.
+					</p>
+					<aside class="example" title="Deactivating individual constraints using reification">
+						<div class="shapes-graph">
+							<div class="turtle">
+ex:PersonShape
+	a sh:NodeShape ;
+	<span class="target-can-be-skipped">sh:targetClass ex:Person ;</span>
+	sh:property ex:PersonShape-name .
+
+ex:PersonShape-name
+	a sh:PropertyShape ;
+	sh:path ex:name ;
+	sh:minCount 1 {| sh:deactivated true |} ;
+	sh:maxCount 1 .
+							</div>
+							<div class="jsonld">
 							</div>
 						</div>
 					</aside>
@@ -6656,6 +6696,7 @@ ex:NameGroup
 				<li>Added the new class <a href="#ShapeClass"><code>sh:ShapeClass</code></a> for implicit class targets, see <a href="https://github.com/w3c/data-shapes/issues/212">Issue 212</a></li>
 				<li>Moved SPARQL-based validators from Core to an Appendix of SHACL-SPARQL, see <a href="https://github.com/w3c/data-shapes/issues/271">Issue 271</a></li>
 				<li>Added the new constraint component <a href="#ExpressionConstraintComponent"><code>sh:expression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/357">Issue 357</a></li>
+				<li>Values for <a href="#deactivated"><code>sh:deactivated</code></a>, <a href="#message"><code>sh:message</code></a> and <a href="#severity"><code>sh:severity</code></a> can now be specified using RDF 1.2 reification, see <a href="https://github.com/w3c/data-shapes/issues/173">Issue 173</a></li>
 			</ul>
 		</section>
 	</body>

--- a/shacl12-test-suite/tests/core/misc/deactivated-003.ttl
+++ b/shacl12-test-suite/tests/core/misc/deactivated-003.ttl
@@ -1,0 +1,43 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource
+  rdf:type rdfs:Resource ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:datatype xsd:boolean {| sh:deactivated true |} ;
+  sh:property ex:TestShape2 {| sh:deactivated true |} ;
+  sh:targetNode ex:InvalidResource ;
+.
+ex:TestShape2
+  rdf:type sh:PropertyShape ;
+  sh:path ex:property ;
+  sh:minCount 1 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <deactivated-003>
+    ) ;
+.
+<deactivated-003>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:deactivated 003" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "true"^^xsd:boolean ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl12-test-suite/tests/core/misc/manifest.ttl
+++ b/shacl12-test-suite/tests/core/misc/manifest.ttl
@@ -7,6 +7,7 @@
 	rdfs:label "Tests converted from http://datashapes.org/sh/tests/tests/core/misc" ;
 	mf:include <deactivated-001.ttl> ;
 	mf:include <deactivated-002.ttl> ;
+	mf:include <deactivated-003.ttl> ;
 	mf:include <message-001.ttl> ;
 	mf:include <severity-001.ttl> ;
 	mf:include <severity-002.ttl> ;

--- a/shacl12-test-suite/tests/core/misc/manifest.ttl
+++ b/shacl12-test-suite/tests/core/misc/manifest.ttl
@@ -9,6 +9,7 @@
 	mf:include <deactivated-002.ttl> ;
 	mf:include <deactivated-003.ttl> ;
 	mf:include <message-001.ttl> ;
+	mf:include <message-002.ttl> ;
 	mf:include <severity-001.ttl> ;
 	mf:include <severity-002.ttl> ;
 	mf:include <severity-003.ttl> ;

--- a/shacl12-test-suite/tests/core/misc/manifest.ttl
+++ b/shacl12-test-suite/tests/core/misc/manifest.ttl
@@ -11,4 +11,5 @@
 	mf:include <message-001.ttl> ;
 	mf:include <severity-001.ttl> ;
 	mf:include <severity-002.ttl> ;
+	mf:include <severity-003.ttl> ;
 	.

--- a/shacl12-test-suite/tests/core/misc/message-002.ttl
+++ b/shacl12-test-suite/tests/core/misc/message-002.ttl
@@ -1,0 +1,47 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:datatype xsd:integer {| sh:message "Test message"@en |} ;
+  sh:targetNode ex:InvalidNode ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <message-002>
+    ) ;
+.
+<message-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of custom sh:message 002" ;
+  rdfs:comment """
+  		Note: This test verifies that the sh:message is copied into sh:resultMessage.
+  		To pass this test, the test harness needs to preserve all sh:resultMessage triples
+  		that are mentioned in the 'expected' results graph.""" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidNode ;
+          sh:resultMessage "Test message"@en ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidNode ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl12-test-suite/tests/core/misc/severity-003.ttl
+++ b/shacl12-test-suite/tests/core/misc/severity-003.ttl
@@ -1,0 +1,42 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:datatype xsd:integer {| sh:severity sh:Warning |} ;
+  sh:targetNode "Hello" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <severity-003>
+    ) ;
+.
+<severity-003>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:severity 003" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Hello" ;
+          sh:resultSeverity sh:Warning ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Hello" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -116,8 +116,7 @@ sh:message
 sh:severity
 	a rdf:Property ;
 	rdfs:label "severity"@en ;
-	rdfs:comment "Defines the severity that validation results produced by a shape must have. Defaults to sh:Violation."@en ;
-	rdfs:domain sh:Shape ;
+	rdfs:comment "Defines the severity that validation results produced by a shape or constraint must have. Defaults to sh:Violation."@en ;
 	rdfs:range sh:Severity ;
 	rdfs:isDefinedBy sh: .
 


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #173

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-173/shacl12-core/index.html)
