### PR TITLE
Issue 172: Support for `sh:closed sh:ByTypes`

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -6140,23 +6140,23 @@ ex:Bob ex:age 23 {|
 							If <code>$closed</code> is <code>sh:ByTypes</code>, then <code>P</code> is the set of <a>IRI</a> properties
 							that can be reached from the value node via the following algorithm, plus <code>rdf:type</code>:
 							<div style="margin: 20px">
-							<code>
-function collectProperties(S)<br />
-&nbsp;&nbsp;add all IRI properties that can be reached from S via the SPARQL path<br />
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sh:property/sh:path<br />
-&nbsp;&nbsp;if S is a SHACL instance of rdfs:Class in the shapes graph {<br />
-&nbsp;&nbsp;&nbsp;&nbsp;for each triple in the shapes graph matching (S rdfs:subClassOf ?o)<br />
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;collectProperties(?o)<br />
-&nbsp;&nbsp;&nbsp;&nbsp;for each triple in the shapes graph matching (?s sh:targetClass S)<br />
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;collectProperties(?s)<br />
-&nbsp;&nbsp;}<br/>
-&nbsp;&nbsp;if S is a SHACL instance of sh:NodeShape in the shapes graph<br />
-&nbsp;&nbsp;&nbsp;&nbsp;for each triple in the shapes graph matching (S sh:node ?o)<br />
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;collectProperties(?o)<br />
-<br />
-for each rdf:type T of the value node in the data graph<br />
-&nbsp;&nbsp;collectProperties(T)<br />
-</code></div>
+							<pre class="text">
+function collectProperties(S)
+	add all IRI properties that can be reached from S via the SPARQL path
+			sh:property/sh:path
+	if S is a SHACL instance of rdfs:Class in the shapes graph {
+		for each triple in the shapes graph matching (S rdfs:subClassOf ?o)
+			collectProperties(?o)
+		for each triple in the shapes graph matching (?s sh:targetClass S)
+			collectProperties(?s)
+	}
+	if S is a SHACL instance of sh:NodeShape in the shapes graph
+		for each triple in the shapes graph matching (S sh:node ?o)
+			collectProperties(?o)
+
+for each rdf:type T of the value node in the data graph
+	collectProperties(T)
+</pre></div>
 							Note that implementations need to avoid infinite loops in the algorithm above by preventing
 							it from visiting the same `S` twice.
 						</div>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5969,7 +5969,7 @@ ex:Alice
 						in superclasses of the types of the current value node (via <code>rdfs:subClassOf</code>),
 						as well as other shapes that are linked to those types via <code>sh:targetClass</code> and
 						the shapes that can be reached from one node shape to the other via <code>sh:node</code>.
-						Examples for <code>sh:ByTypes</code>> can be found in the test case library:
+						Examples for <code>sh:ByTypes</code> can be found in the test case library:
 						<a href="../shacl12-test-suite/tests/core/node/closed-003.ttl">closed-003.ttl</a>,
 						<a href="../shacl12-test-suite/tests/core/node/closed-004.ttl">closed-004.ttl</a>.
 					</p>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5824,7 +5824,8 @@ ex:HandShape
 							<td><code>sh:closed</code></td>
 							<td>
 								Set to <code>true</code> to close the shape.
-								<span data-syntax-rule="closed-datatype">The values of <code>sh:closed</code> in a shape are literals with datatype <code>xsd:boolean</code>.</span>
+								<span data-syntax-rule="closed-datatype">The values of <code>sh:closed</code> in a shape are literals with datatype <code>xsd:boolean</code>
+									or the <a>IRI</a> <code>sh:ByTypes</code>.</span>
 							</td>
 						</tr>
 						<tr>
@@ -5841,14 +5842,41 @@ ex:HandShape
 						<div class="def-text-body" data-validator="Closed">
 							Let <code>$closed</code> be a <a>parameter value</a> for <code>sh:closed</code>.
 							Let <code>$ignoredProperties</code> be a <a>value</a> for <code>sh:ignoredProperties</code>.
-							If <code>$closed</code> is <code>true</code> then
-							there is a <a>validation result</a> for each <a>triple</a> that has a <a>value node</a> as its
-							<a>subject</a> and a <a>predicate</a> that is not explicitly enumerated as a <a>value</a> of <code>sh:path</code>
-							in any of the <a>property shapes</a> declared via <code>sh:property</code> at the current shape.
+							<br/><br/>
+							If <code>$closed</code> is <code>true</code> or <code>sh:ByTypes</code> and <code>P</code>
+							is the set of properties defined as below
+							then there is a <a>validation result</a> for each <a>triple</a> that has a <a>value node</a> as its
+							<a>subject</a> and a <a>predicate</a> that is not in <code>P</code>.
 							If <code>$ignoredProperties</code> has a value then the properties enumerated as <a>members</a> of this <a>SHACL list</a>
 							are also permitted for the <a>value node</a>.
 							The <a>validation result</a> MUST have the <a>predicate</a> of the triple as its <code>sh:resultPath</code>,
 							and the <a>object</a> of the triple as its <code>sh:value</code>.
+							<br/><br/>
+							If <code>$closed</code> is <code>true</code> then <code>P</code> is the set of <a>IRI</a> properties
+							that can be reached from the current shape via the SPARQL path <code>sh:property/sh:path</code>.
+							<br/><br/>
+							If <code>$closed</code> is <code>sh:ByTypes</code> then <code>P</code> is the set of <a>IRI</a> properties
+							that can be reached from the value node via the following algorithm, plus <code>rdf:type</code>:
+							<div style="margin: 20px">
+							<code>
+function collectProperties(S)<br />
+&nbsp;&nbsp;add all IRI properties that can be reached from S via the SPARQL path<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sh:property/sh:path<br />
+&nbsp;&nbsp;if S is a SHACL instance of rdfs:Class in the shapes graph {<br />
+&nbsp;&nbsp;&nbsp;&nbsp;for each triple in the shapes graph matching (S rdfs:subClassOf ?o)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;collectProperties(?o)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;for each triple in the shapes graph matching (?s sh:targetClass S)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;collectProperties(?s)<br />
+&nbsp;&nbsp;}<br/>
+&nbsp;&nbsp;if S is a SHACL instance of sh:NodeShape in the shapes graph<br />
+&nbsp;&nbsp;&nbsp;&nbsp;for each triple in the shapes graph matching (S sh:node ?o)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;collectProperties(?o)<br />
+<br />
+for each rdf:type T of the value node in the data graph<br />
+&nbsp;&nbsp;collectProperties(T)<br />
+</code></div>
+							Note that implementations need to avoid infinite loops in the algorithm above by preventing
+							to visit the same S twice.
 						</div>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
@@ -5936,6 +5964,15 @@ ex:Alice
 							</div>
 						</div>
 					</aside>
+					<p>
+						The use case for <code>sh:closed sh:ByTypes</code> includes properties that are declared
+						in superclasses of the types of the current value node (via <code>rdfs:subClassOf</code>),
+						as well as other shapes that are linked to those types via <code>sh:targetClass</code> and
+						the shapes that can be reached from one node shape to the other via <code>sh:node</code>.
+						Examples for <code>sh:ByTypes</code>> can be found in the test case library:
+						<a href="../shacl12-test-suite/tests/core/node/closed-003.ttl">closed-003.ttl</a>,
+						<a href="../shacl12-test-suite/tests/core/node/closed-004.ttl">closed-004.ttl</a>.
+					</p>
 				</section>
 				
 				<section id="HasValueConstraintComponent">

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -6142,20 +6142,20 @@ ex:Bob ex:age 23 {|
 							<div style="margin: 20px">
 							<pre class="text">
 function collectProperties(S)
-	add all IRI properties that can be reached from S via the SPARQL path
-			sh:property/sh:path
-	if S is a SHACL instance of rdfs:Class in the shapes graph {
-		for each triple in the shapes graph matching (S rdfs:subClassOf ?o)
-			collectProperties(?o)
-		for each triple in the shapes graph matching (?s sh:targetClass S)
-			collectProperties(?s)
-	}
-	if S is a SHACL instance of sh:NodeShape in the shapes graph
-		for each triple in the shapes graph matching (S sh:node ?o)
-			collectProperties(?o)
+    add all IRI properties that can be reached from S via the SPARQL path
+            sh:property/sh:path
+    if S is a SHACL instance of rdfs:Class in the shapes graph {
+        for each triple in the shapes graph matching (S rdfs:subClassOf ?o)
+            collectProperties(?o)
+        for each triple in the shapes graph matching (?s sh:targetClass S)
+            collectProperties(?s)
+    }
+    if S is a SHACL instance of sh:NodeShape in the shapes graph
+        for each triple in the shapes graph matching (S sh:node ?o)
+            collectProperties(?o)
 
 for each rdf:type T of the value node in the data graph
-	collectProperties(T)
+    collectProperties(T)
 </pre></div>
 							Note that implementations need to avoid infinite loops in the algorithm above by preventing
 							it from visiting the same `S` twice.

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -1111,7 +1111,7 @@ ex:PersonShape
 					<div class="diagram-class-properties">
 						<div class="diagram-class-properties-start">
 							<div><b><a href="#constraints">Constraint parameters</a></b>, for example:</div>
-							<div><a href="#ClosedConstraintComponent">sh:closed</a> : xsd:boolean</div>
+							<div><a href="#ClosedConstraintComponent">sh:closed</a> : xsd:boolean or sh:ByTypes</div>
 							<div><a href="#OrConstraintComponent">sh:or</a> : rdf:List</div>
 							<div><a href="#NotConstraintComponent">sh:not</a> : sh:Shape</div>
 							<div><a href="#PropertyConstraintComponent">sh:property</a> : sh:PropertyShape</div>
@@ -6656,6 +6656,7 @@ ex:NameGroup
 				<li>Added the new class <a href="#ShapeClass"><code>sh:ShapeClass</code></a> for implicit class targets, see <a href="https://github.com/w3c/data-shapes/issues/212">Issue 212</a></li>
 				<li>Moved SPARQL-based validators from Core to an Appendix of SHACL-SPARQL, see <a href="https://github.com/w3c/data-shapes/issues/271">Issue 271</a></li>
 				<li>Added the new constraint component <a href="#ExpressionConstraintComponent"><code>sh:expression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/357">Issue 357</a></li>
+				<li>Added the new value <code>sh:ByTypes</code> for <a href="#ClosedConstraintComponent"><code>sh:closed</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/172">Issue 172</a></li>
 			</ul>
 		</section>
 	</body>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5844,7 +5844,7 @@ ex:HandShape
 							Let <code>$ignoredProperties</code> be a <a>value</a> for <code>sh:ignoredProperties</code>.
 							<br/><br/>
 							If <code>$closed</code> is <code>true</code> or <code>sh:ByTypes</code> and <code>P</code>
-							is the set of properties defined as below
+							is the set of properties defined below,
 							then there is a <a>validation result</a> for each <a>triple</a> that has a <a>value node</a> as its
 							<a>subject</a> and a <a>predicate</a> that is not in <code>P</code>.
 							If <code>$ignoredProperties</code> has a value then the properties enumerated as <a>members</a> of this <a>SHACL list</a>
@@ -5852,10 +5852,10 @@ ex:HandShape
 							The <a>validation result</a> MUST have the <a>predicate</a> of the triple as its <code>sh:resultPath</code>,
 							and the <a>object</a> of the triple as its <code>sh:value</code>.
 							<br/><br/>
-							If <code>$closed</code> is <code>true</code> then <code>P</code> is the set of <a>IRI</a> properties
+							If <code>$closed</code> is <code>true</code>, then <code>P</code> is the set of <a>IRI</a> properties
 							that can be reached from the current shape via the SPARQL path <code>sh:property/sh:path</code>.
 							<br/><br/>
-							If <code>$closed</code> is <code>sh:ByTypes</code> then <code>P</code> is the set of <a>IRI</a> properties
+							If <code>$closed</code> is <code>sh:ByTypes</code>, then <code>P</code> is the set of <a>IRI</a> properties
 							that can be reached from the value node via the following algorithm, plus <code>rdf:type</code>:
 							<div style="margin: 20px">
 							<code>
@@ -5876,7 +5876,7 @@ for each rdf:type T of the value node in the data graph<br />
 &nbsp;&nbsp;collectProperties(T)<br />
 </code></div>
 							Note that implementations need to avoid infinite loops in the algorithm above by preventing
-							to visit the same S twice.
+							it from visiting the same `S` twice.
 						</div>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
@@ -6690,10 +6690,10 @@ ex:NameGroup
 			<ul>
 				<li>Introduced <a>node expressions</a> as an extension point to dynamically compute lists of nodes. Generalized <code>sh:targetNode</code>, <code>sh:deactivated</code> and <code>sh:defaultValue</code>, and introduced <code>sh:values</code> to support node expressions.</li>
 				<li>Added the new constraint component <a href="#SingleLineConstraintComponent"><code>sh:singleLine</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/177">Issue 177</a></li>
-				<li>Added the new class <a href="#ShapeClass"><code>sh:ShapeClass</code></a> for implicit class targets, see <a href="https://github.com/w3c/data-shapes/issues/212">Issue 212</a></li>
-				<li>Moved SPARQL-based validators from Core to an Appendix of SHACL-SPARQL, see <a href="https://github.com/w3c/data-shapes/issues/271">Issue 271</a></li>
-				<li>Added the new constraint component <a href="#ExpressionConstraintComponent"><code>sh:expression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/357">Issue 357</a></li>
-				<li>Added the new value <code>sh:ByTypes</code> for <a href="#ClosedConstraintComponent"><code>sh:closed</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/172">Issue 172</a></li>
+				<li>Added the new class <a href="#ShapeClass"><code>sh:ShapeClass</code></a> for implicit class targets; see <a href="https://github.com/w3c/data-shapes/issues/212">Issue 212</a></li>
+				<li>Moved SPARQL-based validators from Core to an Appendix of SHACL-SPARQL; see <a href="https://github.com/w3c/data-shapes/issues/271">Issue 271</a></li>
+				<li>Added the new constraint component <a href="#ExpressionConstraintComponent"><code>sh:expression</code></a>; see <a href="https://github.com/w3c/data-shapes/issues/357">Issue 357</a></li>
+				<li>Added the new value <code>sh:ByTypes</code> for <a href="#ClosedConstraintComponent"><code>sh:closed</code></a>; see <a href="https://github.com/w3c/data-shapes/issues/172">Issue 172</a></li>
 			</ul>
 		</section>
 	</body>

--- a/shacl12-test-suite/tests/core/node/closed-003.ttl
+++ b/shacl12-test-suite/tests/core/node/closed-003.ttl
@@ -1,0 +1,68 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:RootClass
+  a rdfs:Class, sh:NodeShape ;
+  sh:property [ sh:path ex:rootClassProperty1 ] ;
+  sh:closed sh:ByTypes ;
+  sh:ignoredProperties ( rdf:type ) ;
+.
+ex:SubClass
+  a rdfs:Class, sh:NodeShape ;
+  rdfs:subClassOf ex:RootClass ;
+  sh:property [ sh:path ex:subClassProperty1 ] ;
+  sh:property [ sh:path ex:subClassProperty2 ] ;
+  sh:closed sh:ByTypes ;
+  sh:ignoredProperties ( rdf:type ) ;
+.
+
+# Invalid because it uses ex:subClassProperty1 but it's not an instance of SubClass
+ex:InvalidInstance1
+  a ex:RootClass ;
+  ex:subClassProperty1 1 ;
+.
+ex:ValidInstance1
+  a ex:RootClass ;
+  ex:rootClassProperty1 1 ;
+.
+ex:ValidInstance2
+  a ex:SubClass ;
+  ex:rootClassProperty1 1 ;
+  ex:subClassProperty1 3 ;
+  ex:subClassProperty2 4 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <closed-003>
+    ) ;
+.
+<closed-003>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:closed at node shape 003" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:subClassProperty1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClosedConstraintComponent ;
+          sh:sourceShape ex:RootClass ;
+          sh:value 1 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl12-test-suite/tests/core/node/closed-003.ttl
+++ b/shacl12-test-suite/tests/core/node/closed-003.ttl
@@ -12,7 +12,6 @@ ex:RootClass
   a rdfs:Class, sh:NodeShape ;
   sh:property [ sh:path ex:rootClassProperty1 ] ;
   sh:closed sh:ByTypes ;
-  sh:ignoredProperties ( rdf:type ) ;
 .
 ex:SubClass
   a rdfs:Class, sh:NodeShape ;
@@ -20,7 +19,6 @@ ex:SubClass
   sh:property [ sh:path ex:subClassProperty1 ] ;
   sh:property [ sh:path ex:subClassProperty2 ] ;
   sh:closed sh:ByTypes ;
-  sh:ignoredProperties ( rdf:type ) ;
 .
 
 # Invalid because it uses ex:subClassProperty1 but it's not an instance of SubClass

--- a/shacl12-test-suite/tests/core/node/closed-004.ttl
+++ b/shacl12-test-suite/tests/core/node/closed-004.ttl
@@ -57,12 +57,12 @@ ex:ValidInstance2
 <>
   rdf:type mf:Manifest ;
   mf:entries (
-      <closed-003>
+      <closed-004>
     ) ;
 .
-<closed-003>
+<closed-004>
   rdf:type sht:Validate ;
-  rdfs:label "Test of sh:closed at node shape 003" ;
+  rdfs:label "Test of sh:closed at node shape 004" ;
   mf:action [
       sht:dataGraph <> ;
       sht:shapesGraph <> ;

--- a/shacl12-test-suite/tests/core/node/closed-004.ttl
+++ b/shacl12-test-suite/tests/core/node/closed-004.ttl
@@ -1,0 +1,84 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:RootClass
+  a rdfs:Class, sh:NodeShape ;
+  sh:property [ sh:path ex:rootClassProperty1 ] ;
+  sh:closed sh:ByTypes ;
+.
+ex:SubClass
+  a rdfs:Class, sh:NodeShape ;
+  rdfs:subClassOf ex:RootClass ;
+  sh:property [ sh:path ex:subClassProperty1 ] ;
+  sh:property [ sh:path ex:subClassProperty2 ] ;
+.
+ex:RootShape
+  a sh:NodeShape ;
+  sh:targetClass ex:RootClass ;
+  sh:property [ sh:path ex:rootShapeProperty1 ] ;
+.
+ex:SubShape
+  a sh:NodeShape ;
+  sh:targetClass ex:SubClass ;
+  sh:node ex:SuperShape ;
+  sh:property [ sh:path ex:subShapeProperty1 ] ;
+.
+ex:SuperShape
+  a sh:NodeShape ;
+  sh:property [ sh:path ex:superShapeProperty1 ] ;
+.
+
+# Invalid because it uses ex:subClassProperty1 but it's not an instance of SubClass
+ex:InvalidInstance1
+  a ex:RootClass ;
+  ex:subClassProperty1 1 ;
+.
+ex:ValidInstance1
+  a ex:RootClass ;
+  ex:rootClassProperty1 1 ;
+  ex:rootShapeProperty1 2 ;
+.
+ex:ValidInstance2
+  a ex:SubClass ;
+  ex:rootClassProperty1 1 ;
+  ex:rootShapeProperty1 2 ;
+  ex:subClassProperty1 3 ;
+  ex:subClassProperty2 4 ;
+  ex:subShapeProperty1 5 ;
+  ex:superShapeProperty1 6 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <closed-003>
+    ) ;
+.
+<closed-003>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:closed at node shape 003" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:subClassProperty1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClosedConstraintComponent ;
+          sh:sourceShape ex:RootClass ;
+          sh:value 1 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl12-test-suite/tests/core/node/manifest.ttl
+++ b/shacl12-test-suite/tests/core/node/manifest.ttl
@@ -12,6 +12,8 @@
 	mf:include <class-003.ttl> ;
 	mf:include <closed-001.ttl> ;
 	mf:include <closed-002.ttl> ;
+	mf:include <closed-003.ttl> ;
+	mf:include <closed-004.ttl> ;
 	mf:include <datatype-001.ttl> ;
 	mf:include <datatype-002.ttl> ;
 	mf:include <disjoint-001.ttl> ;

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -534,7 +534,6 @@ sh:ClosedConstraintComponent
 sh:ClosedConstraintComponent-closed
 	a sh:Parameter ; 
 	sh:path sh:closed ;
-	sh:datatype xsd:boolean ;
 	rdfs:isDefinedBy sh: .
 
 sh:ClosedConstraintComponent-ignoredProperties


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #172

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-172/shacl12-core/index.html)
