### PR TITLE
Initial contribution to define Node Expressions library

### DIFF
--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -486,6 +486,8 @@
 						<dfn data-cite="shacl12-core#dfn-shacl-instance" data-lt="shacl instance">SHACL instance</dfn>,
 						<dfn data-cite="shacl12-core#dfn-shacl-subclass" data-lt="shacl subclass">SHACL subclass</dfn>,
 						<dfn data-cite="shacl12-core#dfn-shacl-type" data-lt="shacl type">SHACL type</dfn>,
+						<dfn data-cite="shacl12-core#dfn-shacl-list" data-lt="shacl list|shacl lists">SHACL list</dfn>,
+						<dfn data-cite="shacl12-core#dfn-members" data-lt="members">members</dfn>,
 						<dfn data-cite="shacl12-core#dfn-well-formed" data-lt="well-formed">well-formed</dfn>,
 						as defined in the SHACL 1.2 Core specification [[!shacl12-core]].
 					</div>
@@ -573,6 +575,7 @@
 				Such blank nodes are only <a>well-formed</a> if they are not the <a>subject</a> of any other
 				triples, or where any of these properties are used more than once.
 				Also, the tables may list SHACL constraints that the property values are required to conform to.
+				In the tables, mandatory properties are rendered in <b>bold face</b>.
 			</p>
 			<section id="library-constants">
 				<h3>Constant Node Expressions</h3>
@@ -640,7 +643,7 @@
 								</thead>
 								<tbody>
 									<tr>
-										<td><code>sh:var</code></td>
+										<td><b><code>sh:var</code></b></td>
 										<td>
 											<code>sh:datatype xsd:string</code><br />
 											<code>sh:minLength 1</code></li>
@@ -694,7 +697,51 @@ ex:Person-loves
 
 				<section id="ListExpression">
 					<h3>List Expressions</h3>
-					<p class="todo">TODO</p>
+					<p class="syntax">
+						<span data-syntax-rule="ListExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>list expression</dfn> with the <a>function name</a> <code>sh:ListExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>rdf:first</code></b></td>
+										<td>
+										</td>
+										<td>
+											The first member of the list.
+										</td>
+									</tr>
+									<tr>
+										<td><b><code>rdf:rest</code></b></td>
+										<td>
+											Must be a <a>well-formed</a> <a>SHACL list</a>.
+										</td>
+										<td>
+											The rest of the list, e.g. <code>rdf:nil</code>.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="ListExpression-evaluation">
+						<div class="def-header">EVALUATION OF LIST EXPRESSIONS</div>
+						<p>
+							The <a>output nodes</a> of a <a>list expression</a> are the <a>members</a> of the <a>SHACL list</a>.
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p>
+						Note that <code>rdf:nil</code> itself is not a <a>list expression</a> because it will be interpreted
+						as a <a>IRI expression</a>.
+						As a result, all <a>well-formed</a> list expressions have at least one <a>member</a>.
+					</p>
+					<p class="todo">TODO: Add example</p>
 				</section>
 
 				<section id="PathExpression">
@@ -711,9 +758,9 @@ ex:Person-loves
 								</thead>
 								<tbody>
 									<tr>
-										<td><code>sh:path</code></td>
+										<td><b><code>sh:path</code></b></td>
 										<td>
-											must be a <a>well-formed</a> <a>SHACL property path</a>
+											Must be a <a>well-formed</a> <a>SHACL property path</a>.
 										</td>
 										<td>
 											The path to get the values from.
@@ -722,7 +769,7 @@ ex:Person-loves
 									<tr>
 										<td><code>sh:nodes</code></td>
 										<td>
-											optional, must be a <a>well-formed</a> <a>node expression</a>
+											Optional, must be a <a>well-formed</a> <a>node expression</a>.
 										</td>
 										<td>
 											A node expression producing the <a>focus nodes</a>, defaulting
@@ -785,7 +832,59 @@ skos:ConceptScheme-topConceptCount
 
 				<section id="IfExpression">
 					<h3>If Expressions</h3>
-					<p class="todo">TODO</p>
+					<p class="syntax">
+						<span data-syntax-rule="IfExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called an <dfn>if expression</dfn> with the <a>function name</a> <code>sh:IfExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>sh:if</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											A node expression that must return <code>true</code> as its only <a>output node</a>
+											so that the <code>sh:then</code> branch is returned, otherwise <code>sh:else</code>.
+										</td>
+									</tr>
+									<tr>
+										<td><code>sh:then</code></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+											Optional, if <code>sh:else</code> exists.
+										</td>
+										<td>
+											The <a>node expression</a> that is returned when the <code>sh:if</code> evaluated to <code>[true]</code>.
+										</td>
+									</tr>
+									<tr>
+										<td><code>sh:else</code></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+											Optional, if <code>sh:then</code> exists.
+										</td>
+										<td>
+											The <a>node expression</a> that is returned when the <code>sh:if</code> did not evaluate to <code>[true]</code>.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="IfExpression-evaluation">
+						<div class="def-header">EVALUATION OF IF EXPRESSIONS</div>
+						<p>
+							TODO
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p class="todo">TODO: Add example</p>
 				</section>
 
 			</section>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -638,9 +638,9 @@
 			<p>
 				The syntax definitions of node expression functions that are based on <a>blank nodes</a>
 				typically use a table of properties that these blank nodes can or must have.
-				Such blank nodes are only <a>well-formed</a> if they are not the <a>subject</a> of any other
-				triples, or where any of these properties are used more than once.
-				Also, the tables may list SHACL constraints that the property values are required to conform to.
+				Such blank nodes are only <a>well-formed</a> when they are not the <a>subject</a> of any other
+				triples, and when none of these properties is used more than once.
+				The tables may also list SHACL constraints with which the property values are required to conform.
 				In the tables, mandatory properties are rendered in <b>bold face</b>.
 			</p>
 

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -567,6 +567,13 @@
 				This section defines all <a>node expression functions</a> that are built into SHACL engines
 				that implement this specification.
 			</p>
+			<p>
+				The syntax definitions of node expression functions that are based on <a>blank nodes</a>
+				typically use a table of properties that these blank nodes can or must have.
+				Such blank nodes are only <a>well-formed</a> if they are not the <a>subject</a> of any other
+				triples, or where any of these properties are used more than once.
+				Also, the tables may list SHACL constraints that the property values are required to conform to.
+			</p>
 			<section id="library-constants">
 				<h3>Constant Node Expressions</h3>
 				<p>
@@ -621,14 +628,30 @@
 
 				<section id="VarExpression">
 					<h3>Var Expressions</h3>
-					<p>
-						A <a>blank node</a> that has a <a>value</a> for <code>sh:var</code>
-						is called a <dfn>var expression</dfn> with the <a>function name</a> <code>sh:VarExpression</code>.
-					</p>
 					<p class="syntax">
-						<span data-syntax-rule="VarExpression-syntax">A node in an RDF graph is a <a>well-formed</a> <a>var expression</a> if it is a <a>blank node</a>
-						that is the <a>subject</a> of exactly one <a>triple</a> in the <a>shapes graph</a> and the <a>predicate</a> of this <a>triple</a> is <code>sh:var</code>
-						and the <a>object</a> of this <a>triple</a> is an <code>xsd:string</code> <a>literal</a> with a minimum length of <code>1</code>.</span>
+						<span data-syntax-rule="VarExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>var expression</dfn> with the <a>function name</a> <code>sh:VarExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><code>sh:var</code></td>
+										<td>
+											<code>sh:datatype xsd:string</code><br />
+											<code>sh:minLength 1</code></li>
+										</td>
+										<td>
+											The variable name, e.g. <code>"focusNode"</code>.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
 					</p>
 					<div class="def" id="VarExpression-evaluation">
 						<div class="def-header">EVALUATION OF VAR EXPRESSIONS</div>
@@ -676,16 +699,38 @@ ex:Person-loves
 
 				<section id="PathExpression">
 					<h3>Path Expressions</h3>
-					<p>
-						A <a>blank node</a> that has a <a>value</a> for <code>sh:path</code>
-						is called a <dfn>path expression</dfn> with the <a>function name</a> <code>sh:PathExpression</code>.
-					</p>
 					<p class="syntax">
-						<span data-syntax-rule="PathExpression-syntax">A node in an RDF graph is a <a>well-formed</a> <a>path expression</a> if it is a <a>blank node</a>
-						that is the <a>subject</a> of exactly one <a>triple</a> in the <a>shapes graph</a> where the <a>predicate</a> is <code>sh:path</code>
-						and the <a>object</a> is a <a>well-formed</a> <a>SHACL property path</a>.
-						The <a>path expression</a> may be the subject of exactly one more <a>triple</a>, with the <a>predicate</a> of that <a>triple</a>
-						being <code>sh:nodes</code> and the <a>object</a> a <a>well-formed</a> <a>node expression</a>.
+						<span data-syntax-rule="PathExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>path expression</dfn> with the <a>function name</a> <code>sh:PathExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><code>sh:path</code></td>
+										<td>
+											must be a <a>well-formed</a> <a>SHACL property path</a>
+										</td>
+										<td>
+											The path to get the values from.
+										</td>
+									</tr>
+									<tr>
+										<td><code>sh:nodes</code></td>
+										<td>
+											optional, must be a <a>well-formed</a> <a>node expression</a>
+										</td>
+										<td>
+											A node expression producing the <a>focus nodes</a>, defaulting
+											to the current focus node from the evaluation context.
+										</td>
+									</tr>
+								</tbody>
+							</table>
 						</span>
 					</p>
 					<div class="def" id="PathExpression-evaluation">
@@ -697,6 +742,7 @@ ex:Person-loves
 							Let <code>N</code> be the nodes produced by <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
 							The <a>output nodes</a> of the <a>path expression</a> are the list of <a>nodes</a> produced by concatenating
 							the <a>value nodes</a> of the <code>path</code> at each <a>node</a> in <code>N</code>.
+							<span class="todo">TODO: Clarify if those can contain duplicates.</span>
 						</p>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
@@ -809,10 +855,6 @@ skos:ConceptScheme-topConceptCount
 
 			</section>
 
-		</section>
-
-		<section id="syntax-rules" class="appendix">
-			<h2>Summary of Syntax Rules from this Document</h2>
 		</section>
 
 		<section id="security">

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1066,19 +1066,109 @@ skos:ConceptScheme-topConceptCount
 					<p class="todo">TODO: Example</p>
 				</section>
 
-				<section id="OrderByExpression">
-					<h3>OrderBy Expressions</h3>
-					<p class="todo">TODO</p>
-				</section>
-
 				<section id="LimitExpression">
 					<h3>Limit Expressions</h3>
-					<p class="todo">TODO</p>
+					<p class="syntax">
+						<span data-syntax-rule="LimitExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>limit expression</dfn> with the <a>function name</a> <code>sh:LimitExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>sh:limit</code></b></td>
+										<td>
+											<code>sh:datatype xsd:integer</code><br />
+											<code>sh:minInclusive 0</code>
+										</td>
+										<td>
+											The maximum number of nodes that shall be returned.
+										</td>
+									</tr>
+									<tr>
+										<td><b><code>sh:nodes</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The input nodes.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="LimitExpression-evaluation">
+						<div class="def-header">EVALUATION OF LIMIT EXPRESSIONS</div>
+						<p>
+							Let <code>limit</code> be the <a>value</a> of <code>sh:limit</code>
+							and <code>nodes</code> be the <a>value</a> of <code>sh:nodes</code> in the <a>limit expression</a>.
+							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
+							The <a>output nodes</a> of the <a>limit expression</a> are the first <code>limit</code> <a>nodes</a> in <code>N</code>
+							from left to right, in the same order.
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p class="todo">TODO: Example</p>
 				</section>
 
 				<section id="OffsetExpression">
 					<h3>Offset Expressions</h3>
-					<p class="todo">TODO</p>
+					<p class="syntax">
+						<span data-syntax-rule="OffsetExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called an <dfn>offset expression</dfn> with the <a>function name</a> <code>sh:OffsetExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>sh:offset</code></b></td>
+										<td>
+											<code>sh:datatype xsd:integer</code><br />
+											<code>sh:minInclusive 0</code>
+										</td>
+										<td>
+											The number of nodes that shall be skipped from the <code>sh:nodes</code>.
+										</td>
+									</tr>
+									<tr>
+										<td><b><code>sh:nodes</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The input nodes.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="OffsetExpression-evaluation">
+						<div class="def-header">EVALUATION OF OFFSET EXPRESSIONS</div>
+						<p>
+							Let <code>offset</code> be the <a>value</a> of <code>sh:offset</code>
+							and <code>nodes</code> be the <a>value</a> of <code>sh:nodes</code> in the <a>offset expression</a>.
+							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
+							The <a>output nodes</a> of the <a>offset expression</a> are the a>nodes</a> in <code>N</code>
+							except for the first <code>offset</code> nodes from left to right, in the same order.
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p class="todo">TODO: Example</p>
+				</section>
+
+				<section id="OrderByExpression">
+					<h3>OrderBy Expressions</h3>
+					<p class="todo">TODO: This should be cleaned up from the SHACL-AF definition and requires thought</p>
 				</section>
 
 			</section>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -448,6 +448,7 @@
 						<dfn data-cite="rdf12-concepts#dfn-node" data-lt="node|nodes">node</dfn> of an RDF graph,
 						<dfn data-cite="rdf12-concepts#dfn-datatype" data-lt="datatype|datatypes">datatype</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-rdf-term" data-lt="term|terms">RDF term</dfn>, and
+						<dfn data-cite="rdf12-concepts#dfn-rdf-term-equality" data-lt="term equality">term equality</dfn>, and
 						<dfn data-cite="rdf12-concepts#dfn-subject" data-lt="subject|subjects">subject</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-predicate" data-lt="predicate|predicates">predicate</dfn>, and
 						<dfn data-cite="rdf12-concepts#dfn-object" data-lt="object|objects">object</dfn> of RDF triples
@@ -894,22 +895,175 @@ skos:ConceptScheme-topConceptCount
 
 				<section id="DistinctExpression">
 					<h3>Distinct Expressions</h3>
-					<p class="todo">TODO</p>
+					<p class="syntax">
+						<span data-syntax-rule="DistinctExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>distinct expression</dfn> with the <a>function name</a> <code>sh:DistinctExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>sh:distinct</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The node expression that shall be reduced to its distinct members.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="DistinctExpression-evaluation">
+						<div class="def-header">EVALUATION OF DISTINCT EXPRESSIONS</div>
+						<p>
+							Let <code>distinct</code> be the <a>value</a> of <code>sh:distinct</code> in the <a>distinct expression</a>.
+							Let <code>input</code> be the <a>output nodes</a> of <code>evalExpr(distinct, focusGraph, focusNode, scope)</code>.
+							The <a>output nodes</a> of the <a>distinct expression</a> are the list of <a>nodes</a> in <code>input</code>
+							in the same order but with duplicates eliminated (the first occurences of each node shall be kept, the others removed).
+							Nodes are compared using <a>term equality</a>, i.e. <code>"01"^^xsd:integer</code> is distinct from <code>"1"^^xsd:integer</code>.
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p class="todo">TODO: Example</p>
 				</section>
 
 				<section id="IntersectionExpression">
 					<h3>Intersection Expressions</h3>
-					<p class="todo">TODO</p>
+					<p class="syntax">
+						<span data-syntax-rule="IntersectionExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called an <dfn>intersection expression</dfn> with the <a>function name</a> <code>sh:IntersectionExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>sh:intersection</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>SHACL list</a> where each <a>member</a> is a <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The node expressions that shall be intersected.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="IntersectionExpression-evaluation">
+						<div class="def-header">EVALUATION OF INTERSECTION EXPRESSIONS</div>
+						<p>
+							Let <code>members</code> be the <a>members</a> of the <a>value</a> of <code>sh:intersection</code> in the <a>intersection expression</a>.
+							The <a>output nodes</a> of the <a>intersection expression</a> are the list of <a>nodes</a> that are in all <a>output nodes</a>
+							for each <a>node expression</a> <code>NE</code> in <code>members</code>, using <code>evalExpr(NE, focusGraph, focusNode, scope)</code>.
+							Nodes must be equal using <a>term equality</a>, i.e. <code>"01"^^xsd:integer</code> is distinct from <code>"1"^^xsd:integer</code>.
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p class="todo">TODO: Example</p>
 				</section>
 
 				<section id="UnionExpression">
 					<h3>Union Expressions</h3>
-					<p class="todo">TODO</p>
+					<p class="syntax">
+						<span data-syntax-rule="UnionExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>union expression</dfn> with the <a>function name</a> <code>sh:UnionExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>sh:union</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>SHACL list</a> where each <a>member</a> is a <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The node expressions that shall be unioned.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="UnionExpression-evaluation">
+						<div class="def-header">EVALUATION OF UNION EXPRESSIONS</div>
+						<p>
+							Let <code>members</code> be the <a>members</a> of the <a>value</a> of <code>sh:union</code> in the <a>union expression</a>.
+							The <a>output nodes</a> of the <a>union expression</a> are the concatenation of all <a>output nodes</a>
+							for each <a>node expression</a> <code>NE</code> in <code>members</code>, using <code>evalExpr(NE, focusGraph, focusNode, scope)</code>.
+							The order is preserved, evaluating the <code>members</code> from left to right and keeping the order of each list.
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p>
+						Note that a <a>union expression</a> may produce duplicate <a>output nodes</a> if the individual output nodes overlap.
+						Use <a href="DistinctExpression">sh:distinct</a> to eliminate duplicates.
+					</p>
+					<p class="todo">TODO: Example</p>
 				</section>
 
 				<section id="MinusExpression">
 					<h3>Minus Expressions</h3>
-					<p class="todo">TODO</p>
+					<p class="syntax">
+						<span data-syntax-rule="MinusExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>minus expression</dfn> with the <a>function name</a> <code>sh:MinusExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>sh:minus</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The nodes that shall be removed from the <code>sh:nodes</code>.
+										</td>
+									</tr>
+									<tr>
+										<td><b><code>sh:nodes</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The input nodes.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="MinusExpression-evaluation">
+						<div class="def-header">EVALUATION OF MINUS EXPRESSIONS</div>
+						<p>
+							Let <code>minus</code> be the <a>value</a> of <code>sh:minus</code>
+							and <code>nodes</code> be the <a>value</a> of <code>sh:nodes</code> in the <a>minus expression</a>.
+							Let <code>M</code> be the <a>output nodes</a> of <code>evalExpr(minus, focusGraph, focusNode, scope)</code>.
+							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
+							The <a>output nodes</a> of the <a>minus expression</a> are the <a>nodes</a> in <code>N</code>
+							except those that are also in <code>M</code>, preserving the order of <code>N</code>.
+							Nodes must be equal using <a>term equality</a>, i.e. <code>"01"^^xsd:integer</code> is distinct from <code>"1"^^xsd:integer</code>.
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p class="todo">TODO: Example</p>
 				</section>
 
 				<section id="OrderByExpression">

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -553,23 +553,13 @@
 			</section>
 		</section>
 
-
-
-		<section id="library">
-			<h2>Node Expression Library</h2>
+		<section id="syntax">
+			<h2>Node Expression Syntax</h2>
 			<p>
-				This section defines all <a>node expression functions</a> that are built into SHACL engines
-				that implement this specification.
+				This section introduces the general syntax of SHACL <a>node expressions</a>.
 			</p>
-			<p>
-				The syntax definitions of node expression functions that are based on <a>blank nodes</a>
-				typically use a table of properties that these blank nodes can or must have.
-				Such blank nodes are only <a>well-formed</a> if they are not the <a>subject</a> of any other
-				triples, or where any of these properties are used more than once.
-				Also, the tables may list SHACL constraints that the property values are required to conform to.
-				In the tables, mandatory properties are rendered in <b>bold face</b>.
-			</p>
-			<section id="library-constants">
+
+			<section id="ConstantNodeExpression">
 				<h3>Constant Node Expressions</h3>
 				<p>
 					The <a>node expression functions</a> in this section were introduced in the SHACL Core
@@ -617,6 +607,42 @@
 				</section>
 
 			</section>
+
+			<section id="blank-node-functions">
+				<h2>Node Expressions based on Blank Nodes</h2>
+				<p>
+					...
+				</p>
+				<section id="ListParameterFunction">
+					<h3>List Parameter Functions</h3>
+					<p>
+						...
+					</p>
+				</section>
+				<section id="NamedArgumentFunctions">
+					<h3>Named Argument Functions</h3>
+					<p>
+						...
+					</p>
+				</section>
+			</section>
+
+		</section>
+
+		<section id="library">
+			<h2>Node Expressions Library</h2>
+			<p>
+				This section defines all <a>node expression functions</a> that are built into SHACL engines
+				that implement this specification.
+			</p>
+			<p>
+				The syntax definitions of node expression functions that are based on <a>blank nodes</a>
+				typically use a table of properties that these blank nodes can or must have.
+				Such blank nodes are only <a>well-formed</a> if they are not the <a>subject</a> of any other
+				triples, or where any of these properties are used more than once.
+				Also, the tables may list SHACL constraints that the property values are required to conform to.
+				In the tables, mandatory properties are rendered in <b>bold face</b>.
+			</p>
 
 			<section id="library-basic">
 				<h2>Basic Node Expressions</h2>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -841,8 +841,8 @@ skos:ConceptScheme-topConceptCount
 											A <a>well-formed</a> <a>node expression</a>.
 										</td>
 										<td>
-											A node expression that must return <code>true</code> as its only <a>output node</a>
-											so that the <code>sh:then</code> branch is returned, otherwise <code>sh:else</code>.
+											A node expression. The <code>sh:then</code> branch is returned when the <code>sh:if</code> expression
+											returns <code>true</code> as its only <a>output node</a>, in all other cases <code>sh:else</code>.
 										</td>
 									</tr>
 									<tr>
@@ -995,7 +995,7 @@ skos:ConceptScheme-topConceptCount
 							Let <code>members</code> be the <a>members</a> of the <a>value</a> of <code>sh:union</code> in the <a>union expression</a>.
 							The <a>output nodes</a> of the <a>union expression</a> are the concatenation of all <a>output nodes</a>
 							for each <a>node expression</a> <code>NE</code> in <code>members</code>, using <code>evalExpr(NE, focusGraph, focusNode, scope)</code>.
-							The order is preserved, evaluating the <code>members</code> from left to right and keeping the order of each set of output nodes.
+							The order is preserved, evaluating the <code>members</code> from left to right and keeping the order of each list of output nodes.
 						</p>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -572,8 +572,8 @@
 			<section id="library-constants">
 				<h3>Constant Node Expressions</h3>
 				<p>
-					The <a>node expression functions</a> in this section were already introduced in the SHACL Core
-					specificiation but are repeated here to keep this document self-contained.
+					The <a>node expression functions</a> in this section were introduced in the SHACL Core
+					specification but are repeated here to keep this document self-contained.
 				</p>
 				
 				<section id="IRIExpression">

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -528,15 +528,6 @@
 						<td><code>http://example.com/ns#</code></td>
 					</tr>
 				</table>
-				<p>
-					Throughout the document, color-coded boxes containing RDF graphs in Turtle will appear. These fragments of Turtle documents use the prefix
-					bindings given above.
-				</p>
-				<pre class="example-shapes">        # This box represents a shapes graph</pre>
-
-				<pre class="example-data">        # This box represents a data graph.</pre>
-
-				<pre class="example-results">        # This box represents an output results graph</pre>
 
 				<p>Formal definitions appear in blue boxes:</p>
 				<div class="def def-sparql">
@@ -1178,22 +1169,161 @@ skos:ConceptScheme-topConceptCount
 
 				<section id="CountExpression">
 					<h3>Count Expressions</h3>
-					<p class="todo">TODO</p>
+					<p class="syntax">
+						<span data-syntax-rule="CountExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>count expression</dfn> with the <a>function name</a> <code>sh:CountExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>sh:count</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The input nodes that shall be counted.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="CountExpression-evaluation">
+						<div class="def-header">EVALUATION OF COUNT EXPRESSIONS</div>
+						<p>
+							Let <code>count</code> be the <a>value</a> of <code>sh:count</code> in the <a>count expression</a>.
+							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(count, focusGraph, focusNode, scope)</code>.
+							The <a>output nodes</a> of the <a>count expression</a> is the list consisting of exactly one
+							<code>xsd:integer</code> <a>literal</a> that is computed as the length of <code>N</code>.
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p class="todo">TODO: Example</p>
 				</section>
 
 				<section id="MinExpression">
 					<h3>Min Expressions</h3>
-					<p class="todo">TODO</p>
+					<p class="syntax">
+						<span data-syntax-rule="MinExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>min expression</dfn> with the <a>function name</a> <code>sh:MinExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>sh:min</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The input nodes from which the minimum value shall be returned.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="MinExpression-evaluation">
+						<div class="def-header">EVALUATION OF MIN EXPRESSIONS</div>
+						<p>
+							Let <code>min</code> be the <a>value</a> of <code>sh:min</code> in the <a>min expression</a>.
+							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(min, focusGraph, focusNode, scope)</code>.
+							The <a>output nodes</a> of the <a>min expression</a> is the list consisting of at most one <a>node</a>
+							that is computed as the minimum value from <code>N</code>.
+							<span class="todo">Clarify exactly how that is computed, maybe via reference to SPARQL MIN</span>
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p class="todo">TODO: Example</p>
 				</section>
 
 				<section id="MaxExpression">
 					<h3>Max Expressions</h3>
-					<p class="todo">TODO</p>
+					<p class="syntax">
+						<span data-syntax-rule="MaxExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>max expression</dfn> with the <a>function name</a> <code>sh:MaxExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>sh:max</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The input nodes from which the maximum value shall be returned.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="MaxExpression-evaluation">
+						<div class="def-header">EVALUATION OF MAX EXPRESSIONS</div>
+						<p>
+							Let <code>max</code> be the <a>value</a> of <code>sh:max</code> in the <a>max expression</a>.
+							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(max, focusGraph, focusNode, scope)</code>.
+							The <a>output nodes</a> of the <a>max expression</a> is the list consisting of at most one <a>node</a>
+							that is computed as the maximum value from <code>N</code>.
+							<span class="todo">Clarify exactly how that is computed, maybe via reference to SPARQL MAX</span>
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p class="todo">TODO: Example</p>
 				</section>
 
 				<section id="SumExpression">
 					<h3>Sum Expressions</h3>
-					<p class="todo">TODO</p>
+					<p class="syntax">
+						<span data-syntax-rule="SumExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>sum expression</dfn> with the <a>function name</a> <code>sh:SumExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>sh:sum</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The input nodes from which the sum shall be returned.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="SumExpression-evaluation">
+						<div class="def-header">EVALUATION OF SUM EXPRESSIONS</div>
+						<p>
+							Let <code>sum</code> be the <a>value</a> of <code>sh:sum</code> in the <a>sum expression</a>.
+							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(sum, focusGraph, focusNode, scope)</code>.
+							The <a>output nodes</a> of the <a>sum expression</a> is the list consisting of exactly one <a>node</a>
+							that is computed as the sum of all <a>nodes</a> from <code>N</code>.
+							<span class="todo">Clarify exactly how that is computed, maybe via reference to SPARQL SUM</span>
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p class="todo">TODO: Example</p>
 				</section>
 
 			</section>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -5,6 +5,93 @@
 		<title>SHACL 1.2 Node Expressions</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script class="remove">
+		
+			function prepareSyntaxRules() {
+				document.querySelectorAll("[data-syntax-rule]").forEach(element => {
+					let ruleId = element.getAttribute("data-syntax-rule");
+					let tr = document.createElement("tr");
+					tr.classList.add("syntax-rule-tr");
+					let td1 = document.createElement("td");
+					td1.classList.add("syntax-rule-id");
+					let a = document.createElement("a");
+					a.classList.add("syntax-rule-id-a");
+					a.href = "#syntax-rule-" + ruleId;
+					a.textContent = ruleId;
+					td1.appendChild(a);
+					let td2 = document.createElement("td");
+					td2.innerHTML = element.innerHTML;
+					tr.appendChild(td1);
+					tr.appendChild(td2);
+
+					// Replace <dfn> elements inside `tr` with <a> elements
+					tr.querySelectorAll("dfn").forEach(dfn => {
+    					let a = document.createElement("a");
+    					a.textContent = dfn.textContent;
+    					dfn.replaceWith(a);
+					});
+
+					document.getElementById("syntax-rules-table").appendChild(tr);
+					element.setAttribute("id", "syntax-rule-" + ruleId);
+				});
+			}
+		
+			function prepareValidators() {
+				document.querySelectorAll("[data-validator]").forEach(element => {
+					let validatorId = element.getAttribute("data-validator") + "ConstraintComponent";
+					let tr = document.createElement("tr");
+					tr.classList.add("validator-tr");
+					let td = document.createElement("td");
+					tr.appendChild(td);
+					let a = document.createElement("a");
+					a.classList.add("validator-id-a");
+					a.href = `#validator-${validatorId}`;
+					a.textContent = `sh:${validatorId}`;
+					td.appendChild(a);
+					td.innerHTML += ": " + element.innerHTML;
+					document.getElementById("validators-table").appendChild(tr);
+					element.id = "validator-" + validatorId;
+				});
+			}
+
+			document.addEventListener("DOMContentLoaded", () => {
+				// Replace code div blocks in shapes, data, and results graph with tabs
+				for (const graph of document.querySelectorAll(".shapes-graph, .data-graph, .results-graph")) {
+					const tabs = document.createElement("aside");
+					tabs.classList.add("ds-selector-tabs");
+					graph.firstElementChild.classList.add("selected");
+
+					for (const child of graph.children) {
+						child.classList.add("tab");
+					}
+
+					tabs.append(...graph.children);
+					graph.append(tabs)
+				}
+
+				// Generate buttons for the selection logic
+				for (const tabs of document.querySelectorAll(".ds-selector-tabs")) {
+					const selectors = document.createElement("div");
+					selectors.classList.add("selectors");
+					selectors.innerHTML = `
+						<button class="selected" data-selects="turtle">Turtle</button>
+						<button data-selects="jsonld">JSON-LD</button>
+					`
+
+					tabs.prepend(selectors);
+				}
+
+				// Add example button selection logic
+				for (const button of document.querySelectorAll(".ds-selector-tabs .selectors button")) {
+					button.onclick = () => {
+						const ex = button.closest(".ds-selector-tabs");
+						ex.querySelector("button.selected").classList.remove("selected");
+						ex.querySelector(".selected").classList.remove("selected");
+						button.classList.add('selected');
+						ex.querySelector("." + button.dataset.selects).classList.add("selected");
+					}
+				}
+			});
+
 			var respecConfig = {
 				localBiblio: {},
 
@@ -36,6 +123,13 @@
 						w3cid: "164266"
 					},
 					{
+						name:       "Holger Knublauch",
+						company:    "TopQuadrant, Inc.",
+						companyURL: "https://topquadrant.com/",
+						mailto:     "holger@topquadrant.com",
+						w3cid:      46500
+					},
+					{
 						name: "Simon Steyskal",
 						company: "Siemens AG",
 						companyURL: "https://siemens.com",
@@ -46,44 +140,33 @@
 			};
 		</script>
 		<style>
+
 			pre {
 				tab-size: 3;
-				-moz-tab-size: 3;
-				/* Code for Firefox */
-				-o-tab-size: 3;
-				/* Code for Opera */
-				word-wrap: normal;
+				-moz-tab-size: 3; /* Code for Firefox */
+				-o-tab-size: 3; /* Code for Opera */
 			}
 
 			th {
 				text-align: left;
 			}
-
-			table.rule {
-				background-color: #ebebe0;
-			}
-
-			table.rule td {
-				text-align: center;
-			}
-
-			td.up {
-				border-bottom: 1px solid black;
-			}
-
+			table.rule { background-color: #EBEBE0; }
+			table.rule td { text-align: center; }
+			td.up { border-bottom:1px solid black; }
+			
 			td {
 				vertical-align: top;
 			}
-
+			
 			.algorithm {
 				background: #fafafc;
 				border-left-style: solid;
-				border-left-width: 0.5em;
+				border-left-width: .5em;
 				border-color: #c0c0c0;
 				margin-bottom: 16px;
 				padding: 8px;
 			}
-
+			
 			.arg {
 				font-weight: bold;
 				color: #000080;
@@ -92,60 +175,55 @@
 			.def {
 				background: #fcfcfc;
 				border-left-style: solid;
-				border-left-width: 0.5em;
+				border-left-width: .5em;
 				border-color: #c0c0c0;
 				margin-bottom: 16px;
 			}
-
-			.def-sparql {
-			}
-
-			.def-sparql-body {
-				margin-top: 0px;
-				margin-bottom: 0px;
-			}
-
+			
 			.def-text {
 			}
-
+			
 			.def-text-body {
 			}
-
+			
 			.def-header {
 				color: #a0a0a0;
 				font-size: 16px;
 				padding-bottom: 8px;
 			}
-
+			
 			.diagram-class {
-				border: 1px solid black;
-				border-radius: 4px;
+				border: 1px solid black; 
+				border-radius: 4px; 
 				width: 360px;
 			}
-
+			
 			.diagram-class-name {
-				font-size: 16px;
-				font-weight: bold;
+				font-size: 16px; 
+				font-weight: bold; 
 				text-align: center;
 			}
-
+			
 			.diagram-class-properties {
-				border-top: 1px solid black;
+				border-top: 1px solid black; 
 			}
-
+			
 			.diagram-class-properties-start {
 				padding: 8px;
 			}
-
+			
 			.diagram-class-properties-section {
 				border-top: 1px dashed #808080;
 				padding: 8px;
 			}
 
+			.example {
+				overflow-y: hidden !important;
+			}
+			
 			.focus-node-selected {
 				color: blue;
 			}
-
 			.focus-node-error {
 				color: red;
 			}
@@ -153,7 +231,6 @@
 			.triple-can-be-skipped {
 				color: grey;
 			}
-
 			.focus-node-error {
 				color: red;
 			}
@@ -162,17 +239,17 @@
 				color: darkslategray;
 				font-style: italic;
 			}
-
+			
 			.component-class {
 				font-weight: bold;
 				font-size: 16px;
 			}
-
+			
 			.parameter-context {
 				font-weight: bold;
 				font-size: 16px;
 			}
-
+			
 			.parameters {
 				font-weight: bold;
 				font-size: 16px;
@@ -181,168 +258,162 @@
 			.part-header {
 				font-weight: bold;
 			}
-
+			
 			.syntax {
 				border-left-style: solid;
-				border-left-width: 0.5em;
+				border-left-width: .5em;
 				border-color: #d0d0d0;
 				margin-bottom: 16px;
-				padding: 0.5em 1em;
+				padding: .5em 1em;
 				background-color: #f6f6f6;
 			}
-
+			
 			.syntax-rule-id {
 				padding-right: 10px;
 			}
-
+			
 			.syntax-rule-id-a {
 				white-space: nowrap;
 			}
-
+			
 			.validator-id-a {
 				font-weight: bold;
 				white-space: nowrap;
 			}
-
+		
 			.term {
 				font-style: italic;
 			}
-
+			
 			.term-def-header {
 				font-style: italic;
 				font-weight: bold;
 			}
-
+		
 			.term-table {
 				border-collapse: collapse;
 				border-color: #000000;
 				margin: 16px;
 			}
 
-			.term-table td,
-			th {
+			.term-table td, th {
 				border-width: 1px;
 				border-style: solid;
 				padding: 5px;
 			}
-
+		
 			.todo {
 				color: red;
 			}
-
-			/* example pre taken / adapted from R2RML */
-			pre.example-shapes,
-			pre.example-data,
-			pre.example-results,
-			pre.example-other,
-			pre.example-sparql {
-				margin-left: 0;
-				padding: 0 2em;
-				margin-top: 1.5em;
-				padding: 1em;
-				white-space: pre !important;
+			
+			pre {
+				word-wrap: normal;
 			}
 
-			pre.example-shapes:before,
-			pre.example-data:before,
-			pre.example-results:before,
-			pre.example-other:before,
-			pre.example-sparql:before {
-				background: white;
-				display: block;
-				font-family: sans-serif;
-				margin: -1em 0 0.4em -1em;
-				padding: 0.2em 1em;
+			.turtle {
+				font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
+				font-size: 14.4px;
+				hyphens: none;
+				overflow-x: auto;
+				padding: .5em;
+				tab-size: 3;
+				-moz-tab-size: 3; /* Code for Firefox */
+				-o-tab-size: 3; /* Code for Opera */
+				text-align: start;
+				margin-bottom: -1.5em;
+				margin-top: -1.5em;
+				white-space: pre;
 			}
 
-			pre.example-shapes {
-				background: #deb;
-			}
-
-			pre.example-shapes,
-			pre.example-shapes:before {
-				border: 1px solid #bbb;
-			}
-
-			pre.example-shapes:before {
-				color: #888;
-				content: "Example shapes graph";
-				width: 13em;
-			}
-
-			pre.example-data {
-				background: #eeb;
-			}
-
-			pre.example-data,
-			pre.example-data:before {
+			.data-graph { 
+				background: #eeb; 
 				border: 1px solid #cc9;
+				margin-top: 0.3em;
+			}
+			.data-graph:before { 
+				color: #996; 
+				content: "Data graph"; 
+				padding-left: 0.4em;
+			}
+			
+			.results-graph { 
+				background: #edb; 
+				border: 1px solid #bbb;
+				margin-top: 0.3em;
+			}
+			.results-graph:before { 
+				color: #997; 
+				content: "Validation results"; 
+				padding-left: 0.4em;
+			}
+			
+			.shapes-graph { 
+				background: #deb; 
+				border: 1px solid #bbb;
+				margin-top: 0.3em;
+			}
+			.shapes-graph:before { 
+				color: #888; 
+				content: "Shapes graph"; 
+				padding-left: 0.4em;
 			}
 
-			pre.example-data:before {
-				color: #996;
-				content: "Example data graph";
-				width: 13em;
-			}
-
-			pre.example-results:before {
-				color: #797;
-				content: "Example validation results";
-				width: 13em;
-			}
-
-			pre.example-other {
-				background: #bed;
-			}
-
-			pre.example-other,
-			pre.example-other:before {
-				border: 1px solid #ddd;
-			}
-
-			pre.example-other:before {
-				color: #888;
-				content: "Example";
-				width: 13em;
-			}
-
-			pre.example-sparql {
-				background: #bed;
-			}
-
-			pre.example-sparql,
-			pre.example-sparql:before {
-				border: 1px solid #ddd;
-			}
-
-			pre.example-sparql:before {
-				color: #888;
-				content: "Example SPARQL";
-				width: 13em;
-			}
-
-			.example-results {
-				background: #edb;
-			}
-
-			.example-results,
-			.example-results:before,
-			.example-results th,
-			.example-results td {
-				border: 1px solid #cca;
+			/* no dark mode, keep colors for shapes-graph, data-graph, and results graph background */
+			code.hljs {
+				--base: transparent;
+				--mono-1: #383a42;
 			}
 
 			/* our syntax menu for switching */
 			div.syntaxmenu {
 				border: 1px dotted black;
-				padding: 0.5em;
-				margin: 1em;
+				padding:0.5em;
+				margin: 1em; 
 			}
 
 			@media print {
-				div.syntaxmenu {
-					display: none;
-				}
+				div.syntaxmenu { display:none; }
+			}
+
+			/* example tab selection */
+			.ds-selector-tabs .selectors {
+				padding: 0;
+				border-bottom: 1px solid #ccc;
+				height: 28px;
+			}
+			.ds-selector-tabs .selectors button {
+				display: inline-block;
+				min-width: 54px;
+				text-align: center;
+				font-size: 11px;
+				font-weight: bold;
+				height: 27px;
+				padding: 0 8px;
+				line-height: 27px;
+				transition: all,0.218s;
+				border-top-right-radius: 2px;
+				border-top-left-radius: 2px;
+				color: #666;
+				border: 1px solid transparent;
+			}
+			.ds-selector-tabs .selectors button:first-child {
+				margin-left: 2px;
+			}
+			.ds-selector-tabs .selectors button.selected {
+				color: #202020 !important;
+				border: 1px solid #ccc;
+				border-bottom: 1px solid #fff !important;
+			}
+			.ds-selector-tabs .selectors button:hover {
+				background-color: transparent;
+				color: #202020;
+				cursor: pointer;
+			}
+			.ds-selector-tabs .tab {
+				display: none;
+			}
+			.ds-selector-tabs .selected {
+				display: block;
 			}
 		</style>
 	</head>
@@ -365,169 +436,67 @@
 
 			<section id="terminolgy">
 				<h3>Terminology</h3>
-
-				<p class="ednote">Connect to definitions in RDF 1.2 Concepts.</p>
-
-				<p>
-					The terminology used throughout this document is consistent with the definitions in the main SHACL [[shacl]] specification, which references
-					terms from RDF [[rdf11-concepts]]. This includes the terms
-					<dfn data-lt="bindings">
-						<a href="https://www.w3.org/TR/shacl/#dfn-binding">binding</a>
-					</dfn>
-					,
-					<dfn data-lt="blank nodes">
-						<a href="https://www.w3.org/TR/shacl/#dfn-blank-node">blank node</a>
-					</dfn>
-					,
-					<dfn data-lt="conform|conforms">
-						<a href="https://www.w3.org/TR/shacl/#dfn-conforms">conformance</a>
-					</dfn>
-					,
-					<dfn data-lt="constraints">
-						<a href="https://www.w3.org/TR/shacl/#dfn-constraint">constraint</a>
-					</dfn>
-					,
-					<dfn data-lt="constraint components">
-						<a href="https://www.w3.org/TR/shacl/#dfn-constraint-component">constraint component</a>
-					</dfn>
-					,
-					<dfn data-lt="data graphs">
-						<a href="https://www.w3.org/TR/shacl/#dfn-data-graph">data graph</a>
-					</dfn>
-					,
-					<dfn data-lt="datatypes">
-						<a href="https://www.w3.org/TR/shacl/#dfn-datatype">datatype</a>
-					</dfn>
-					,
-					<dfn data-lt="failures">
-						<a href="https://www.w3.org/TR/shacl/#dfn-failure">failure</a>
-					</dfn>
-					,
-					<dfn data-lt="focus nodes">
-						<a href="https://www.w3.org/TR/shacl/#dfn-focus-node">focus node</a>
-					</dfn>
-					,
-					<dfn data-lt="RDF graphs|graphs|graph">
-						<a href="https://www.w3.org/TR/shacl/#dfn-rdf-graph">RDF graph</a>
-					</dfn>
-					,
-					<dfn><a href="https://www.w3.org/TR/shacl/#dfn-ill-formed">ill-formed</a></dfn>
-					,
-					<dfn data-lt="IRIs"><a href="https://www.w3.org/TR/shacl/#dfn-iri">IRI</a></dfn>
-					,
-					<dfn data-lt="literals">
-						<a href="https://www.w3.org/TR/shacl/#dfn-literal">literal</a>
-					</dfn>
-					,
-					<dfn data-lt="local names">
-						<a href="https://www.w3.org/TR/shacl/#dfn-local-name">local name</a>
-					</dfn>
-					,
-					<dfn data-lt="members">
-						<a href="https://www.w3.org/TR/shacl/#dfn-members">member</a>
-					</dfn>
-					,
-					<dfn data-lt="nodes|RDF node">
-						<a href="https://www.w3.org/TR/shacl/#dfn-node">node</a>
-					</dfn>
-					,
-					<dfn data-lt="node shapes">
-						<a href="https://www.w3.org/TR/shacl/#dfn-node-shape">node shape</a>
-					</dfn>
-					,
-					<dfn data-lt="objects">
-						<a href="https://www.w3.org/TR/shacl/#dfn-object">object</a>
-					</dfn>
-					,
-					<dfn data-lt="parameters">
-						<a href="https://www.w3.org/TR/shacl/#dfn-parameters">parameter</a>
-					</dfn>
-					,
-					<dfn data-lt="pre-bind|pre-bound">
-						<a href="https://www.w3.org/TR/shacl/#pre-binding">pre-binding</a>
-					</dfn>
-					,
-					<dfn data-lt="predicates">
-						<a href="https://www.w3.org/TR/shacl/#dfn-predicate">predicate</a>
-					</dfn>
-					,
-					<dfn data-lt="property paths">
-						<a href="https://www.w3.org/TR/shacl/#dfn-shacl-property-path">property path</a>
-					</dfn>
-					,
-					<dfn data-lt="property shapes">
-						<a href="https://www.w3.org/TR/shacl/#dfn-property-shape">property shape</a>
-					</dfn>
-					,
-					<dfn data-lt="RDF terms|terms|term">
-						<a href="https://www.w3.org/TR/shacl/#dfn-rdf-term">RDF term</a>
-					</dfn>
-					,
-					<dfn data-lt="SHACL instances">
-						<a href="https://www.w3.org/TR/shacl/#dfn-shacl-instance">SHACL instance</a>
-					</dfn>
-					,
-					<dfn data-lt="SHACL lists">
-						<a href="https://www.w3.org/TR/shacl/#dfn-shacl-list">SHACL list</a>
-					</dfn>
-					,
-					<dfn data-lt="SHACL subclasses">
-						<a href="https://www.w3.org/TR/shacl/#dfn-shacl-subclass">SHACL subclass</a>
-					</dfn>
-					,
-					<dfn data-lt="shapes">
-						<a href="https://www.w3.org/TR/shacl/#dfn-shape">shape</a>
-					</dfn>
-					,
-					<dfn data-lt="shapes graphs">
-						<a href="https://www.w3.org/TR/shacl/#dfn-shapes-graph">shapes graph</a>
-					</dfn>
-					,
-					<dfn data-lt="solutions">
-						<a href="https://www.w3.org/TR/shacl/#dfn-solution">solution</a>
-					</dfn>
-					,
-					<dfn data-lt="subjects">
-						<a href="https://www.w3.org/TR/shacl/#dfn-subject">subject</a>
-					</dfn>
-					,
-					<dfn data-lt="targets">
-						<a href="https://www.w3.org/TR/shacl/#dfn-target">target</a>
-					</dfn>
-					,
-					<dfn data-lt="triples">
-						<a href="https://www.w3.org/TR/shacl/#dfn-rdf-triple">triple</a>
-					</dfn>
-					,
-					<dfn><a href="https://www.w3.org/TR/shacl/#dfn-validation">validation</a></dfn>
-					,
-					<dfn data-lt="validation reports">
-						<a href="https://www.w3.org/TR/shacl/#dfn-validation-report">validation report</a>
-					</dfn>
-					,
-					<dfn data-lt="validation results">
-						<a href="https://www.w3.org/TR/shacl/#dfn-validation-results">validation result</a>
-					</dfn>
-					,
-					<dfn data-lt="validators">
-						<a href="https://www.w3.org/TR/shacl/#dfn-validators">validator</a>
-					</dfn>
-					,
-					<dfn data-lt="values">
-						<a href="https://www.w3.org/TR/shacl/#dfn-value">value</a>
-					</dfn>
-					,
-					<dfn data-lt="value nodes">
-						<a href="https://www.w3.org/TR/shacl/#dfn-value-nodes">value node</a>
-					</dfn>
-					.
-				</p>
+				<div class="def" id="rdf-terminology">
+					<div class="term-def-header">Basic RDF Terminology</div>
+					<div>
+						This document uses the terms 
+						<dfn data-cite="rdf12-concepts#dfn-rdf-graph" data-lt="graph|graphs|RDF graphs">RDF graph</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-rdf-triple" data-lt="triple|triples">RDF triple</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-iri" data-lt="IRI|IRIs">IRI</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-literal" data-lt="literal|literals">literal</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-blank-node" data-lt="blank node|blank nodes">blank node</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-node" data-lt="node|nodes">node</dfn> of an RDF graph,
+						<dfn data-cite="rdf12-concepts#dfn-datatype" data-lt="datatype|datatypes">datatype</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-rdf-term" data-lt="term|terms">RDF term</dfn>, and
+						<dfn data-cite="rdf12-concepts#dfn-subject" data-lt="subject|subjects">subject</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-predicate" data-lt="predicate|predicates">predicate</dfn>, and
+						<dfn data-cite="rdf12-concepts#dfn-object" data-lt="object|objects">object</dfn> of RDF triples
+						as defined in RDF 1.2 Concepts and Abstract Syntax [[!rdf12-concepts]].
+					</div>
+				</div>
+				<div class="def" id="shacl-terminology">
+					<div class="term-def-header">Basic SHACL Terminology</div>
+					<div>
+						This document uses the terms
+						<dfn data-cite="shacl12-core#dfn-focus-node" data-lt="focus node|focus nodes">focus node</dfn>,
+						<dfn data-cite="shacl12-core#dfn-value" data-lt="value">value</dfn>,
+						<dfn data-cite="shacl12-core#dfn-value-node" data-lt="value node|value nodes">value node</dfn>,
+						<dfn data-cite="shacl12-core#dfn-constraint" data-lt="constraint|constraints">constraint</dfn>,
+						<dfn data-cite="shacl12-core#dfn-constraint-component" data-lt="constraint component|constraint components">constraint component</dfn>,
+						<dfn data-cite="shacl12-core#dfn-parameter" data-lt="parameter|parameters">parameter</dfn>,
+						<dfn data-cite="shacl12-core#dfn-mandatory-parameter" data-lt="mandatory parameter|mandatory parameters">mandatory parameter</dfn>,
+						<dfn data-cite="shacl12-core#dfn-optional-parameter" data-lt="optional parameter|optional parameters">optional parameter</dfn>,
+						<dfn data-cite="shacl12-core#dfn-parameter-value" data-lt="parameter value">parameter value</dfn>,
+						<dfn data-cite="shacl12-core#dfn-shape" data-lt="shape|shapes">shape</dfn>,
+						<dfn data-cite="shacl12-core#dfn-node-shape" data-lt="node shape|node shapes">node shape</dfn>,
+						<dfn data-cite="shacl12-core#dfn-property-shape" data-lt="property shape|property shapes">property shape</dfn>,
+						<dfn data-cite="shacl12-core#dfn-shacl-property-path" data-lt="shacl property path|shacl property paths">SHACL property path</dfn>,
+						<dfn data-cite="shacl12-core#dfn-sparql-property-path" data-lt="sparql property path|sparql property paths">SPARQL property path</dfn>,
+						<dfn data-cite="shacl12-core#dfn-shapes-graph" data-lt="shapes graph">shapes graph</dfn>,
+						<dfn data-cite="shacl12-core#dfn-target" data-lt="target|targets">target</dfn>,
+						<dfn data-cite="shacl12-core#dfn-validators" data-lt="validator|validators">validator</dfn>,
+						<dfn data-cite="shacl12-core#dfn-node-expression" data-lt="node expression|node expresssions">node expression</dfn>,
+						<dfn data-cite="shacl12-core#dfn-node-expression-function" data-lt="node expression function|node expresssion functions">node expression function</dfn>,
+						<dfn data-cite="shacl12-core#dfn-function-name" data-lt="node expression function name">function name</dfn>,
+						<dfn data-cite="shacl12-core#dfn-key-parameter" data-lt="key parameter">key parameter</dfn>,
+						<dfn data-cite="shacl12-core#dfn-output-nodes" data-lt="output nodes">output nodes</dfn>,
+						<dfn data-cite="shacl12-core#dfn-focus-graph" data-lt="focus graph">focus graph</dfn>,
+						<dfn data-cite="shacl12-core#dfn-conform" data-lt="conform|conforms">conform</dfn>,
+						<dfn data-cite="shacl12-core#dfn-failure" data-lt="failure|failures">failure</dfn>,
+						<dfn data-cite="shacl12-core#dfn-shacl-instance" data-lt="shacl instance">SHACL instance</dfn>,
+						<dfn data-cite="shacl12-core#dfn-shacl-subclass" data-lt="shacl subclass">SHACL subclass</dfn>,
+						<dfn data-cite="shacl12-core#dfn-shacl-type" data-lt="shacl type">SHACL type</dfn>,
+						<dfn data-cite="shacl12-core#dfn-well-formed" data-lt="well-formed">well-formed</dfn>,
+						as defined in the SHACL 1.2 Core specification [[!shacl12-core]].
+					</div>
+				</div>
 			</section>
 			<section class="conventions">
 				<h3>Document Conventions</h3>
 				<p>
-					Some examples in this document use Turtle [[turtle]]. The reader is expected to be familiar with SHACL [[shacl]] and SPARQL
-					[[sparql-query]].
+					Some examples in this document use Turtle [[rdf12-turtle]].
+					The reader is expected to be familiar with SHACL [[shacl12-core]] and SPARQL
+					[[sparql12-query]].
 				</p>
 				<p>Within this document, the following namespace prefix bindings are used:</p>
 				<table class="term-table">
@@ -592,9 +561,156 @@
 
 
 
-		<section id="section">
-			<h2>Section</h2>
-			<p>Content.</p>
+		<section id="library">
+			<h2>Node Expression Library</h2>
+			<p>
+				This section defines all <a>node expression functions</a> that are built into SHACL engines
+				that implement this specification.
+			</p>
+			<section id="library-constants">
+				<h3>Constant Node Expressions</h3>
+				<p>
+					The <a>node expression functions</a> in this section were already introduced in the SHACL Core
+					specificiation but are repeated here to keep this document self-contained.
+				</p>
+				
+				<section id="IRIExpression">
+					<h3>IRI Expressions</h3>
+					<p>
+						A <a>node expression</a> that is a <a>IRI</a> is called an <dfn>IRI expression</dfn> with the <a>function name</a>
+						<code>sh:IRIExpression</code>.
+					</p>
+					<p class="syntax">
+						<span data-syntax-rule="IRIExpression-syntax">A node in an RDF graph is a <a>well-formed</a> <a>IRI expression</a> if it is an <a>IRI</a>.</span>
+					</p>
+					<div class="def" id="IRIExpression-evaluation">
+						<div class="def-header">EVALUATION OF IRI EXPRESSIONS</div>
+						<p>
+							The <a>output nodes</a> of an <a>IRI expression</a> are the list consisting of exactly the <a>node expression</a> itself:
+							<br/>
+							<br/>
+							<code>evalExpr(expr, focusGraph, focusNode, scope) -> [expr]</code>
+						</p>
+					</div>
+				</section>
+				
+				<section id="LiteralExpression">
+					<h3>Literal Expressions</h3>
+					<p>
+						A <a>node expression</a> that is a <a>literal</a> is called a <dfn>literal expression</dfn> with the <a>function name</a>
+						<code>sh:LiteralExpression</code>.
+					</p>
+					<p class="syntax">
+						<span data-syntax-rule="LiteralExpression-syntax">A node in an RDF graph is a <a>well-formed</a> <a>literal expression</a> if it is a <a>literal</a>.</span>
+					</p>
+					<div class="def" id="LiteralExpression-evaluation">
+						<div class="def-header">EVALUATION OF LITERAL EXPRESSIONS</div>
+						<p>
+							The <a>output nodes</a> of a <a>literal expression</a> are the list consisting of exactly the <a>node expression</a> itself:
+							<br/>
+							<br/>
+							<code>evalExpr(expr, focusGraph, focusNode, scope) -> [expr]</code>
+						</p>
+					</div>
+				</section>
+
+			</section>
+			<section>
+				<h2>Basic Node Expressions</h2>
+
+				<section id="VarExpression">
+					<h3>Var Expressions</h3>
+					<p>
+						A <a>blank node</a> that has a <a>value</a> for <code>sh:var</code>
+						is called a <dfn>var expression</dfn> with the <a>function name</a> <code>sh:VarExpression</code>.
+					</p>
+					<p class="syntax">
+						<span data-syntax-rule="VarExpression-syntax">A node in an RDF graph is a <a>well-formed</a> <a>var expression</a> if it is a <a>blank node</a>
+						that is the <a>subject</a> of exactly one <a>triple</a> in the <a>shapes graph</a> and the <a>predicate</a> of this <a>triple</a> is <code>sh:var</code>
+						and the <a>object</a> of this <a>triple</a> is an <code>xsd:string</code> <a>literal</a> with a minimum length of <code>1</code>.</span>
+					</p>
+					<div class="def" id="VarExpression-evaluation">
+						<div class="def-header">EVALUATION OF VAR EXPRESSIONS</div>
+						<p>
+							Let <code>var</code> be the <a>value</a> of <code>sh:var</code> in the <a>var expression</a>.
+							The <a>output nodes</a> of the <a>var expression</a> are computed as follows, in order:
+						</p>
+						<ol>
+							<li>if <code>var</code> is <code>"focusNode"</code> then <code>evalExpr(expr, focusGraph, focusNode, scope) -> [focusNode]</code></li>
+							<li>if <code>var</code> is in the <code>scope</code> then <code>evalExpr(expr, focusGraph, focusNode, scope) -> [ scope[var] ]</code></li>
+							<li>otherwise <code>evalExpr(expr, focusGraph, focusNode, scope) -> []</code></li>
+						</ol>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p>
+						The following example illustrates the use of a <a>var expression</a> pointing at the current <a>focus node</a>
+						to state that the default value of the <code>ex:loves</code> relationship is the current instance of <code>ex:Person</code>,
+						creating a self-reference.
+					</p>
+					<p>
+						<aside class="example" title="A var expression stating that any Person loves him or herself by default.">
+							<div class="shapes-graph">
+								<div class="turtle">
+ex:Person
+	a sh:ShapeClass ;
+	sh:property ex:Person-loves .
+
+ex:Person-loves
+	a sh:PropertyShape ;
+	sh:path ex:loves ;
+	sh:defaultValue <b>[ sh:var "focusNode" ] .</b>
+								</div>
+								<div class="jsonld">
+									TODO
+								</div>
+							</div>
+						</aside>
+					</p>
+				</section>
+
+				<section id="PathExpression">
+					<h3>Path Expressions</h3>
+					<p>
+						A <a>blank node</a> that has a <a>value</a> for <code>sh:path</code>
+						is called a <dfn>path expression</dfn> with the <a>function name</a> <code>sh:PathExpression</code>.
+					</p>
+					<p class="syntax">
+						<span data-syntax-rule="PathExpression-syntax">A node in an RDF graph is a <a>well-formed</a> <a>path expression</a> if it is a <a>blank node</a>
+						that is the <a>subject</a> of exactly one <a>triple</a> in the <a>shapes graph</a> where the <a>predicate</a> is <code>sh:path</code>
+						and the <a>object</a> is a <a>well-formed</a> <a>SHACL property path</a>.
+						The <a>path expression</a> may be the subject of exactly one more <a>triple</a>, with the <a>predicate</a> of that <a>triple</a>
+						being <code>sh:nodes</code> and the <a>object</a> a <a>well-formed</a> <a>node expression</a>.
+						</span>
+					</p>
+					<div class="def" id="PathExpression-evaluation">
+						<div class="def-header">EVALUATION OF PATH EXPRESSIONS</div>
+						<p>
+							Let <code>path</code> be the <a>value</a> of <code>sh:path</code>,
+							and <code>nodes</code> be the <a>value</a> of <code>sh:nodes</code> in the <a>path expression</a>.
+							If <code>sh:nodes</code> is not given, <code>nodes</code> is the list consistent of exactly the <a>focus node</a>.
+							The <a>output nodes</a> of the <a>path expression</a> are the list of <a>nodes</a> produced by TODO
+
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p>
+						The following example illustrates the use of a <a>path expression</a> TODO
+					</p>
+					<p>
+						<aside class="example" title="TODO">
+							<div class="shapes-graph">
+								<div class="turtle">
+									TODO
+								</div>
+								<div class="jsonld">
+									TODO
+								</div>
+							</div>
+						</aside>
+					</p>
+				</section>
+
+			</section>
 		</section>
 
 		<section id="syntax-rules" class="appendix">

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -615,7 +615,8 @@
 				</section>
 
 			</section>
-			<section>
+
+			<section id="library-basic">
 				<h2>Basic Node Expressions</h2>
 
 				<section id="VarExpression">
@@ -668,6 +669,11 @@ ex:Person-loves
 					</p>
 				</section>
 
+				<section id="ListExpression">
+					<h3>List Expressions</h3>
+					<p class="todo">TODO</p>
+				</section>
+
 				<section id="PathExpression">
 					<h3>Path Expressions</h3>
 					<p>
@@ -688,19 +694,39 @@ ex:Person-loves
 							Let <code>path</code> be the <a>value</a> of <code>sh:path</code>,
 							and <code>nodes</code> be the <a>value</a> of <code>sh:nodes</code> in the <a>path expression</a>.
 							If <code>sh:nodes</code> is not given, <code>nodes</code> is the list consistent of exactly the <a>focus node</a>.
-							The <a>output nodes</a> of the <a>path expression</a> are the list of <a>nodes</a> produced by TODO
-
+							Let <code>N</code> be the nodes produced by <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
+							The <a>output nodes</a> of the <a>path expression</a> are the list of <a>nodes</a> produced by concatenating
+							the <a>value nodes</a> of the <code>path</code> at each <a>node</a> in <code>N</code>.
 						</p>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
 					<p>
-						The following example illustrates the use of a <a>path expression</a> TODO
+						The following example illustrates the use of a <a>path expression</a> to compute the values
+						of the property <code>ex:topConceptCount</code>.
+						The path expression returns the values of <code>skos:hasTopConcept</code> at each <code>skos:ConceptScheme</code>
+						and these are processed by the <a href="#CountExpression"><code>sh:count</code></a> to return the
+						number of top concepts.
 					</p>
 					<p>
 						<aside class="example" title="TODO">
 							<div class="shapes-graph">
 								<div class="turtle">
-									TODO
+skos:ConceptScheme
+	a sh:ShapeClass ;
+	sh:property skos:ConceptScheme-topConceptCount .
+
+skos:ConceptScheme-topConceptCount
+	a sh:PropertyShape ;
+	sh:path ex:topConceptCount ;
+	sh:datatype xsd:integer ;
+	sh:description "The number of top concepts in this scheme." ;
+	sh:maxCount 1 ;
+	sh:name "top concept count" ;
+	sh:values [
+		sh:count [
+			<b>sh:path skos:hasTopConcept</b> ;
+		] ;
+	] .								
 								</div>
 								<div class="jsonld">
 									TODO
@@ -708,9 +734,81 @@ ex:Person-loves
 							</div>
 						</aside>
 					</p>
+					<p class="todo">TODO: Add second example that uses sh:nodes</p>
+				</section>
+
+				<section id="IfExpression">
+					<h3>If Expressions</h3>
+					<p class="todo">TODO</p>
 				</section>
 
 			</section>
+
+			<section id="library-list-operators">
+				<h2>List Operator Expressions</h2>
+
+				<section id="DistinctExpression">
+					<h3>Distinct Expressions</h3>
+					<p class="todo">TODO</p>
+				</section>
+
+				<section id="IntersectionExpression">
+					<h3>Intersection Expressions</h3>
+					<p class="todo">TODO</p>
+				</section>
+
+				<section id="UnionExpression">
+					<h3>Union Expressions</h3>
+					<p class="todo">TODO</p>
+				</section>
+
+				<section id="MinusExpression">
+					<h3>Minus Expressions</h3>
+					<p class="todo">TODO</p>
+				</section>
+
+				<section id="OrderByExpression">
+					<h3>OrderBy Expressions</h3>
+					<p class="todo">TODO</p>
+				</section>
+
+				<section id="LimitExpression">
+					<h3>Limit Expressions</h3>
+					<p class="todo">TODO</p>
+				</section>
+
+				<section id="OffsetExpression">
+					<h3>Offset Expressions</h3>
+					<p class="todo">TODO</p>
+				</section>
+
+			</section>
+
+			<section id="library-aggregation">
+				<h2>Aggregation Expressions</h2>
+
+				<section id="CountExpression">
+					<h3>Count Expressions</h3>
+					<p class="todo">TODO</p>
+				</section>
+
+				<section id="MinExpression">
+					<h3>Min Expressions</h3>
+					<p class="todo">TODO</p>
+				</section>
+
+				<section id="MaxExpression">
+					<h3>Max Expressions</h3>
+					<p class="todo">TODO</p>
+				</section>
+
+				<section id="SumExpression">
+					<h3>Sum Expressions</h3>
+					<p class="todo">TODO</p>
+				</section>
+
+			</section>
+
 		</section>
 
 		<section id="syntax-rules" class="appendix">

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -579,7 +579,7 @@
 				<section id="IRIExpression">
 					<h3>IRI Expressions</h3>
 					<p>
-						A <a>node expression</a> that is a <a>IRI</a> is called an <dfn>IRI expression</dfn> with the <a>function name</a>
+						A <a>node expression</a> that is an <a>IRI</a> is called an <dfn>IRI expression</dfn> with the <a>function name</a>
 						<code>sh:IRIExpression</code>.
 					</p>
 					<p class="syntax">
@@ -786,7 +786,7 @@ ex:Person-loves
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
 					<p>
-						The following example illustrates the use of a <a>path expression</a> to compute the values
+						The following example illustrates the use of a <a>path expression</a> to compute the value
 						of the property <code>ex:topConceptCount</code>.
 						The path expression returns the values of <code>skos:hasTopConcept</code> at each <code>skos:ConceptScheme</code>
 						and these are processed by the <a href="#CountExpression"><code>sh:count</code></a> to return the
@@ -849,7 +849,7 @@ skos:ConceptScheme-topConceptCount
 										<td><code>sh:then</code></td>
 										<td>
 											A <a>well-formed</a> <a>node expression</a>.
-											Optional, if <code>sh:else</code> exists.
+											Optional but at least one of <code>sh:then</code> or <code>sh:else</code> is required.
 										</td>
 										<td>
 											The <a>node expression</a> that is returned when the <code>sh:if</code> evaluated to <code>[true]</code>.
@@ -859,7 +859,7 @@ skos:ConceptScheme-topConceptCount
 										<td><code>sh:else</code></td>
 										<td>
 											A <a>well-formed</a> <a>node expression</a>.
-											Optional, if <code>sh:then</code> exists.
+											Optional but at least one of <code>sh:then</code> or <code>sh:else</code> is required.
 										</td>
 										<td>
 											The <a>node expression</a> that is returned when the <code>sh:if</code> did not evaluate to <code>[true]</code>.
@@ -954,8 +954,8 @@ skos:ConceptScheme-topConceptCount
 						<div class="def-header">EVALUATION OF INTERSECTION EXPRESSIONS</div>
 						<p>
 							Let <code>members</code> be the <a>members</a> of the <a>value</a> of <code>sh:intersection</code> in the <a>intersection expression</a>.
-							The <a>output nodes</a> of the <a>intersection expression</a> are the list of <a>nodes</a> that are in all <a>output nodes</a>
-							for each <a>node expression</a> <code>NE</code> in <code>members</code>, using <code>evalExpr(NE, focusGraph, focusNode, scope)</code>.
+							The <a>output nodes</a> of the <a>intersection expression</a> are the <a>nodes</a> that form the intersection of the <a>output nodes</a>
+							produced by each <a>node expression</a> <code>NE</code> in <code>members</code>, using <code>evalExpr(NE, focusGraph, focusNode, scope)</code>.
 							Nodes must be equal using <a>term equality</a>, i.e. <code>"01"^^xsd:integer</code> is distinct from <code>"1"^^xsd:integer</code>.
 						</p>
 					</div>
@@ -995,7 +995,7 @@ skos:ConceptScheme-topConceptCount
 							Let <code>members</code> be the <a>members</a> of the <a>value</a> of <code>sh:union</code> in the <a>union expression</a>.
 							The <a>output nodes</a> of the <a>union expression</a> are the concatenation of all <a>output nodes</a>
 							for each <a>node expression</a> <code>NE</code> in <code>members</code>, using <code>evalExpr(NE, focusGraph, focusNode, scope)</code>.
-							The order is preserved, evaluating the <code>members</code> from left to right and keeping the order of each list.
+							The order is preserved, evaluating the <code>members</code> from left to right and keeping the order of each set of output nodes.
 						</p>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
@@ -1149,7 +1149,7 @@ skos:ConceptScheme-topConceptCount
 							Let <code>offset</code> be the <a>value</a> of <code>sh:offset</code>
 							and <code>nodes</code> be the <a>value</a> of <code>sh:nodes</code> in the <a>offset expression</a>.
 							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
-							The <a>output nodes</a> of the <a>offset expression</a> are the a>nodes</a> in <code>N</code>
+							The <a>output nodes</a> of the <a>offset expression</a> are the <a>nodes</a> in <code>N</code>
 							except for the first <code>offset</code> nodes from left to right, in the same order.
 						</p>
 					</div>


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

This is an initial contribution from me to the Node Expressions document, introducing the definitions of the supported Node Expression types that were mostly already present in SHACL-AF. This isn't complete but hopefully a starting point that gets the ball rolling. Some details are missing but we mainly need to add examples. I copied some of the latest JS support code and styles from the Core spec.

I have added myself as editor too, if that's OK.

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/hk-node-expr-start/shacl12-node-expr/index.html)
