### PR TITLE
Issue 159: SHACL SPARQL cannot use `VALUES`?

### DIFF
--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -1536,7 +1536,6 @@ ex:Resource-uriLength
 					<li>SPARQL queries must not contain a federated query (<code>SERVICE</code>)</li>
 					<li>SPARQL queries must not contain a <code>VALUES</code> clause that mentions any potentially pre-bound variable</li>
 					<li>SPARQL queries must not use the syntax form ​​<code>AS ?var</code> for any potentially pre-bound variable</li>
-					<li><a data-cite="sparql12-query/#subqueries">Subqueries</a> must return all potentially pre-bound variables, except <code>shapesGraph</code> and <code>currentShape</code> which are optional as already mentioned in <a href="#sparql-constraints-prebound"></a></li> 
 				</ul>
 			</div>
 
@@ -1848,7 +1847,7 @@ ASK {
 				<li>Added the <a>node expression function</a> <a href="#SelectExpression"><code>sh:SelectExpression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/288">Issue 288</a></li>
 				<li>Added support for <a>annotation properties</a>, see <a href="https://github.com/w3c/data-shapes/issues/327">Issue 327</a></li>
 				<li>Added the <a>node expression function</a> <a href="#SPARQLExprExpression"><code>sh:SPARQLExprExpression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/315">Issue 315</a></li>
-				<li>Clarified that VALUES clauses are only disallowed when they mention <a href="#pre-binding">pre-bound variables</a>, see <a href="https://github.com/w3c/data-shapes/issues/159">Issue 159</a></li>
+				<li>Clarified that VALUES clauses are only disallowed when they mention <a href="#pre-binding">pre-bound variables</a> and removed the restriction on sub-SELECTs, see <a href="https://github.com/w3c/data-shapes/issues/159">Issue 159</a></li>
 			</ul>
 		</section>		
 		  

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -1534,7 +1534,7 @@ ex:Resource-uriLength
 				<ul>
 					<li>SPARQL queries must not contain a <code>MINUS</code> clause</li>
 					<li>SPARQL queries must not contain a federated query (<code>SERVICE</code>)</li>
-					<li>SPARQL queries must not contain a <code>VALUES</code> clause</li>
+					<li>SPARQL queries must not contain a <code>VALUES</code> clause that mentions any potentially pre-bound variable</li>
 					<li>SPARQL queries must not use the syntax form ​​<code>AS ?var</code> for any potentially pre-bound variable</li>
 					<li><a data-cite="sparql12-query/#subqueries">Subqueries</a> must return all potentially pre-bound variables, except <code>shapesGraph</code> and <code>currentShape</code> which are optional as already mentioned in <a href="#sparql-constraints-prebound"></a></li> 
 				</ul>
@@ -1848,6 +1848,7 @@ ASK {
 				<li>Added the <a>node expression function</a> <a href="#SelectExpression"><code>sh:SelectExpression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/288">Issue 288</a></li>
 				<li>Added support for <a>annotation properties</a>, see <a href="https://github.com/w3c/data-shapes/issues/327">Issue 327</a></li>
 				<li>Added the <a>node expression function</a> <a href="#SPARQLExprExpression"><code>sh:SPARQLExprExpression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/315">Issue 315</a></li>
+				<li>Clarified that VALUES clauses are only disallowed when they mention <a href="#pre-binding">pre-bound variables</a>, see <a href="https://github.com/w3c/data-shapes/issues/159">Issue 159</a></li>
 			</ul>
 		</section>		
 		  


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #159

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-159/shacl12-sparql/index.html)
