### PR TITLE
feat: #192 add severity levels that are not violations

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -1740,6 +1740,14 @@ ex:Bob ex:livesIn ex:NewYork .
 							<th>Description</th>
 						</tr>
 						<tr>
+							<td><code>sh:Trace</code></td>
+							<td>A trace message that is not a violation.</td>
+						</tr>
+						<tr>
+							<td><code>sh:Debug</code></td>
+							<td>A debug message that is not a violation.</td>
+						</tr>
+						<tr>
 							<td><code>sh:Info</code></td>
 							<td>A non-critical constraint violation indicating an informative message.</td>
 						</tr>
@@ -1752,6 +1760,10 @@ ex:Bob ex:livesIn ex:NewYork .
 							<td>A constraint violation.</td>
 						</tr>
 					</table>
+					<p>
+						Validation engines may treat <code>sh:Info</code> and <code>sh:Warning</code> as non-violating based on
+						options passed to the engine. By default, they must be treated as violations.
+					</p>
 					<p>
 						In addition to declaring severities per shape, the property <code>sh:severity</code> can also be used
 						on a <a>reifier</a> for a triple where the <a>shape</a> is the <a>subject</a> and one of the <a>parameters</a>
@@ -2917,7 +2929,7 @@ ex:SomeClass-alternativePathExample
 						<p>
 							Each SHACL instance of <code>sh:ValidationReport</code> in the results graph has exactly one value for the property <code>sh:conforms</code> and the value is of datatype <code>xsd:boolean</code>.
 							It represents the outcome of the <a>conformance checking</a>.
-							The value of <code>sh:conforms</code> is <code>true</code> if and only if the <a>validation</a> did not produce any <a>validation results</a>, and <code>false</code> otherwise.
+							The value of <code>sh:conforms</code> is <code>true</code> if and only if the <a>validation</a> did not produce any <a>validation results</a> with a severity level representing a violation, and <code>false</code> otherwise.
 						</p>
 					</section>
 					<section id="result">

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -1761,8 +1761,8 @@ ex:Bob ex:livesIn ex:NewYork .
 						</tr>
 					</table>
 					<p>
-						Validation engines may treat <code>sh:Info</code> and <code>sh:Warning</code> as non-violating based on
-						options passed to the engine. By default, they must be treated as violations.
+						Validation engines MAY treat <code>sh:Info</code> and <code>sh:Warning</code> as non-violating based on
+						options passed to the engine. By default, they are treated as violations.
 					</p>
 					<p>
 						In addition to declaring severities per shape, the property <code>sh:severity</code> can also be used
@@ -2814,7 +2814,7 @@ ex:SomeClass-alternativePathExample
 				<h3>Conformance Checking</h3>
 				<p>
 					A <a>focus node</a> <dfn data-lt="conform|conformance">conforms</dfn> to a <a>shape</a> if and only if
-					the set of result of the <a>validation</a> of the <a>focus node</a> against the <a>shape</a> is empty and no <a>failure</a>
+					the set of result of the <a>validation</a> of the <a>focus node</a> against the <a>shape</a> does not contain any results with a severity level representing a violation and no <a>failure</a>
 					has been reported by it.
 				</p>
 				<p>

--- a/shacl12-test-suite/tests/core/misc/manifest.ttl
+++ b/shacl12-test-suite/tests/core/misc/manifest.ttl
@@ -13,4 +13,6 @@
 	mf:include <severity-001.ttl> ;
 	mf:include <severity-002.ttl> ;
 	mf:include <severity-003.ttl> ;
+	mf:include <severity-004.ttl> ;
+	mf:include <severity-005.ttl> ;
 	.

--- a/shacl12-test-suite/tests/core/misc/severity-004.ttl
+++ b/shacl12-test-suite/tests/core/misc/severity-004.ttl
@@ -1,0 +1,43 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:datatype xsd:integer ;
+  sh:severity sh:Debug ;
+  sh:targetNode "Hello" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <severity-004>
+    ) ;
+.
+<severity-004>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:severity sh:Debug 004" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "true"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Hello" ;
+          sh:resultSeverity sh:Debug ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Hello" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl12-test-suite/tests/core/misc/severity-005.ttl
+++ b/shacl12-test-suite/tests/core/misc/severity-005.ttl
@@ -1,0 +1,43 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:datatype xsd:integer ;
+  sh:severity sh:Trace ;
+  sh:targetNode "Hello" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <severity-005>
+    ) ;
+.
+<severity-005>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:severity sh:Trace 005" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "true"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Hello" ;
+          sh:resultSeverity sh:Trace ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Hello" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -221,6 +221,18 @@ sh:Severity
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:isDefinedBy sh: .
 
+sh:Trace
+	a sh:Severity ;
+	rdfs:label "Trace"@en ;
+	rdfs:comment "The severity for a trace validation result."@en ;
+	rdfs:isDefinedBy sh: .
+
+sh:Debug
+	a sh:Severity ;
+	rdfs:label "Debug"@en ;
+	rdfs:comment "The severity for a debug validation result."@en ;
+	rdfs:isDefinedBy sh: .
+
 sh:Info
 	a sh:Severity ;
 	rdfs:label "Info"@en ;


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

This PR closes #192 "Add severity levels that are not violations". It contains the following changes:

- Adds `sh:Trace` and `sh:Debug` severity levels that aren't violations.
- Allows validation engines to treat `sh:Info` and `sh:Warning` as non-violating.
- Changes the definition of `sh:conforms` of being true when there are no results to being true if there are no results with a severity level that is a violation.

A rule based on RDF classes for sh:conforms would have been preferred, but since it's possible to dynamically set sh:Info and sh:Warning being a violation, that is not possible.

Allowing validation engines to treat levels as non-violating but keeping the default makes this a non-breaking change.

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-192-severity-levels/shacl12-core/index.html)
