### PR TITLE
Update SHACL Core Outline Section

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -471,17 +471,17 @@
 				The introduction includes a <a href="#terminology">Terminology</a> section.
 			</p>
 			<p>
-				The sections 2 and 3 cover SHACL shapes, constraints, as well as property paths.
+				Sections 2 and 3 cover SHACL shapes and constraints, as well as property paths.
 			</p>
 			<p>
-				The section 4 introduces node expressions, while section 5 defines validation in SHACL.
+				Section 4 introduces node expressions, while section 5 defines validation in SHACL.
 			</p>
 			<p>
-				The section 6 defines the built-in SHACL Core constraint components. Meanwhile, section 7 discusses non-validating properties.
+				Section 6 defines the built-in SHACL Core constraint components, and section 7 discusses non-validating properties.
 			</p>
 			<p>
 				The syntax of SHACL is RDF.
-				The examples in this document use Turtle [[rdf12-turtle]], JSON-LD [[json-ld]] and SHACL-C [[shacl12-shacl-c]].
+				The examples in this document use Turtle [[rdf12-turtle]], JSON-LD [[json-ld]], and SHACL-C [[shacl12-shacl-c]].
 				Other RDF serializations such as RDF/XML may be used in practice.
 				The reader should be familiar with basic RDF concepts [[rdf12-concepts]] such as triples.
 			</p>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -481,7 +481,7 @@
 			</p>
 			<p>
 				The syntax of SHACL is RDF.
-				The examples in this document use Turtle [[rdf12-turtle]], JSON-LD [[json-ld]], and SHACL-C [[shacl12-shacl-c]].
+				The examples in this document use Turtle [[rdf12-turtle]], JSON-LD [[json-ld]], and SHACL-C [[?shacl12-shacl-c]].
 				Other RDF serializations such as RDF/XML may be used in practice.
 				The reader should be familiar with basic RDF concepts [[rdf12-concepts]] such as triples.
 			</p>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -158,6 +158,12 @@
 						href: "https://w3c.github.io/data-shapes/shacl12-shacl-shacl/",
 						status: "ED",
 						publisher: "W3C",
+					},
+					"shacl12-shacl-c": {
+						title: "SHACL Compact Syntax",
+						href: "https://w3c.github.io/data-shapes/shacl-compact-syntax/",
+						status: "ED",
+						publisher: "W3C",
 					}
 				}
 			};
@@ -475,7 +481,7 @@
 			</p>
 			<p>
 				The syntax of SHACL is RDF.
-				The examples in this document use Turtle [[rdf12-turtle]], JSON-LD [[json-ld]] and SHACL-C.
+				The examples in this document use Turtle [[rdf12-turtle]], JSON-LD [[json-ld]] and SHACL-C [[shacl12-shacl-c]].
 				Other RDF serializations such as RDF/XML may be used in practice.
 				The reader should be familiar with basic RDF concepts [[rdf12-concepts]] such as triples.
 			</p>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -465,8 +465,17 @@
 				The introduction includes a <a href="#terminology">Terminology</a> section.
 			</p>
 			<p>
+				The sections 2 and 3 cover SHACL shapes, constraints, as well as property paths.
+			</p>
+			<p>
+				The section 4 introduces node expressions, while section 5 defines validation in SHACL.
+			</p>
+			<p>
+				The section 6 defines the built-in SHACL Core constraint components. Meanwhile, section 7 discusses non-validating properties.
+			</p>
+			<p>
 				The syntax of SHACL is RDF.
-				The examples in this document use Turtle [[rdf12-turtle]] and (in one instance) JSON-LD [[json-ld]].
+				The examples in this document use Turtle [[rdf12-turtle]], JSON-LD [[json-ld]] and SHACL-C.
 				Other RDF serializations such as RDF/XML may be used in practice.
 				The reader should be familiar with basic RDF concepts [[rdf12-concepts]] such as triples.
 			</p>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -7936,6 +7936,7 @@ ex:NameGroup
 				<li>Added the new constraint component <a href="#NodeByExpressionConstraintComponent"><code>sh:nodeByExpression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/408">Issue 408</a></li>
 				<li>Added the new value <code>sh:ByTypes</code> for <a href="#ClosedConstraintComponent"><code>sh:closed</code></a>; see <a href="https://github.com/w3c/data-shapes/issues/172">Issue 172</a></li>
 				<li>The values of <a href="#ClassConstraintComponent"><code>sh:class</code></a> and <a href="#DatatypeConstraintComponent"><code>sh:datatype</code></a> can now also be lists, indicating a union of choices; see <a href="https://github.com/w3c/data-shapes/issues/160">Issue 160</a></li>
+				<li>Added the new constraint component <a href="#ReifierShapeShapeConstraintComponent"><code>sh:ReifierShape</code></a>; see <a href="https://github.com/w3c/data-shapes/issues/300">Issue 300</a></li>
 			</ul>
 		</section>
 	


### PR DESCRIPTION
Closes #442 

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-442-update-core-outline/shacl12-core/index.html#document-outline)
