### PR TITLE
Issue 419: Add shaclc snippets

### DIFF
--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -1,4 +1,5 @@
 import rdf from 'rdf-ext'
+import { parse } from 'shaclc-parse'
 
 async function parseJsonld (jsonld, context = {}) {
   try {
@@ -23,7 +24,16 @@ async function parseTurtle (turtle, prefixes = '') {
   }
 }
 
+async function parseShaclc (shaclc, prefixes = '') {
+  try {
+    return rdf.dataset(parse(`${prefixes}\n${shaclc}`))
+  } catch (err) {
+    return null
+  }
+}
+
 export {
   parseJsonld,
-  parseTurtle
+  parseTurtle,
+  parseShaclc
 }

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -13,7 +13,9 @@
         "commander": "^13.1.0",
         "jsdom": "^26.1.0",
         "mkdirp": "^3.0.1",
-        "rdf-ext": "^2.5.2"
+        "rdf-ext": "^2.5.2",
+        "shaclc-parse": "^1.4.3",
+        "shaclc-write": "^1.5.0"
       },
       "devDependencies": {
         "stricter-standard": "^0.3.1"
@@ -277,6 +279,18 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@jeswr/prefixcc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jeswr/prefixcc/-/prefixcc-1.2.1.tgz",
+      "integrity": "sha512-kBBXbqsaeh3Irp416h/RbelqJgIOp6X/OJJlYmLyr/9qlBYKTKSCuEv5/xjZ0Yf8Yec+QFRYBaOQ2JkMBSH7KA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1091,6 +1105,57 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/cross-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/cross-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2115,6 +2180,20 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -3937,6 +4016,34 @@
         "readable-stream": "^4.3.0"
       }
     },
+    "node_modules/rdf-string-ttl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rdf-string-ttl/-/rdf-string-ttl-1.3.2.tgz",
+      "integrity": "sha512-yqolaVoUvTaSC5aaQuMcB4BL54G/pCGsV4jQH87f0TvAx8zHZG0koh7XWrjva/IPGcVb1QTtaeEdfda5mcddJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/rdf-string-ttl/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rdf-string-ttl/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
     "node_modules/rdfxml-streaming-parser": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-3.0.1.tgz",
@@ -4278,6 +4385,27 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/shaclc-parse": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/shaclc-parse/-/shaclc-parse-1.4.3.tgz",
+      "integrity": "sha512-MQJWVFjfzzMUvieFO0STWjIo49ywy63UkVSsr0e8+8xHUns6X+i3yWYxNKd+GtSEJjBNZxxrUubog+hnd7PvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0",
+        "n3": "^1.16.3"
+      }
+    },
+    "node_modules/shaclc-write": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/shaclc-write/-/shaclc-write-1.5.0.tgz",
+      "integrity": "sha512-5+uFmw28BUqCW5UC4FyFwB8VTsdzPyh4LB2pAI5DRjn6xWgl1bsfied9K9HbQYrONNtmhLpPFse79N3Tvj+kLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jeswr/prefixcc": "^1.2.1",
+        "n3": "^1.16.3",
+        "rdf-string-ttl": "^1.3.2"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,7 +14,9 @@
     "commander": "^13.1.0",
     "jsdom": "^26.1.0",
     "mkdirp": "^3.0.1",
-    "rdf-ext": "^2.5.2"
+    "rdf-ext": "^2.5.2",
+    "shaclc-parse": "^1.4.3",
+    "shaclc-write": "^1.5.0"
   },
   "devDependencies": {
     "stricter-standard": "^0.3.1"

--- a/scripts/sync-code-snippets.js
+++ b/scripts/sync-code-snippets.js
@@ -8,8 +8,9 @@ import { Command } from 'commander'
 import jsdom from 'jsdom'
 import { mkdirp } from 'mkdirp'
 import rdf from 'rdf-ext'
+import { write as shaclcWrite } from 'shaclc-write'
 import prettyJsonld from './lib/prettyJsonld.js'
-import { parseJsonld, parseTurtle } from './lib/utils.js'
+import { parseJsonld, parseTurtle, parseShaclc } from './lib/utils.js'
 
 rdf.formats.import(pretty)
 
@@ -40,10 +41,29 @@ const turtlePrefixes = `
 @prefix ex: <http://example.com/ns#>.
 `
 
+const shaclcPrefixes = 
+  'BASE <http://example.com/>' +
+  turtlePrefixes.replaceAll('@prefix', 'PREFIX').replaceAll('.', '')
+
 function escape (str) {
   return str
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;')
+}
+
+// Convert Turtle shapes to SHACL Compact Syntax using shaclc-write
+async function convertTurtleToShaclc (dataset) {
+  // Convert to SHACL-C using shaclc-write
+  const result = await shaclcWrite(dataset, { prefixes: jsonldContext['@context'], requireBase: false })
+  const shaclcContent = result.text
+  
+  // Clean up the output (remove base and unwanted prefixes)
+  let cleanedShaclc = shaclcContent
+    .replace(/^BASE\s+<[^>]+>\s*\n/i, '')
+    .replace(/^PREFIX\s+\w*:\s*<[^>]+>\s*\n/gmi, '')
+    .trim()
+
+  return cleanedShaclc
 }
 
 class Snippet {
@@ -69,9 +89,11 @@ class Snippet {
 
       this.turtleContent = this.root.querySelector('.turtle')?.textContent
       this.jsonldContent = this.root.querySelector('.jsonld pre.jsonld')?.textContent
+      this.shaclcContent = this.root.querySelector('.shaclc pre.shaclc')?.textContent
 
       this.jsonldRdf = await parseJsonld(this.jsonldContent, jsonldContext)
       this.turtleRdf = await parseTurtle(this.turtleContent, turtlePrefixes)
+      this.shaclcRdf = this.shaclcContent ? await parseShaclc(this.shaclcContent, shaclcPrefixes) : null;
 
       if (this.turtleRdf) {
         const jsonldStr = await rdf.io.dataset.toText('application/ld+json', this.turtleRdf, { context: jsonldContext })
@@ -81,11 +103,28 @@ class Snippet {
         jsonldFull = prettyJsonld(jsonldFull)
 
         this.jsonldExpected = JSON.stringify(jsonldFull, null, '\t')
-        this.isExpected = this.jsonldExpected === this.jsonldContent
+        this.isJsonExpected = this.jsonldExpected === this.jsonldContent
+
+        if (this.root.classList.contains('shapes-graph')) {
+          try {
+            this.shaclcExpected = await convertTurtleToShaclc(this.turtleRdf)
+          } catch (err) {
+            console.error(`Error converting Turtle to SHACL-C for ${this.id}:`)
+            this.shaclcExpected = null
+          }
+          if (this.shaclcExpected) {
+            this.isShaclcExpected = this.shaclcExpected === this.shaclcContent
+          } else {
+            this.isShaclcExpected = true
+          }
+        }
       }
 
       if (this.jsonldRdf && this.turtleRdf) {
-        this.isEqual = this.jsonldRdf.equals(this.turtleRdf)
+        this.isJsonldEqual = this.jsonldRdf.equals(this.turtleRdf)
+      }
+      if (this.shaclcRdf && this.turtleRdf) {
+        this.isShaclcEqual = this.shaclcRdf.equals(this.turtleRdf)
       }
     } catch (err) {
       this.error = err.message
@@ -116,6 +155,15 @@ class Snippet {
     if (this.jsonldExpected) {
       await writeFile(join(base, `${this.indexStr}-jsonld-expected.json`), escape(this.jsonldExpected))
     }
+    if (this.shaclcContent) {
+      await writeFile(join(base, `${this.indexStr}-shaclc-content.shce`), this.shaclcContent)
+    }
+    if (this.shaclcRdf) {
+      await writeFile(join(base, `${this.indexStr}-shaclc-rdf.ttl`), this.shaclcRdf.toCanonical())
+    }
+    if (this.shaclcExpected) {
+      await writeFile(join(base, `${this.indexStr}-shaclc-expected.shce`), escape(this.shaclcExpected))
+    }
   }
 
   static async from (root, options) {
@@ -127,11 +175,12 @@ class Snippet {
   }
 }
 
-async function main (path, { output, spec, writeEqual }) {
+async function main (path, { output, spec, writeEqual, writeShaclc, writeJsonld }) {
   try {
     const content = await readFile(path, { encoding: 'utf8' })
     const dom = new jsdom.JSDOM(content)
     const snippets = [...dom.window.document.querySelectorAll('.shapes-graph, .data-graph, .results-graph')]
+    let documentModified = false
 
     await mkdirp(output)
 
@@ -151,12 +200,22 @@ async function main (path, { output, spec, writeEqual }) {
       if (!snippet.jsonldContent) {
         console.log(`${snippet.id}: JSON-LD content missing`)
 
+        // Write back to spec if enabled
+        if (writeJsonld && snippet.jsonldExpected) {
+          const jsonldElement = snippet.root.querySelector('.jsonld pre.jsonld')
+          if (jsonldElement) {
+            jsonldElement.textContent = snippet.jsonldExpected
+            documentModified = true
+            console.log(`${snippet.id}: Updated JSON-LD content in spec`)
+          }
+        }
+
         await snippet.write(output)
-      } else if (!snippet.isEqual) {
+      } else if (!snippet.isJsonldEqual) {
         console.log(`${snippet.id}: JSON-LD triples are different from turtle`)
 
         await snippet.write(output)
-      } else if (!snippet.isExpected) {
+      } else if (!snippet.isJsonExpected) {
         console.log(`${snippet.id}: JSON-LD content doesn't look as expected`)
 
         await snippet.write(output)
@@ -165,6 +224,55 @@ async function main (path, { output, spec, writeEqual }) {
           await snippet.write(output)
         }
       }
+
+      if (snippet.root.classList.contains('shapes-graph')) {
+        if (!snippet.shaclcContent) {
+          console.log(`${snippet.id}: SHACL-C content missing`)
+
+          // Write back to spec if enabled
+          if (writeShaclc && snippet.shaclcExpected) {
+            console.log(`${snippet.id}: Writing SHACL-C content to spec`)
+            let shaclcElement = snippet.root.querySelector('.shaclc pre.shaclc')
+
+            // If the element does not exist, create it
+            if (!shaclcElement) {
+              const divElement = dom.window.document.createElement('div')
+              divElement.className = 'shaclc'
+              const preElement = dom.window.document.createElement('pre')
+              preElement.className = 'shaclc'
+              preElement.textContent = snippet.shaclcExpected
+              divElement.appendChild(preElement)
+              snippet.root.appendChild(divElement)
+            } else {
+              shaclcElement.textContent = snippet.shaclcExpected
+            }
+
+            documentModified = true
+            console.log(`${snippet.id}: Updated SHACL-C content in spec`)
+          }
+
+          await snippet.write(output)
+        } else if (!snippet.isShaclcEqual) {
+          console.log(`${snippet.id}: SHACL-C triples are different from turtle`)
+
+          await snippet.write(output)
+        } else if (!snippet.isShaclcExpected) {
+          console.log(`${snippet.id}: SHACL-C content doesn't look as expected`)
+
+          await snippet.write(output)
+        } else {
+          if (writeEqual) {
+            await snippet.write(output)
+          }
+        }
+      }
+    }
+    if (documentModified) {
+      const updatedContent = dom.serialize() + '\n'
+      await writeFile(path, updatedContent, { encoding: 'utf8' })
+      console.log(`Updated specification file: ${path}`)
+    } else {
+      console.log('No changes made to the specification file.')
     }
   } catch (err) {
     console.error(err)
@@ -178,6 +286,8 @@ program
   .option('-o, --output <path>', 'output folder')
   .option('-s, --spec <id>', 'id of the specification')
   .option('--write-equal', 'write snippets that are equal')
+  .option('--write-shaclc', 'write shaclc to the specification file')
+  .option('--write-jsonld', 'write jsonld to the specification file')
   .action(async (path, { ...options }) => {
     if (!options.spec) {
       options.spec = path.split(sep).slice(-2)[0]

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -70,9 +70,14 @@
 				for (const tabs of document.querySelectorAll(".ds-selector-tabs")) {
 					const selectors = document.createElement("div");
 					selectors.classList.add("selectors");
+					
+					// Check if shaclc div exists in this tab group
+					const hasShaclc = tabs.querySelector(".shaclc");
+					
 					selectors.innerHTML = `
 						<button class="selected" data-selects="turtle">Turtle</button>
 						<button data-selects="jsonld">JSON-LD</button>
+						${hasShaclc ? '<button data-selects="shaclc">SHACL-C</button>' : ''}
 					`
 
 					tabs.prepend(selectors);

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -1,9 +1,7 @@
-<!DOCTYPE html>
-<html>
-	<head>
+<!DOCTYPE html><html><head>
 		<title>SHACL 1.2 Core</title>
 		<meta charset="utf-8">
-		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer=""></script>
 		<script class="remove">
 		
 			function prepareSyntaxRules() {
@@ -522,7 +520,7 @@
 						with <a>subject</a> <code>n</code>, <a>predicate</a> <code>p</code>, and <a>object</a> <code>v</code>.
 						The phrase "Every value of P in graph G ..." means "Every object of a triple in G with predicate P ...".
 						(In this document, the verbs <em>specify</em> or <em>declare</em> are sometimes used to express the fact that an RDF term has values for a given predicate in a graph.)
-						<br />
+						<br>
 						<dfn data-lt="SPARQL property path">SPARQL property paths</dfn> are defined as in <a href="https://www.w3.org/TR/sparql12-query/#pp-language">SPARQL 1.2</a>.
 						An RDF term <code>n</code> has value <code>v</code> for <a>SPARQL property path</a> expression
 						<code>p</code> in an RDF graph <code>G</code> if there is a solution mapping in the result of the SPARQL query
@@ -539,7 +537,7 @@
 						for the property <code>rdf:first</code> in <code>G</code> and exactly one <a>value</a>
 						for the property <code>rdf:rest</code> in <code>G</code> that is also a SHACL list in <code>G</code>,
 						and the list does not have itself as a value of the property path <code>rdf:rest+</code> in <code>G</code>.</span>
-						<br />
+						<br>
 						The  <dfn data-lt="member">members</dfn> of any SHACL list except <code>rdf:nil</code> in an RDF
 						graph <code>G</code> consist of its value for <code>rdf:first</code> in <code>G</code> followed by
 						the members in <code>G</code> of its value for <code>rdf:rest</code> in <code>G</code>.
@@ -605,10 +603,13 @@
 					Within this document, the following namespace prefix definitions are used:
 				</p>
 				<table class="term-table">
-					<tr>
+					<thead>
+						<tr>
 						<th>Prefix</th>
 						<th>Namespace</th>
 					</tr>
+				</thead>
+				<tbody>
 					<tr>
 						<td><code>owl:</code></td>
 						<td><code>http://www.w3.org/2002/07/owl#</code></td>
@@ -633,7 +634,8 @@
 						<td><code>ex:</code></td>
 						<td><code>http://example.com/ns#</code></td>
 					</tr>
-				</table>
+				</tbody>
+			</table>
 
 				<p>
 					Within this document, the following JSON-LD context is used:
@@ -1110,7 +1112,7 @@ ex:PersonShape
 					</div>
 				</div>
 				<div style="height: 60px; margin-left: 260px">
-					<img alt="Class Diagram Arrows" src="images/Class-Diagram-Arrows.png" />
+					<img alt="Class Diagram Arrows" src="images/Class-Diagram-Arrows.png">
 				</div>
 				<div style="white-space: nowrap; min-width: 1000px">
 				<div class="diagram-class" style="float: left; margin-right: 60px;">
@@ -1597,7 +1599,7 @@ ex:NewYork a ex:Place .
 							<div class="shapes-graph">
 								<div class="turtle">
 ex:Person
-	<b>a sh:ShapeClass</b> .</pre>
+	<b>a sh:ShapeClass</b> .
 								</div>
 								<div class="jsonld">
 									<pre class="jsonld">{
@@ -1746,7 +1748,7 @@ ex:Bob ex:livesIn ex:NewYork .
 						These are declared in the SHACL vocabulary as SHACL instances of <code>sh:Severity</code>.
 					</p>
 					<table class="term-table">
-						<tr>
+						<tbody><tr>
 							<th>Severity</th>
 							<th>Description</th>
 						</tr>
@@ -1762,7 +1764,7 @@ ex:Bob ex:livesIn ex:NewYork .
 							<td><code>sh:Violation</code></td>
 							<td>A constraint violation.</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<p>
 						In addition to declaring severities per shape, the property <code>sh:severity</code> can also be used
 						on a <a>reifier</a> for a triple where the <a>shape</a> is the <a>subject</a> and one of the <a>parameters</a>
@@ -1773,7 +1775,7 @@ ex:Bob ex:livesIn ex:NewYork .
 						Let <code>T</code> be the set of <a>triples</a> that represent a <a>constraint</a> in a <a>shape</a>.
 						A <a>shapes graph</a> can specify at most one <a>value</a> for the property <code>sh:severity</code>
 						in the <a>reifiers</a> of the <a>triples</a> in <code>T</code>.
-					</p>
+					</span></p>
 					<p><em>The remainder of this section is informative.</em></p>
 					<p>
 						The specific values of <code>sh:severity</code> have no impact on the validation,
@@ -2013,7 +2015,7 @@ ex:MyShape
 						Let <code>T</code> be the set of <a>triples</a> that represent a <a>constraint</a> in a <a>shape</a>.
 						A <a>shapes graph</a> can specify at most one <a>value</a> for the property <code>sh:message</code>
 						in the <a>reifiers</a> of the <a>triples</a> in <code>T</code>.
-					</p>
+					</span></p>
 					<p><em>The remainder of this section is informative.</em></p>
 					<p>
 						See the <a href="#results-message">section on <code>sh:resultMessage</code> in the validation results</a>
@@ -2202,10 +2204,10 @@ ex:PersonShape-name
 					<span data-syntax-rule="path-maxCount">A shape has at most one <a>value</a> for <code>sh:path</code>.</span>
 					<span data-syntax-rule="path-node">The <a>value</a> of <code>sh:path</code> in a property shape is a <a>well-formed</a>
 					<a>SHACL property path</a>.</span>
-					<br/><br/>
+					<br><br>
 					It is recommended, but not required, for a <a>property shape</a> to be declared as a <a>SHACL instance</a> of <code>sh:PropertyShape</code>.
 					<span data-syntax-rule="PropertyShape-path-minCount"><a>SHACL instances</a> of <code>sh:PropertyShape</code> have one <a>value</a> for the property <code>sh:path</code>.</span>
-					<br/><br/>
+					<br><br>
 					<span data-syntax-rule="path-values">A <a>property shape</a> has at most one <a>value</a> for the property <code>sh:values</code> and this <a>value</a> is a <a>well-formed</a> <a>node expression</a>.</span>
 					<span data-syntax-rule="path-defaultValue">A <a>property shape</a> has at most one <a>value</a> for the property <code>sh:defaultValue</code> and this <a>value</a> is a <a>well-formed</a> <a>node expression</a>.</span>
 					<span data-syntax-rule="path-values-iri">A <a>property shape</a> can only have <a>values</a> for <code>sh:values</code> and/or <code>sh:defaultValue</code> when its <a>value</a> for <code>sh:path</code> is a <a href="#property-path-predicate">Predicate Path</a>.</span>
@@ -2546,7 +2548,7 @@ ex:SomeClass-alternativePathExample
 			</div>
 			<div class="def" id="node-expression-evaluation">
 				<div class="def-header">EVALUATION OF NODE EXPRESSIONS</div>
-				The <dfn>evaluation</dfn> of a node expression is defined as a function <code>evalExpr(expr, focusGraph, focusNode, scope) -> outputNodes</code>
+				The <dfn>evaluation</dfn> of a node expression is defined as a function <code>evalExpr(expr, focusGraph, focusNode, scope) -&gt; outputNodes</code>
 				where
 				<ul>
 					<li><code>expr</code> is a <a>node expression</a> in a <a>shapes graph</a>.
@@ -2579,9 +2581,9 @@ ex:SomeClass-alternativePathExample
 					<div class="def-header">EVALUATION OF IRI EXPRESSIONS</div>
 					<p>
 						The <a>output nodes</a> of an <a>IRI expression</a> are the list consisting of exactly the <a>node expression</a> itself:
-						<br/>
-						<br/>
-						<code>evalExpr(expr, focusGraph, focusNode, scope) -> [expr]</code>
+						<br>
+						<br>
+						<code>evalExpr(expr, focusGraph, focusNode, scope) -&gt; [expr]</code>
 					</p>
 				</div>
 			</section>
@@ -2598,9 +2600,9 @@ ex:SomeClass-alternativePathExample
 					<div class="def-header">EVALUATION OF LITERAL EXPRESSIONS</div>
 					<p>
 						The <a>output nodes</a> of a <a>literal expression</a> are the list consisting of exactly the <a>node expression</a> itself:
-						<br/>
-						<br/>
-						<code>evalExpr(expr, focusGraph, focusNode, scope) -> [expr]</code>
+						<br>
+						<br>
+						<code>evalExpr(expr, focusGraph, focusNode, scope) -&gt; [expr]</code>
 					</p>
 				</div>
 			</section>
@@ -3113,7 +3115,7 @@ ex:SomeClass-alternativePathExample
 			<p>
 				Note that these validators define the <em>only</em> validation results that are being produced by the component.
 				Furthermore, the validators always produce <em>new</em> result nodes, i.e. when the textual definition states that
-				&quot;...there is a validation result...&quot; then this refers to a distinct new node in a results graph.
+				"...there is a validation result..." then this refers to a distinct new node in a results graph.
 			</p>
 			<p><em>The remainder of this section is informative.</em></p>
 			<p>
@@ -3148,10 +3150,12 @@ ex:SomeClass-alternativePathExample
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:class</code></td>
 							<td>
@@ -3160,7 +3164,7 @@ ex:SomeClass-alternativePathExample
 								or <a>blank nodes</a> that are <a>well-formed</a> <a>SHACL lists</a> where all <a>members</a> are <a>IRIs</a>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Class">
@@ -3168,7 +3172,7 @@ ex:SomeClass-alternativePathExample
 							Let <code>classes</code> be a set of <a>IRIs</a> so that
 							when <code>$class</code> is an <a>IRI</a> then the set only consists of exactly that IRI,
 							and when <code>$class</code> is a <a>blank node</a> <a>SHACL list</a> then the set consists of
-							exactly the members of the list.<br /><br />
+							exactly the members of the list.<br><br>
 							For each <a>value node</a>
 							that is either a <a>literal</a>, or a non-literal that is not a <a>SHACL instance</a> of any of the <code>classes</code> in the <a>data graph</a>,
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
@@ -3296,10 +3300,12 @@ ex:Alice a ex:Person ; ex:pet ex:Tessie, ex:Rusty .
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:datatype</code></td>
 							<td>
@@ -3309,7 +3315,7 @@ ex:Alice a ex:Person ; ex:pet ex:Tessie, ex:Rusty .
 								or a <a>blank node</a> that is a <a>well-formed</a> <a>SHACL list</a> where all <a>members</a> are <a>IRIs</a>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Datatype">
@@ -3317,10 +3323,10 @@ ex:Alice a ex:Person ; ex:pet ex:Tessie, ex:Rusty .
 							Let <code>datatypes</code> be a set of <a>IRIs</a> so that
 							when <code>$datatype</code> is an <a>IRI</a> then the set only consists of exactly that IRI,
 							and when <code>$datatype</code> is a <a>blank node</a> <a>SHACL list</a> then the set consists of
-							exactly the members of the list.<br /><br />
+							exactly the members of the list.<br><br>
 							For each <a>value node</a>
 							that is not a <a>literal</a>, or is a <a>literal</a> with a datatype that matches none of the <code>datatypes</code>,
-							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.<br /><br />
+							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.<br><br>
 							The datatype of a literal is determined following the <a data-cite="sparql12-query/#func-datatype">datatype</a> function of SPARQL 1.2.
 							A <a>literal</a> matches a datatype if the <a>literal</a>'s datatype has the same <a>IRI</a>
 							and, for the datatypes supported by SPARQL 1.2, is not an <a data-cite="rdf12-concepts#section-Graph-Literal">ill-typed</a> literal.
@@ -3421,7 +3427,7 @@ ex:TextExampleShape
 						<div class="data-graph">
 							<div class="turtle">
 ex:Estonia rdfs:label "Estonia", "Estland"@de .
-<span class="focus-node-error">ex:GreatBritain</span> rdfs:label "Great Britain", "&lt;b&gt;Great&lt/b&gt; Britain"^^rdf:HTML .
+<span class="focus-node-error">ex:GreatBritain</span> rdfs:label "Great Britain", "&lt;b&gt;Great&lt;/b&gt; Britain"^^rdf:HTML .
 							</div>
 							<div class="jsonld">
 							</div>
@@ -3440,10 +3446,12 @@ ex:Estonia rdfs:label "Estonia", "Estland"@de .
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:nodeKind</code></td>
 							<td>
@@ -3454,7 +3462,7 @@ ex:Estonia rdfs:label "Estonia", "Estland"@de .
 								<span data-syntax-rule="nodeKind-maxCount">A shape has at most one value for <code>sh:nodeKind</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="NodeKind">
@@ -3535,10 +3543,12 @@ ex:Bob ex:knows ex:Alice .
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:minCount</code></td>
 							<td>
@@ -3548,7 +3558,7 @@ ex:Bob ex:knows ex:Alice .
 								<span data-syntax-rule="minCount-datatype">The values of <code>sh:minCount</code> in a property shape are literals with datatype <code>xsd:integer</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MinCount">
@@ -3626,10 +3636,12 @@ ex:MinCountExampleShape
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:maxCount</code></td>
 							<td>
@@ -3639,7 +3651,7 @@ ex:MinCountExampleShape
 								<span data-syntax-rule="maxCount-datatype">The values of <code>sh:maxCount</code> in a property shape are literals with datatype <code>xsd:integer</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MaxCount">
@@ -3785,10 +3797,12 @@ ex:Bob ex:age 23 .
 					</p>
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:minExclusive</code></td>
 							<td>
@@ -3797,7 +3811,7 @@ ex:Bob ex:age 23 .
 								<span data-syntax-rule="minExclusive-maxCount">A shape has at most one value for <code>sh:minExclusive</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MinExclusive">
@@ -3821,10 +3835,12 @@ ex:Bob ex:age 23 .
 					</p>
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:minInclusive</code></td>
 							<td>
@@ -3833,7 +3849,7 @@ ex:Bob ex:age 23 .
 								<span data-syntax-rule="minInclusive-maxCount">A shape has at most one value for <code>sh:minInclusive</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MinInclusive">
@@ -3852,10 +3868,12 @@ ex:Bob ex:age 23 .
 					</p>
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:maxExclusive</code></td>
 							<td>
@@ -3864,7 +3882,7 @@ ex:Bob ex:age 23 .
 								<span data-syntax-rule="maxExclusive-maxCount">A shape has at most one value for <code>sh:maxExclusive</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MaxExclusive">
@@ -3883,10 +3901,12 @@ ex:Bob ex:age 23 .
 					</p>
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:maxInclusive</code></td>
 							<td>
@@ -3895,7 +3915,7 @@ ex:Bob ex:age 23 .
 								<span data-syntax-rule="maxInclusive-maxCount">A shape has at most one value for <code>sh:maxInclusive</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MaxInclusive">
@@ -3926,10 +3946,12 @@ ex:Bob ex:age 23 .
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:minLength</code></td>
 							<td>
@@ -3938,7 +3960,7 @@ ex:Bob ex:age 23 .
 								<span data-syntax-rule="minLength-maxCount">A shape has at most one value for <code>sh:minLength</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MinLength">
@@ -3969,10 +3991,12 @@ ex:Bob ex:age 23 .
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:maxLength</code></td>
 							<td>
@@ -3981,7 +4005,7 @@ ex:Bob ex:age 23 .
 								<span data-syntax-rule="maxLength-maxCount">A shape has at most one value for <code>sh:maxLength</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MaxLength">
@@ -4068,10 +4092,12 @@ ex:Bob ex:password "123456789" .
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:pattern</code></td>
 							<td>
@@ -4087,7 +4113,7 @@ ex:Bob ex:password "123456789" .
 								<span data-syntax-rule="flags-datatype">The values of <code>sh:flags</code> in a shape are literals with datatype <code>xsd:string</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Pattern">
@@ -4184,10 +4210,12 @@ ex:Alice ex:bCode "B102" .
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:singleLine</code></td>
 							<td>
@@ -4196,7 +4224,7 @@ ex:Alice ex:bCode "B102" .
 								<span data-syntax-rule="singleLine-maxCount">A shape has at most one value for <code>sh:singleLine</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="SingleLine">
@@ -4289,10 +4317,12 @@ ex:SingleLineExampleShape
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:languageIn</code></td>
 							<td>
@@ -4302,7 +4332,7 @@ ex:SingleLineExampleShape
 								<span data-syntax-rule="languageIn-maxCount">A shape has at most one value for <code>sh:languageIn</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="LanguageIn">
@@ -4423,10 +4453,12 @@ ex:Mountain
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:uniqueLang</code></td>
 							<td>
@@ -4436,7 +4468,7 @@ ex:Mountain
 								<span data-syntax-rule="uniqueLang-scope"><a>Node shapes</a> cannot have any value for <code>sh:uniqueLang</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="UniqueLang">
@@ -4549,10 +4581,12 @@ ex:Alice
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:memberShape</code></td>
 							<td>
@@ -4560,7 +4594,7 @@ ex:Alice
 								<span data-syntax-rule="memberShape-node">The value of <code>sh:memberShape</code> must be a <a>well-formed</a> <a>node shape</a>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MemberShape">
@@ -4674,10 +4708,12 @@ ex:agenda1 a ex:Agenda ;
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:minListLength</code></td>
 							<td>
@@ -4686,7 +4722,7 @@ ex:agenda1 a ex:Agenda ;
 								<span data-syntax-rule="minListLength-minInclusive">The values of <code>sh:minListLength</code> in a shape are integers greater than or equal to 0.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MinListLength">
@@ -4777,10 +4813,12 @@ ex:person1 a ex:Person ;
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:maxListLength</code></td>
 							<td>
@@ -4789,7 +4827,7 @@ ex:person1 a ex:Person ;
 								<span data-syntax-rule="maxListLength-minInclusive">The values of <code>sh:maxListLength</code> in a shape are integers greater than or equal to 0.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="MaxListLength">
@@ -4884,10 +4922,12 @@ ex:person1 a ex:Person ;
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:uniqueMembers</code></td>
 							<td>
@@ -4895,7 +4935,7 @@ ex:person1 a ex:Person ;
 								<span data-syntax-rule="uniqueMembers-datatype">The values of <code>sh:uniqueMembers</code> in a shape are literals with datatype <code>xsd:boolean</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="UniqueMembers">
@@ -5005,10 +5045,12 @@ ex:person1 a ex:Person ;
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:equals</code></td>
 							<td>
@@ -5016,7 +5058,7 @@ ex:person1 a ex:Person ;
 								<span data-syntax-rule="equals-nodeKind">The values of <code>sh:equals</code> in a shape are <a>IRIs</a>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Equals">
@@ -5094,10 +5136,12 @@ ex:Bob
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:disjoint</code></td>
 							<td>
@@ -5105,7 +5149,7 @@ ex:Bob
 								<span data-syntax-rule="disjoint-nodeKind">The values of <code>sh:disjoint</code> in a shape are <a>IRIs</a>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Disjoint">
@@ -5195,10 +5239,12 @@ ex:USA
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:lessThan</code></td>
 							<td>
@@ -5207,7 +5253,7 @@ ex:USA
 								<span data-syntax-rule="lessThan-scope"><a>Node shapes</a> cannot have any value for <code>sh:lessThan</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="LessThan">
@@ -5262,10 +5308,12 @@ ex:LessThanExampleShape
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:lessThanOrEquals</code></td>
 							<td>
@@ -5274,7 +5322,7 @@ ex:LessThanExampleShape
 								<span data-syntax-rule="lessThanOrEquals-scope"><a>Node shapes</a> cannot have any value for <code>sh:lessThanOrEquals</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="LessThanOrEquals">
@@ -5306,10 +5354,12 @@ ex:LessThanExampleShape
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:not</code></td>
 							<td>
@@ -5317,7 +5367,7 @@ ex:LessThanExampleShape
 								<span data-syntax-rule="not-node">The values of <code>sh:not</code> in a shape must be <a>well-formed</a> <a>shapes</a>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Not">
@@ -5392,10 +5442,12 @@ ex:NotExampleShape
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:and</code></td>
 							<td>
@@ -5404,7 +5456,7 @@ ex:NotExampleShape
 								<span data-syntax-rule="and-members-node">Each <a>member</a> of such list must be a <a>well-formed</a> <a>shape</a>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="And">
@@ -5541,10 +5593,12 @@ ex:ValidInstance
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:or</code></td>
 							<td>
@@ -5553,7 +5607,7 @@ ex:ValidInstance
 								<span data-syntax-rule="or-members-node">Each <a>member</a> of such list must be a <a>well-formed</a> <a>shape</a>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Or">
@@ -5761,10 +5815,12 @@ ex:shapeRoot a sh:NodeShape;
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:xone</code></td>
 							<td>
@@ -5773,7 +5829,7 @@ ex:shapeRoot a sh:NodeShape;
 								<span data-syntax-rule="xone-members-node">Each <a>member</a> of such list must be a <a>well-formed</a> <a>shape</a>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Xone">
@@ -5928,10 +5984,12 @@ ex:Carla a ex:Person ;
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:node</code></td>
 							<td>
@@ -5939,7 +5997,7 @@ ex:Carla a ex:Person ;
 								<span data-syntax-rule="node-node">The values of <code>sh:node</code> in a shape must be <a>well-formed</a> <a>node shapes</a>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Node">
@@ -6125,10 +6183,12 @@ ex:RetosAddress
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:property</code></td>
 							<td>
@@ -6136,7 +6196,7 @@ ex:RetosAddress
 								<span data-syntax-rule="property-node">Each value of <code>sh:property</code> in a shape must be a <a>well-formed</a> <a>property shape</a>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Property">
@@ -6171,10 +6231,12 @@ ex:RetosAddress
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:qualifiedValueShape</code></td>
 							<td>
@@ -6208,7 +6270,7 @@ ex:RetosAddress
 								This is a <a>mandatory parameter</a> of <code>sh:QualifiedMaxCountConstraintComponent</code>.
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION of Sibling Shapes</div>
@@ -6459,10 +6521,12 @@ ex:HandShape
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:reifierShape</code></td>
 							<td>
@@ -6481,7 +6545,7 @@ ex:HandShape
 								<span data-syntax-rule="reificationRequired-datatype">The values of <code>sh:reificationRequired</code> in a shape are literals with datatype <code>xsd:boolean</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
@@ -6648,10 +6712,12 @@ ex:Bob ex:age 23 {|
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:closed</code></td>
 							<td>
@@ -6668,13 +6734,13 @@ ex:Bob ex:age 23 {|
 								<span data-syntax-rule="ignoredProperties-members-nodeKind">Each <a>member</a> of such a list must be a <a>IRI</a>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div id="def-ClosedShape-text" class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Closed">
 							Let <code>$closed</code> be a <a>parameter value</a> for <code>sh:closed</code>.
 							Let <code>$ignoredProperties</code> be a <a>value</a> for <code>sh:ignoredProperties</code>.
-							<br/><br/>
+							<br><br>
 							If <code>$closed</code> is <code>true</code> or <code>sh:ByTypes</code> and <code>P</code>
 							is the set of properties defined below,
 							then there is a <a>validation result</a> for each <a>triple</a> that has a <a>value node</a> as its
@@ -6683,15 +6749,14 @@ ex:Bob ex:age 23 {|
 							are also permitted for the <a>value node</a>.
 							The <a>validation result</a> MUST have the <a>predicate</a> of the triple as its <code>sh:resultPath</code>,
 							and the <a>object</a> of the triple as its <code>sh:value</code>.
-							<br/><br/>
+							<br><br>
 							If <code>$closed</code> is <code>true</code>, then <code>P</code> is the set of <a>IRI</a> properties
 							that can be reached from the current shape via the SPARQL path <code>sh:property/sh:path</code>.
-							<br/><br/>
+							<br><br>
 							If <code>$closed</code> is <code>sh:ByTypes</code>, then <code>P</code> is the set of <a>IRI</a> properties
 							that can be reached from the value node via the following algorithm, plus <code>rdf:type</code>:
 							<div style="margin: 20px">
-							<pre class="text">
-function collectProperties(S)
+							<pre class="text">function collectProperties(S)
     add all IRI properties that can be reached from S via the SPARQL path
             sh:property/sh:path
     if S is a SHACL instance of rdfs:Class in the shapes graph {
@@ -6818,17 +6883,19 @@ ex:Alice
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:hasValue</code></td>
 							<td>
 								A specific required value.
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div id="def-hasValue-text" class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="HasValue">
@@ -6901,10 +6968,12 @@ ex:Alice
 
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:in</code></td>
 							<td>
@@ -6913,7 +6982,7 @@ ex:Alice
 								<span data-syntax-rule="in-maxCount">A shape has at most one value for <code>sh:in</code>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="In">
@@ -6995,10 +7064,12 @@ ex:RainbowPony ex:color ex:Pink .
 		
 					<div class="parameters">Parameters:</div>
 					<table class="term-table">
-						<tr>
+						<thead><tr>
 							<th>Property</th>
 							<th>Summary and Syntax Rules</th>
 						</tr>
+						</thead>
+				<tbody>
 						<tr>
 							<td><code>sh:expression</code></td>
 							<td>
@@ -7007,7 +7078,7 @@ ex:RainbowPony ex:color ex:Pink .
 								<a>shape</a> must be well-formed <a>node expressions</a>.</span>
 							</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div class="def def-text">
 						<div class="def-header">TEXTUAL DEFINITION</div>
 						<div class="def-text-body" data-validator="Expression">
@@ -7243,7 +7314,7 @@ ex:AddressGroup
 				<div style="background: #f3f3f3; padding: 8px">
 					<div style="font-size: 18px; color: #0000a0"><b>Name</b></div>
 					<table>
-						<tr>
+						<tbody><tr>
 							<td style="text-align: right; width: 160px"><b>first name:</b></td>
 							<td>John</td>
 						</tr>
@@ -7251,10 +7322,10 @@ ex:AddressGroup
 							<td style="text-align: right"><b>last name:</b></td>
 							<td>Doe</td>
 						</tr>
-					</table>
+					</tbody></table>
 					<div style="font-size: 18px; padding-top: 6px; color: #0000a0"><b>Address</b></div>
 					<table>
-						<tr>
+						<tbody><tr>
 							<td style="text-align: right; width: 160px"><b>street address:</b></td>
 							<td>123 Silverado Ave</td>
 						</tr>
@@ -7266,7 +7337,7 @@ ex:AddressGroup
 							<td style="text-align: right"><b>zip code:</b></td>
 							<td>54321</td>
 						</tr>
-					</table>
+					</tbody></table>
 				</div>
 				<p>
 					Note that the same information would be generated by the following example,
@@ -7448,11 +7519,11 @@ ex:NameGroup
 				Nodes that violate these rules in a <a>shapes graph</a> are <a>ill-formed</a>.
 			</p>
 			<table class="term-table" id="syntax-rules-table">
-				<tr>
+				<thead><tr>
 					<th>Syntax Rule Id</th>
 					<th>Syntax Rule Text</th>
 				</tr>
-			</table>
+			</thead></table>
 		</section>
 		
 		<section id="shacl-shacl" class="appendix informative">
@@ -7479,10 +7550,10 @@ ex:NameGroup
 				into the prose if the context of the validator in unclear. 
 			</p>
 			<table class="term-table" id="validators-table">
-				<tr>
+				<thead><tr>
 					<th>Validators by Constraint Component</th>
 				</tr>
-			</table>
+			</thead></table>
 		</section>
 		
 		<section id="security" class="appendix informative">
@@ -7529,7 +7600,7 @@ ex:NameGroup
 				<li>The values of <a href="#ClassConstraintComponent"><code>sh:class</code></a> and <a href="#DatatypeConstraintComponent"><code>sh:datatype</code></a> can now also be lists, indicating a union of choices; see <a href="https://github.com/w3c/data-shapes/issues/160">Issue 160</a></li>
 			</ul>
 		</section>
-	</body>
+	
 
 	<script type="text/javascript">
 
@@ -7541,4 +7612,6 @@ ex:NameGroup
 		
 	</script>
 
-</html>
+
+
+</body></html>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -886,7 +886,11 @@ ex:PersonShape
 	}
 }</pre>
 						</div>
-					</div>
+					<div class="shaclc"><pre class="shaclc">shape ex:PersonShape -&gt; ex:Person {
+	closed=true ignoredProperties=[rdf:type] .
+	ex:ssn xsd:string [0..1] pattern="^\\d{3}-\\d{2}-\\d{4}$" .
+	ex:worksFor IRI ex:Company .
+}</pre></div></div>
 				</aside>
 				<p>
 					We can use the shape declaration above to illustrate some of the key terminology used by SHACL.
@@ -1304,7 +1308,10 @@ ex:MultiplePatternsShape
 	]
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:MultiplePatternsShape {
+	ex:name pattern="^Start" flags="i" .
+	ex:name pattern="End$" .
+}</pre></div></div>
 					</aside>
 					<p>
 						Constraint components are associated with <dfn data-lt="validator|validators">validators</dfn>, which provide instructions (for example expressed via SPARQL queries)
@@ -1398,7 +1405,9 @@ ex:PersonShape
 	}
 }</pre>
 								</div>
-							</div>
+							<div class="shaclc"><pre class="shaclc">shape ex:PersonShape {
+	targetNode=ex:Alice .
+}</pre></div></div>
 							<div class="data-graph">
 								<div class="turtle">
 <span class="focus-node-selected">ex:Alice</span> a ex:Person .
@@ -1451,7 +1460,8 @@ ex:PersonShape
 	}
 }</pre>
 								</div>
-							</div>
+							<div class="shaclc"><pre class="shaclc">shape ex:PersonShape -&gt; ex:Person {
+}</pre></div></div>
 
 							<div class="data-graph">
 								<div class="turtle">
@@ -1569,7 +1579,8 @@ ex:Person
 	]
 }</pre>
 								</div>
-							</div>
+							<div class="shaclc"><pre class="shaclc">shapeClass ex:Person {
+}</pre></div></div>
 							<div class="data-graph">
 								<div class="turtle">
 <span class="focus-node-selected">ex:Alice</span> a ex:Person .
@@ -1641,7 +1652,9 @@ ex:TargetSubjectsOfExampleShape
 	}
 }</pre>
 								</div>
-							</div>
+							<div class="shaclc"><pre class="shaclc">shape ex:TargetSubjectsOfExampleShape {
+	targetSubjectsOf=ex:knows .
+}</pre></div></div>
 							<div class="data-graph">
 								<div class="turtle">
 <span class="focus-node-selected">ex:Alice</span> ex:knows ex:Bob .
@@ -1703,7 +1716,9 @@ ex:TargetObjectsOfExampleShape
 	}
 }</pre>
 								</div>
-							</div>
+							<div class="shaclc"><pre class="shaclc">shape ex:TargetObjectsOfExampleShape {
+	targetObjectsOf=ex:knows .
+}</pre></div></div>
 							<div class="data-graph">
 								<div class="turtle">
 ex:Alice ex:knows <span class="focus-node-selected">ex:Bob</span> .
@@ -1854,7 +1869,11 @@ ex:MyShape
 	}
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:MyShape {
+	targetNode=ex:MyInstance .
+	ex:myProperty xsd:string [1..*] severity=Warning .
+	ex:myProperty maxLength=10 message="Too many characters"@en message="Zu viele Zeichen"@de .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:MyInstance
@@ -3220,7 +3239,10 @@ ex:ClassExampleShape
 	]
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:ClassExampleShape {
+	targetNode=ex:Bob targetNode=ex:Alice targetNode=ex:Carol .
+	ex:address ex:PostalAddress .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:Alice a ex:Person .
@@ -3372,7 +3394,10 @@ ex:DatatypeExampleShape
 	]
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:DatatypeExampleShape {
+	targetNode=ex:Alice targetNode=ex:Bob targetNode=ex:Carol .
+	ex:age xsd:integer .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:Alice ex:age "23"^^xsd:integer .
@@ -3499,7 +3524,9 @@ ex:NodeKindExampleShape
 	}
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:NodeKindExampleShape {
+	targetObjectsOf=ex:knows nodeKind=IRI .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:Bob ex:knows ex:Alice .
@@ -3690,7 +3717,10 @@ ex:MaxCountExampleShape
 	}
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:MaxCountExampleShape {
+	targetNode=ex:Bob .
+	ex:birthDate [0..1] .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:Bob ex:birthDate "May 5th 1990" .
@@ -3755,7 +3785,10 @@ ex:NumericRangeExampleShape
 	]
 }</pre>
 						</div>
-					</div>
+					<div class="shaclc"><pre class="shaclc">shape ex:NumericRangeExampleShape {
+	targetNode=ex:Bob targetNode=ex:Alice targetNode=ex:Ted .
+	ex:age minInclusive=0 maxInclusive=150 .
+}</pre></div></div>
 
 					<div class="data-graph">
 						<div class="turtle">
@@ -4057,7 +4090,10 @@ ex:PasswordExampleShape
 	]
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:PasswordExampleShape {
+	targetNode=ex:Bob targetNode=ex:Alice .
+	ex:password minLength=8 maxLength=10 .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:Bob ex:password "123456789" .
@@ -4164,7 +4200,10 @@ ex:PatternExampleShape
 	]
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:PatternExampleShape {
+	targetNode=ex:Bob targetNode=ex:Alice targetNode=ex:Carol .
+	ex:bCode pattern="^B" flags="i" .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:Bob ex:bCode "b101" .
@@ -4385,7 +4424,10 @@ ex:NewZealandLanguagesShape
 	]
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:NewZealandLanguagesShape {
+	targetNode=ex:Mountain targetNode=ex:Berg .
+	ex:prefLabel languageIn=["en" "mi"] .
+}</pre></div></div>
 						<p>
 							From the example instances, <code>ex:Berg</code> will lead to constraint violations for all
 							of its labels.
@@ -4513,7 +4555,10 @@ ex:UniqueLangExampleShape
 	]
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:UniqueLangExampleShape {
+	targetNode=ex:Alice targetNode=ex:Bob .
+	ex:label uniqueLang=true .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:Alice
@@ -5104,7 +5149,10 @@ ex:EqualExampleShape
 	}
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:EqualExampleShape {
+	targetNode=ex:Bob .
+	ex:firstName equals=ex:givenName .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:Bob
@@ -5197,7 +5245,10 @@ ex:DisjointExampleShape
 	]
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:DisjointExampleShape {
+	targetNode=ex:USA targetNode=ex:Germany .
+	ex:prefLabel disjoint=ex:altLabel .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:USA
@@ -5293,7 +5344,9 @@ ex:LessThanExampleShape
 	}
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:LessThanExampleShape {
+	ex:startDate lessThan=ex:endDate .
+}</pre></div></div>
 					</aside>
 				</section>
 				
@@ -5742,7 +5795,9 @@ ex:PersonAddressShape
 	}
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:PersonAddressShape -&gt; ex:Person {
+	ex:address xsd:string|ex:Address .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:Bob ex:address "123 Prinzengasse, Vaduz, Liechtenstein" .
@@ -6074,7 +6129,12 @@ ex:PersonShape
 	]
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:AddressShape {
+	ex:postalCode xsd:string [0..1] .
+}
+shape ex:PersonShape -&gt; ex:Person {
+	ex:address [1..*] @ex:AddressShape .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:Bob a ex:Person ;
@@ -6834,7 +6894,11 @@ ex:ClosedShapeExampleShape
 	]
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:ClosedShapeExampleShape {
+	targetNode=ex:Alice targetNode=ex:Bob closed=true ignoredProperties=[rdf:type] .
+	ex:firstName .
+	ex:lastName .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:Alice
@@ -6933,7 +6997,10 @@ ex:StanfordGraduate
 	}
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:StanfordGraduate {
+	targetNode=ex:Alice .
+	ex:alumniOf hasValue=ex:Stanford .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:Alice
@@ -7031,7 +7098,10 @@ ex:InExampleShape
 	}
 }</pre>
 							</div>
-						</div>
+						<div class="shaclc"><pre class="shaclc">shape ex:InExampleShape {
+	targetNode=ex:RainbowPony .
+	ex:color in=[ex:Pink ex:Purple] .
+}</pre></div></div>
 						<div class="data-graph">
 							<div class="turtle">
 ex:RainbowPony ex:color ex:Pink .
@@ -7611,6 +7681,7 @@ ex:NameGroup
 		}
 		
 	</script>
+
 
 
 


### PR DESCRIPTION
Editorial change to add SHACL-C snippets to the core spec document

Closes #419

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/feat/shaclc-snippets/shacl12-core/index.html)
