### PR TITLE
#401 fix: move shacl-shacl changes to shacl12-vocabularies

### DIFF
--- a/shacl/shacl-shacl.ttl
+++ b/shacl/shacl-shacl.ttl
@@ -118,7 +118,7 @@ shsh:ShapeShape
 	sh:property [
 		sh:path sh:deactivated ;
 		sh:maxCount 1 ;                 # deactivated-maxCount
-		sh:datatype xsd:boolean ;       # deactivated-datatype
+		sh:in ( true false ) ;          # deactivated-datatype
 	] ;
 
 	sh:property [
@@ -182,7 +182,6 @@ shsh:ShapeShape
 		sh:path sh:maxCount ;
 		sh:datatype xsd:integer ;       # maxCount-datatype
 		sh:maxCount 1 ;                 # maxCount-maxCount
-		sh:minInclusive 0 ;              # maxCount-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:maxExclusive ;
@@ -198,13 +197,11 @@ shsh:ShapeShape
 		sh:path sh:maxLength ;
 		sh:datatype xsd:integer ;       # maxLength-datatype
 		sh:maxCount 1 ;                 # maxLength-maxCount
-		sh:minInclusive 0 ;             # maxLength-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:minCount ;
 		sh:datatype xsd:integer ;       # minCount-datatype
 		sh:maxCount 1 ;                 # minCount-maxCount
-		sh:minInclusive 0 ;             # minCount-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:minExclusive ;
@@ -220,7 +217,6 @@ shsh:ShapeShape
 		sh:path sh:minLength ;
 		sh:datatype xsd:integer ;       # minLength-datatype
 		sh:maxCount 1 ;                 # minLength-maxCount
-		sh:minInclusive 0 ;             # minLength-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:nodeKind ;
@@ -246,18 +242,15 @@ shsh:ShapeShape
 		sh:path sh:qualifiedMaxCount ;
 		sh:datatype xsd:integer ;       # qualifiedMaxCount-datatype
 		sh:maxCount 1 ;                 # multiple-parameters
-		sh:minInclusive 0 ;             # qualifiedMaxCount-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:qualifiedMinCount ;
 		sh:datatype xsd:integer ;       # qualifiedMinCount-datatype
 		sh:maxCount 1 ;                 # multiple-parameters
-		sh:minInclusive 0 ;             # qualifiedMinCount-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:qualifiedValueShape ;
 		sh:maxCount 1 ;                 # multiple-parameters
-		sh:node shsh:ShapeShape ;       # qualifiedValueShape-node
 	] ;
 	sh:property [
 		sh:path sh:qualifiedValueShapesDisjoint ;

--- a/shacl12-vocabularies/shacl-shacl.ttl
+++ b/shacl12-vocabularies/shacl-shacl.ttl
@@ -119,7 +119,7 @@ shsh:ShapeShape
 	sh:property [
 		sh:path sh:deactivated ;
 		sh:maxCount 1 ;                 # deactivated-maxCount
-		sh:in ( true false ) ;          # deactivated-datatype
+		sh:datatype xsd:boolean ;       # deactivated-datatype
 	] ;
 
 	sh:property [
@@ -183,6 +183,7 @@ shsh:ShapeShape
 		sh:path sh:maxCount ;
 		sh:datatype xsd:integer ;       # maxCount-datatype
 		sh:maxCount 1 ;                 # maxCount-maxCount
+		sh:minInclusive 0 ;              # maxCount-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:maxExclusive ;
@@ -198,11 +199,13 @@ shsh:ShapeShape
 		sh:path sh:maxLength ;
 		sh:datatype xsd:integer ;       # maxLength-datatype
 		sh:maxCount 1 ;                 # maxLength-maxCount
+		sh:minInclusive 0 ;             # maxLength-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:minCount ;
 		sh:datatype xsd:integer ;       # minCount-datatype
 		sh:maxCount 1 ;                 # minCount-maxCount
+		sh:minInclusive 0 ;             # minCount-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:minExclusive ;
@@ -218,6 +221,7 @@ shsh:ShapeShape
 		sh:path sh:minLength ;
 		sh:datatype xsd:integer ;       # minLength-datatype
 		sh:maxCount 1 ;                 # minLength-maxCount
+		sh:minInclusive 0 ;             # minLength-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:nodeKind ;
@@ -243,15 +247,18 @@ shsh:ShapeShape
 		sh:path sh:qualifiedMaxCount ;
 		sh:datatype xsd:integer ;       # qualifiedMaxCount-datatype
 		sh:maxCount 1 ;                 # multiple-parameters
+		sh:minInclusive 0 ;             # qualifiedMaxCount-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:qualifiedMinCount ;
 		sh:datatype xsd:integer ;       # qualifiedMinCount-datatype
 		sh:maxCount 1 ;                 # multiple-parameters
+		sh:minInclusive 0 ;             # qualifiedMinCount-minInclusive
 	] ;
 	sh:property [
 		sh:path sh:qualifiedValueShape ;
 		sh:maxCount 1 ;                 # multiple-parameters
+		sh:node shsh:ShapeShape ;       # qualifiedValueShape-node
 	] ;
 	sh:property [
 		sh:path sh:qualifiedValueShapesDisjoint ;


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Moves changes to correct shacl-shacl document

Closes #401 - in particular resolving https://github.com/w3c/data-shapes/issues/401#issuecomment-2962468700
