### PR TITLE
Create SHACL Compact Syntax 1.2 specification document

### DIFF
--- a/shacl12-compact-syntax/SHACLC.g4
+++ b/shacl12-compact-syntax/SHACLC.g4
@@ -1,0 +1,117 @@
+grammar SHACLC;
+
+shaclDoc            : directive* (nodeShape|shapeClass)* EOF;
+
+directive           : baseDecl | importsDecl | prefixDecl ;
+baseDecl            : KW_BASE  IRIREF ;
+importsDecl         : KW_IMPORTS IRIREF ;
+prefixDecl          : KW_PREFIX PNAME_NS IRIREF ;
+
+shapeClass          : KW_SHAPE_CLASS iri nodeShapeBody ;
+nodeShape           : KW_SHAPE iri targetClass? nodeShapeBody ;
+nodeShapeBody       : '{' constraint* '}';
+targetClass         : '->' iri+ ;
+
+constraint          : ( nodeOr+ | propertyShape ) '.' ;
+nodeOr              : nodeNot ( '|' nodeNot) * ;
+nodeNot             : negation? nodeValue ;
+nodeValue           : nodeParam '=' iriOrLiteralOrArray ;
+
+propertyShape       : path ( propertyCount | propertyOr )* ;
+propertyOr          : propertyNot ( '|' propertyNot) * ;
+propertyNot         : negation? propertyAtom ;
+propertyAtom        : propertyType | nodeKind | shapeRef | propertyValue | nodeShapeBody ;
+propertyCount       : '[' propertyMinCount '..' propertyMaxCount ']' ;
+propertyMinCount    : INTEGER ;
+propertyMaxCount    : (INTEGER | '*') ;
+propertyType        : iri ;
+nodeKind            : 'BlankNode' | 'IRI' | 'Literal' | 'BlankNodeOrIRI' | 'BlankNodeOrLiteral' | 'IRIOrLiteral' ;
+shapeRef            : ATPNAME_LN | ATPNAME_NS | '@' IRIREF ;
+propertyValue       : propertyParam '=' iriOrLiteralOrArray ;
+negation            : '!' ;
+
+path                : pathAlternative ;
+pathAlternative     : pathSequence ( '|' pathSequence )* ;
+pathSequence        : pathEltOrInverse ( '/' pathEltOrInverse )* ;
+pathElt             : pathPrimary pathMod? ;
+pathEltOrInverse    : pathElt | pathInverse pathElt ;
+pathInverse         : '^' ;
+pathMod             : '?' | '*' | '+' ;
+pathPrimary         : iri | '(' path ')' ;
+
+iriOrLiteralOrArray : iriOrLiteral | array ;
+iriOrLiteral        : iri | literal ;
+
+iri                 : IRIREF | prefixedName ;
+prefixedName        : PNAME_LN | PNAME_NS ;
+
+literal             : rdfLiteral | numericLiteral | booleanLiteral ;
+booleanLiteral      : KW_TRUE | KW_FALSE ;
+numericLiteral      : INTEGER | DECIMAL | DOUBLE ;
+rdfLiteral          : string (LANGTAG | '^^' datatype)? ;
+datatype            : iri ;
+string              : STRING_LITERAL_LONG1 | STRING_LITERAL_LONG2 | STRING_LITERAL1 | STRING_LITERAL2 ;
+
+array               : '[' iriOrLiteral* ']' ;
+
+nodeParam           : 'targetNode' | 'targetObjectsOf' | 'targetSubjectsOf' |
+                      'deactivated' | 'severity' | 'message' |
+                      'class' | 'datatype' | 'nodeKind' |
+                      'minExclusive' | 'minInclusive' | 'maxExclusive' | 'maxInclusive' |
+                      'minLength' | 'maxLength' | 'pattern' | 'flags' | 'languageIn' |
+                      'equals' | 'disjoint' |
+                      'closed' | 'ignoredProperties' | 'hasValue' | 'in' ;
+
+propertyParam       : 'deactivated' | 'severity' | 'message' |
+                      'class' | 'datatype' | 'nodeKind' |
+                      'minExclusive' | 'minInclusive' | 'maxExclusive' | 'maxInclusive' |
+                      'minLength' | 'maxLength' | 'pattern' | 'flags' | 'languageIn' | 'uniqueLang' |
+                      'equals' | 'disjoint' | 'lessThan' | 'lessThanOrEquals' |
+                      'qualifiedValueShape' | 'qualifiedMinCount' | 'qualifiedMaxCount' | 'qualifiedValueShapesDisjoint' |
+                      'closed' | 'ignoredProperties' | 'hasValue' | 'in' ;
+
+// Keywords
+KW_BASE             : 'BASE' ;
+KW_IMPORTS          : 'IMPORTS' ;
+KW_PREFIX           : 'PREFIX' ;
+
+KW_SHAPE_CLASS      : 'shapeClass' ;
+KW_SHAPE            : 'shape' ;
+
+KW_TRUE             : 'true' ;
+KW_FALSE            : 'false' ;
+
+// Terminals
+PASS                : [ \t\r\n]+ -> skip;
+COMMENT             : '#' ~[\r\n]* -> skip;
+
+IRIREF              : '<' (~[\u0000-\u0020=<>\"{}|^`\\] | UCHAR)* '>' ;
+PNAME_NS            : PN_PREFIX? ':' ;
+PNAME_LN            : PNAME_NS PN_LOCAL ;
+ATPNAME_NS          : '@' PN_PREFIX? ':' ;
+ATPNAME_LN          : '@' PNAME_NS PN_LOCAL ;
+LANGTAG             : '@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)* ;
+INTEGER             : [+-]? [0-9]+ ;
+DECIMAL             : [+-]? [0-9]* '.' [0-9]+ ;
+DOUBLE              : [+-]? ([0-9]+ '.' [0-9]* EXPONENT | '.'? [0-9]+ EXPONENT) ;
+fragment EXPONENT   : [eE] [+-]? [0-9]+ ;
+STRING_LITERAL1     : '\'' (~[\u0027\u005C\u000A\u000D] | ECHAR | UCHAR)* '\'' ;
+STRING_LITERAL2     : '"' (~[\u0022\u005C\u000A\u000D] | ECHAR | UCHAR)* '"' ;
+STRING_LITERAL_LONG1: '\'\'\'' (('\'' | '\'\'')? (~[\'\\] | ECHAR | UCHAR))* '\'\'\'' ;
+STRING_LITERAL_LONG2: '"""' (('"' | '""')? (~[\"\\] | ECHAR | UCHAR))* '"""' ;
+fragment UCHAR      : '\\u' HEX HEX HEX HEX | '\\U' HEX HEX HEX HEX HEX HEX HEX HEX ;
+fragment ECHAR      : '\\' [tbnrf\\\"\'] ;
+fragment WS         : [\u0020\u0009\u000D\u000A] ;
+fragment PN_CHARS_BASE: [A-Z] | [a-z] | [\u00C0-\u00D6] | [\u00D8-\u00F6] | [\u00F8-\u02FF] | [\u0370-\u037D]
+                       | [\u037F-\u1FFF] | [\u200C-\u200D] | [\u2070-\u218F] | [\u2C00-\u2FEF] | [\u3001-\uD7FF]
+                       | [\uF900-\uFDCF] | [\uFDF0-\uFFFD]
+					   		   ;
+fragment PN_CHARS_U : PN_CHARS_BASE | '_' ;
+fragment PN_CHARS   : PN_CHARS_U | '-' | [0-9] | [\u00B7] | [\u0300-\u036F] | [\u203F-\u2040] ;
+fragment PN_PREFIX  : PN_CHARS_BASE ((PN_CHARS | '.')* PN_CHARS)? ;
+fragment PN_LOCAL   : (PN_CHARS_U | ':' | [0-9] | PLX) ((PN_CHARS | '.' | ':' | PLX)* (PN_CHARS | ':' | PLX))? ;
+fragment PLX        : PERCENT | PN_LOCAL_ESC ;
+fragment PERCENT    : '%' HEX HEX ;
+fragment HEX        : [0-9] | [A-F] | [a-f] ;
+fragment PN_LOCAL_ESC: '\\' ('_' | '~' | '.' | '-' | '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ','
+                       | ';' | '=' | '/' | '?' | '#' | '@' | '%') ;

--- a/shacl12-compact-syntax/index.html
+++ b/shacl12-compact-syntax/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>SHACL Compact Syntax</title>
+		<meta charset="utf-8">
+	</head>
+	<body>
+		<p>
+			This Editors Draft is intentionally left blank.
+			It is intended to overwrite the earlier editor's draft which documented a proposed design.
+			That proposal did not reach consensus within the Working Group and should not be used.
+		</p>
+		<p>
+			The definition of a SHACL Compact Syntax is being continued by the
+			<a href="https://w3c.github.io/shacl/shacl-compact-syntax/">SHACL Community Group</a>.
+		</p>
+	</body>
+</html>

--- a/shacl12-compact-syntax/index.html
+++ b/shacl12-compact-syntax/index.html
@@ -3,16 +3,817 @@
 	<head>
 		<title>SHACL Compact Syntax</title>
 		<meta charset="utf-8">
+		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" async class="remove"></script>
+		<script class="remove">
+		
+			var respecConfig = {
+				edDraftURI: "https://w3c.github.io/shacl/shacl-compact-syntax/",
+				// issueBase: "http://www.w3.org/2014/data-shapes/track/issues/",
+				specStatus: "CG-DRAFT",
+				shortName:  "shacl-compact-syntax",
+				editors: [
+					{
+						name:       "Vladimir Alexiev",
+						url:        "https://github.com/VladimirAlexiev/my",
+						company:    "Ontotext Corp",
+						companyURL: "http://ontotext.com",
+            w3cid: 	    56618
+					},
+					{
+						name:       "Jesse Wright",
+						company:    "University of Oxford",
+						companyURL: "https://www.cs.ox.ac.uk",
+						mailto:     "jesse@jeswr.org",
+						w3cid:      132252
+					},
+				],
+				formerEditors: [
+					{
+						name:       "Holger Knublauch",
+						url:        "http://knublauch.com/",
+						company:    "TopQuadrant, Inc.",
+						companyURL: "http://topquadrant.com/",
+						w3cid:      46500
+					}
+				],
+				publishDate:  "2018-01-09",
+				wg:           "SHACL Community Group",
+				wgURI:        "https://www.w3.org/community/shacl/",
+				wgPublicList: "public-shacl",
+				wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/73865/status",
+				noHighlightCSS: true
+			};
+		</script>
+		<style>
+
+			pre {
+				tab-size: 3;
+				-moz-tab-size: 3; /* Code for Firefox */
+				-o-tab-size: 3; /* Code for Opera */
+			}
+
+			th {
+				text-align: left;
+			}
+			table.rule { background-color: #EBEBE0; }
+			table.rule td { text-align: center; }
+			td.up { border-bottom:1px solid black; }
+			
+			td {
+				vertical-align: top;
+			}
+			
+			.algorithm {
+				background: #fafafc;
+				border-left-style: solid;
+				border-left-width: .5em;
+				border-color: #c0c0c0;
+				margin-bottom: 16px;
+				padding: 8px;
+			}
+			
+			.arg {
+				font-weight: bold;
+				color: #000080;
+			}
+
+			.def {
+				background: #fcfcfc;
+				border-left-style: solid;
+				border-left-width: .5em;
+				border-color: #c0c0c0;
+				margin-bottom: 16px;
+			}
+			
+			.def-sparql {
+			}
+			
+			.def-sparql-body {
+				margin-top: 0px;
+				margin-bottom: 0px;
+			}
+			
+			.def-text {
+			}
+			
+			.def-text-body {
+			}
+			
+			.def-header {
+				color: #a0a0a0;
+				font-size: 16px;
+				padding-bottom: 8px;
+			}
+			
+			.diagram-class {
+				border: 1px solid black; 
+				border-radius: 4px; 
+				width: 360px;
+			}
+			
+			.diagram-class-name {
+				font-size: 16px; 
+				font-weight: bold; 
+				text-align: center;
+			}
+			
+			.diagram-class-properties {
+				border-top: 1px solid black; 
+			}
+			
+			.diagram-class-properties-start {
+				padding: 8px;
+			}
+			
+			.diagram-class-properties-section {
+				border-top: 1px dashed #808080;
+				padding: 8px;
+			}
+			
+			.focus-node-selected {
+				color: blue;
+			}
+			.focus-node-error {
+				color: red;
+			}
+
+			.triple-can-be-skipped {
+				color: grey;
+			}
+			.focus-node-error {
+				color: red;
+			}
+			
+			.rule {
+			}
+
+			.target-can-be-skipped{
+				color: darkslategray;
+				font-style: italic;
+				data-tooltip: "Custom tooltip text." ;
+				data-tooltip-position: "bottom" ;
+			}
+			
+			.component-class {
+				font-weight: bold;
+				font-size: 16px;
+			}
+			
+			.parameter-context {
+				font-weight: bold;
+				font-size: 16px;
+			}
+			
+			.parameters {
+				font-weight: bold;
+				font-size: 16px;
+			}
+
+			.part-header {
+				font-weight: bold;
+			}
+			
+			.syntax {
+				border-left-style: solid;
+				border-left-width: .5em;
+				border-color: #d0d0d0;
+				margin-bottom: 16px;
+				padding: .5em 1em;
+				background-color: #f6f6f6;
+			}
+			
+			.syntax-rule-id {
+				padding-right: 10px;
+			}
+			
+			.syntax-rule-id-a {
+				white-space: nowrap;
+			}
+			
+			.validator-id-a {
+				font-weight: bold;
+				white-space: nowrap;
+			}
+		
+			.term {
+				font-style: italic;
+			}
+			
+			.term-def-header {
+				font-style: italic;
+				font-weight: bold;
+			}
+		
+			.term-table {
+				border-collapse: collapse;
+				border-color: #000000;
+				margin: 16px;
+			}
+
+			.term-table td, th {
+				border-width: 1px;
+				border-style: solid;
+				padding: 5px;
+			}
+		
+			.todo {
+				color: red;
+			}
+
+			/* example pre taken / adapted from R2RML */
+			pre.grammar, pre.example-shapes, pre.example-shapes-ttl, pre.example-results, pre.example-other, pre.example-js { margin-left: 0; padding: 0 2em; margin-top: 1.5em; padding: 1em; }
+			pre.example-shapes:before, pre.example-shapes-ttl:before, pre.example-js:before, pre.example-results:before, pre.example-other:before { background: white; display: block; font-family: sans-serif; margin: -1em 0 0.4em -1em; padding: 0.2em 1em; }
+			pre.example-shapes { background: #eeb; }
+			pre.example-shapes, pre.example-shapes:before { border: 1px solid #cc9; }
+			pre.example-shapes:before { color: #888; content: "Example in Compact Syntax"; width: 13em; }
+			pre.example-shapes-ttl { background: #deb; }
+			pre.grammar { background: #fdfdfd; border: 1px solid #e0e0e0; }
+			pre.example-shapes-ttl, pre.example-shapes-ttl:before { border: 1px solid #bbb; }
+			pre.example-shapes-ttl:before { color: #996; content: "Example in Turtle Syntax"; width: 13em; }
+			example-results { background: #edb; }
+			example-results, .example-results:before, .example-results th, .example-results td { border: 1px solid #aca; }
+			pre.example-results:before { color: #797; content: "Example validation results"; width: 13em; }
+			pre.example-other { background: #bed; }
+			pre.example-other, pre.example-other:before { border: 1px solid #ddd; }
+			pre.example-other:before { color: #888; content: "Example"; width: 13em; }
+
+			pre.example-js { background: #cceebe; }
+			pre.example-js, pre.example-js:before { border: 1px solid #cc9; }
+			pre.example-js:before { color: #996; content: "Example JavaScript"; width: 13em; }
+
+			/* our syntax menu for switching */
+			div.syntaxmenu {
+				border: 1px dotted black;
+				padding:0.5em;
+				margin: 1em; 
+			}
+
+			@media print {
+				div.syntaxmenu { display:none; }
+			}
+		</style>
 	</head>
 	<body>
-		<p>
-			This Editors Draft is intentionally left blank.
-			It is intended to overwrite the earlier editor's draft which documented a proposed design.
-			That proposal did not reach consensus within the Working Group and should not be used.
-		</p>
-		<p>
-			The definition of a SHACL Compact Syntax is being continued by the
-			<a href="https://w3c.github.io/shacl/shacl-compact-syntax/">SHACL Community Group</a>.
-		</p>
+
+		<section id="abstract">
+			<p>
+				The Shapes Constraint Language (SHACL) [[!shacl]] is a language for validating RDF graphs against a set of conditions.
+				SHACL consists of SHACL Core and SHACL-SPARQL which covers advanced features that use SPARQL-based constraints.
+				The syntax of SHACL is RDF.
+			</p>
+			<p>
+				This document defines the Compact Syntax for a subset of SHACL Core. 
+				The Compact Syntax offers an alternative notation to the general RDF-based notations for SHACL,
+				aimed at human editors and readers.
+			</p>
+		</section>
+
+		<section id="sotd">
+			This specification was started by the RDF Data Shapes WG but is now continued within the
+			SHACL Community Group.
+		</section>
+		
+		<section class="introductory">
+			<h2>Document Outline</h2>
+			<p>
+				Some examples in this document use Turtle [[!turtle]].
+				The reader is expected to be familiar with SHACL [[!shacl]].
+			</p>
+		</section>
+	
+		<section id="introduction">
+			<h2>Introduction</h2>
+
+			<section id="conventions">
+				<h3>Document Conventions</h3>
+				<p>
+					Within this document, the following namespace prefix bindings are used:
+				</p>
+				<table class="term-table">
+					<tr>
+						<th>Prefix</th>
+						<th>Namespace</th>
+					</tr>
+					<tr>
+						<td><code>rdf:</code></td>
+						<td><code>http://www.w3.org/1999/02/22-rdf-syntax-ns#</code></td>
+					</tr>
+					<tr>
+						<td><code>rdfs:</code></td>
+						<td><code>http://www.w3.org/2000/01/rdf-schema#</code></td>
+					</tr>
+					<tr>
+						<td><code>sh:</code></td>
+						<td><code>http://www.w3.org/ns/shacl#</code></td>
+					</tr>
+					<tr>
+						<td><code>xsd:</code></td>
+						<td><code>http://www.w3.org/2001/XMLSchema#</code></td>
+					</tr>
+					<tr>
+						<td><code>ex:</code></td>
+						<td><code>http://example.com/ns#</code></td>
+					</tr>
+				</table>
+			</section>
+			
+			<section class="informative" id="example">
+				<h3>An Example of the SHACL Compact Syntax</h3>
+				<p>
+					The following example illustrates key features of the SHACL Compact Syntax.
+					It is an extended version of the <a href="https://www.w3.org/TR/shacl/#shacl-example">Person Example</a> from [[!shacl]].
+				</p>
+				<pre class="example-shapes">
+BASE &lt;http://example.com/ns&gt;
+
+IMPORTS &lt;http://example.com/person-ontology&gt;
+
+PREFIX ex: &lt;http://example.com/ns#&gt;
+
+shape ex:PersonShape -> ex:Person {
+	closed=true ignoredProperties=[rdf:type] . 
+
+	ex:ssn       xsd:string [0..1] pattern="^\\d{3}-\\d{2}-\\d{4}$" .
+	ex:worksFor  IRI ex:Company [0..*] .
+	ex:address   BlankNode [0..1] {
+		ex:city xsd:string [1..1] .
+		ex:postalCode xsd:integer|xsd:string [1..1] maxLength=5 .
+	} .
+}</pre>
+				<p>
+					Using the <a href="#grammar-section"></a> this example is mapped to the following Turtle RDF graph: 
+				</p>
+				<pre class="example-shapes-ttl">
+@base &lt;http://example.com/ns&gt; .
+@prefix ex: &lt;http://example.com/ns#&gt; .
+@prefix owl: &lt;http://www.w3.org/2002/07/owl#&gt; .
+@prefix rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt; .
+@prefix rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt; .
+@prefix sh: &lt;http://www.w3.org/ns/shacl#&gt; .
+@prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt; .
+
+&lt;http://example.com/ns&gt;
+	rdf:type owl:Ontology ;
+	owl:imports &lt;http://example.com/person-ontology&gt; .
+
+ex:PersonShape
+	a sh:NodeShape ;
+	sh:targetClass ex:Person ;
+	sh:closed true ;
+	sh:ignoredProperties ( rdf:type ) ;
+	sh:property [
+		sh:path ex:ssn ;
+		sh:maxCount 1 ;
+		sh:datatype xsd:string ;
+		sh:pattern "^\\d{3}-\\d{2}-\\d{4}$" ;
+	] ;
+	sh:property [
+		sh:path ex:worksFor ;
+		sh:class ex:Company ;
+		sh:nodeKind sh:IRI ;
+	] ;
+	sh:property [
+		sh:path ex:address ;
+		sh:maxCount 1 ;
+		sh:nodeKind sh:BlankNode ;
+		sh:node [
+			sh:property [
+				sh:path ex:city ;
+				sh:datatype xsd:string ;
+				sh:minCount 1 ;
+				sh:maxCount 1 ;
+			] ;
+			sh:property [
+				sh:path ex:postalCode ;
+				sh:or ( [ sh:datatype xsd:integer ] [ sh:datatype xsd:string ] ) ;
+				sh:minCount 1 ;
+				sh:maxCount 1 ;
+				sh:maxLength 5 ;
+			] ;
+		] ;
+	] .</pre>
+				<p>
+					SHACL also supports a design pattern where shapes that are also declared to be classes apply to
+					all instances of the class.  The Compact Syntax includes the keyword <code>shapeClass</code>
+					for this case, as shown in the snippet below:
+				</p>
+				<pre class="example-shapes">
+shapeClass ex:Person {
+	...
+}</pre>
+				<p>
+					Compared to the example further above using <code>shape</code>, this would produce the following
+					RDF triples (with no <code>sh:targetClass</code> triple):
+				</p>
+				<pre class="example-shapes-ttl">
+ex:Person
+	a sh:NodeShape, rdfs:Class ;
+	...</pre>
+				<p>
+					The SHACL Compact Syntax can be used both as an exchange format but also as temporary editing input format. 
+					If SHACL Compact Syntax files are saved, the recommended file ending is <code>.shaclc</code>.
+				</p>
+			</section>
+		</section>
+		
+		<section id="grammar-section">
+			<h2>Grammar and Production Rules</h2>
+			<p>
+				The following grammar (in <a href="http://www.antlr.org/">ANTLR</a> format) defines the parsing rules
+				for the SHACL Compact Syntax.
+				Valid SHACL Compact Syntax documents must be parseable against this grammar,
+				must not cause any errors during the application of the <a href="#rules">production rules</a>
+				and furthermore produce no <a href="https://www.w3.org/TR/shacl/#dfn-ill-formed">ill-formed</a> nodes.
+			</p>
+			<pre id="grammar" class="grammar">
+grammar SHACLC;
+
+shaclDoc            : directive* (nodeShape|shapeClass)* EOF;
+
+directive           : baseDecl | importsDecl | prefixDecl ;
+baseDecl            : KW_BASE  IRIREF ;
+importsDecl         : KW_IMPORTS IRIREF ;
+prefixDecl          : KW_PREFIX PNAME_NS IRIREF ;
+
+nodeShape           : KW_SHAPE iri targetClass? nodeShapeBody ;
+shapeClass          : KW_SHAPE_CLASS iri nodeShapeBody ;
+nodeShapeBody       : '{' constraint* '}';
+targetClass         : '->' iri+ ;
+
+constraint          : ( nodeOr+ | propertyShape ) '.' ;
+nodeOr              : nodeNot ( '|' nodeNot) * ;
+nodeNot             : negation? nodeValue ;
+nodeValue           : nodeParam '=' iriOrLiteralOrArray ;
+
+propertyShape       : path ( propertyCount | propertyOr )* ;
+propertyOr          : propertyNot ( '|' propertyNot) * ;
+propertyNot         : negation? propertyAtom ;
+propertyAtom        : propertyType | nodeKind | shapeRef | propertyValue | nodeShapeBody ;
+propertyCount       : '[' propertyMinCount '..' propertyMaxCount ']' ;
+propertyMinCount    : INTEGER ;
+propertyMaxCount    : (INTEGER | '*') ;
+propertyType        : iri ;
+nodeKind            : 'BlankNode' | 'IRI' | 'Literal' | 'BlankNodeOrIRI' | 'BlankNodeOrLiteral' | 'IRIOrLiteral' ;
+shapeRef            : ATPNAME_LN | ATPNAME_NS | '@' IRIREF ;
+propertyValue       : propertyParam '=' iriOrLiteralOrArray ;
+negation            : '!' ;
+
+path                : pathAlternative ;
+pathAlternative     : pathSequence ( '|' pathSequence )* ;
+pathSequence        : pathEltOrInverse ( '/' pathEltOrInverse )* ;
+pathElt             : pathPrimary pathMod? ;
+pathEltOrInverse    : pathElt | pathInverse pathElt ;
+pathInverse         : '^' ;
+pathMod             : '?' | '*' | '+' ;
+pathPrimary         : iri | '(' path ')' ;
+
+iriOrLiteralOrArray : iriOrLiteral | array ;
+iriOrLiteral        : iri | literal ;
+
+iri                 : IRIREF | prefixedName ;
+prefixedName        : PNAME_LN | PNAME_NS ;
+
+literal             : rdfLiteral | numericLiteral | booleanLiteral ;
+booleanLiteral      : KW_TRUE | KW_FALSE ;
+numericLiteral      : INTEGER | DECIMAL | DOUBLE ;
+rdfLiteral          : string (LANGTAG | '^^' datatype)? ;
+datatype            : iri ;
+string              : STRING_LITERAL_LONG1 | STRING_LITERAL_LONG2 | STRING_LITERAL1 | STRING_LITERAL2 ;
+
+array               : '[' iriOrLiteral* ']' ;
+
+nodeParam           : 'targetNode' | 'targetObjectsOf' | 'targetSubjectsOf' |
+                      'deactivated' | 'severity' | 'message' |
+                      'class' | 'datatype' | 'nodeKind' |
+                      'minExclusive' | 'minInclusive' | 'maxExclusive' | 'maxInclusive' |
+                      'minLength' | 'maxLength' | 'pattern' | 'flags' | 'languageIn' |
+                      'equals' | 'disjoint' |
+                      'closed' | 'ignoredProperties' | 'hasValue' | 'in' ;
+
+propertyParam       : 'deactivated' | 'severity' | 'message' |
+                      'class' | 'datatype' | 'nodeKind' |
+                      'minExclusive' | 'minInclusive' | 'maxExclusive' | 'maxInclusive' |
+                      'minLength' | 'maxLength' | 'pattern' | 'flags' | 'languageIn' | 'uniqueLang' |
+                      'equals' | 'disjoint' | 'lessThan' | 'lessThanOrEquals' |
+                      'qualifiedValueShape' | 'qualifiedMinCount' | 'qualifiedMaxCount' | 'qualifiedValueShapesDisjoint' |
+                      'closed' | 'ignoredProperties' | 'hasValue' | 'in' ;
+
+// Keywords
+KW_BASE             : 'BASE' ;
+KW_IMPORTS          : 'IMPORTS' ;
+KW_PREFIX           : 'PREFIX' ;
+
+KW_SHAPE_CLASS      : 'shapeClass' ;
+KW_SHAPE            : 'shape' ;
+
+KW_TRUE             : 'true' ;
+KW_FALSE            : 'false' ;
+
+// Terminals
+PASS                : [ \t\r\n]+ -> skip;
+COMMENT             : '#' ~[\r\n]* -> skip;
+
+IRIREF              : '&lt;' (~[\u0000-\u0020=&lt;>\"{}|^`\\] | UCHAR)* '>' ;
+PNAME_NS            : PN_PREFIX? ':' ;
+PNAME_LN            : PNAME_NS PN_LOCAL ;
+ATPNAME_NS          : '@' PN_PREFIX? ':' ;
+ATPNAME_LN          : '@' PNAME_NS PN_LOCAL ;
+LANGTAG             : '@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)* ;
+INTEGER             : [+-]? [0-9]+ ;
+DECIMAL             : [+-]? [0-9]* '.' [0-9]+ ;
+DOUBLE              : [+-]? ([0-9]+ '.' [0-9]* EXPONENT | '.'? [0-9]+ EXPONENT) ;
+fragment EXPONENT   : [eE] [+-]? [0-9]+ ;
+STRING_LITERAL1     : '\'' (~[\u0027\u005C\u000A\u000D] | ECHAR | UCHAR)* '\'' ;
+STRING_LITERAL2     : '"' (~[\u0022\u005C\u000A\u000D] | ECHAR | UCHAR)* '"' ;
+STRING_LITERAL_LONG1: '\'\'\'' (('\'' | '\'\'')? (~[\'\\] | ECHAR | UCHAR))* '\'\'\'' ;
+STRING_LITERAL_LONG2: '"""' (('"' | '""')? (~[\"\\] | ECHAR | UCHAR))* '"""' ;
+fragment UCHAR      : '\\u' HEX HEX HEX HEX | '\\U' HEX HEX HEX HEX HEX HEX HEX HEX ;
+fragment ECHAR      : '\\' [tbnrf\\\"\'] ;
+fragment WS         : [\u0020\u0009\u000D\u000A] ;
+fragment PN_CHARS_BASE: [A-Z] | [a-z] | [\u00C0-\u00D6] | [\u00D8-\u00F6] | [\u00F8-\u02FF] | [\u0370-\u037D]
+                       | [\u037F-\u1FFF] | [\u200C-\u200D] | [\u2070-\u218F] | [\u2C00-\u2FEF] | [\u3001-\uD7FF]
+                       | [\uF900-\uFDCF] | [\uFDF0-\uFFFD]
+					   		   ;
+fragment PN_CHARS_U : PN_CHARS_BASE | '_' ;
+fragment PN_CHARS   : PN_CHARS_U | '-' | [0-9] | [\u00B7] | [\u0300-\u036F] | [\u203F-\u2040] ;
+fragment PN_PREFIX  : PN_CHARS_BASE ((PN_CHARS | '.')* PN_CHARS)? ;
+fragment PN_LOCAL   : (PN_CHARS_U | ':' | [0-9] | PLX) ((PN_CHARS | '.' | ':' | PLX)* (PN_CHARS | ':' | PLX))? ;
+fragment PLX        : PERCENT | PN_LOCAL_ESC ;
+fragment PERCENT    : '%' HEX HEX ;
+fragment HEX        : [0-9] | [A-F] | [a-f] ;
+fragment PN_LOCAL_ESC: '\\' ('_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | '\'' | '(' | ')' | '*' | '+' | ','
+                       | ';' | '=' | '/' | '?' | '#' | '@' | '%') ;
+			</pre>
+			<p id="rules">
+				A parser for the SHACL Compact Syntax receives as input a (text) document plus an optional <em>base URI</em>
+				which is used as initial value for the variable <code>?baseURI</code>.
+				The parser uses a <em>prefix mapping</em> which has initial mappings for the following namespaces:
+			</p>
+			<table class="term-table">
+				<tr>
+					<th>Prefix</th>
+					<th>Namespace</th>
+				</tr>
+				<tr>
+					<td><code>rdf:</code></td>
+					<td><code>http://www.w3.org/1999/02/22-rdf-syntax-ns#</code></td>
+				</tr>
+				<tr>
+					<td><code>rdfs:</code></td>
+					<td><code>http://www.w3.org/2000/01/rdf-schema#</code></td>
+				</tr>
+				<tr>
+					<td><code>sh:</code></td>
+					<td><code>http://www.w3.org/ns/shacl#</code></td>
+				</tr>
+				<tr>
+					<td><code>xsd:</code></td>
+					<td><code>http://www.w3.org/2001/XMLSchema#</code></td>
+				</tr>
+			</table>
+			<p>
+				It then produces a new RDF graph with the triples produced by the following rules.
+			</p>
+			<p>
+				<b>baseDecl</b>: set <code>?baseURI</code> to the IRI specified by <a href="#rule-IRIREF"><code>IRIREF</code></a>.
+			</p>
+			<p>
+				<b>importsDecl</b>: add the IRI specified by <a href="#rule-IRIREF">IRIREF</a> into a set <code>?imports</code>.
+			</p>
+			<p>
+				<b>prefixDecl</b>: add to the prefix mapping a mapping from the prefix <code>PNAME_NS</code> (without the ':') to
+				the namespace specified by <a href="#rule-IRIREF"><code>IRIREF</code></a>.
+			</p>
+			<p>
+				Once the whole document has been completed, produce a triple <code>?baseURI rdf:type owl:Ontology</code>
+				using the final value of <code>baseURI</code>.
+				Report an error if <code>baseURI</code> has no value but <code>imports</code> is not empty.
+				For each <code>iri</code> in <code>imports</code>, produce a triple <code>?baseURI owl:imports ?iri</code>.
+			</p>
+			<p class="rule" id="rule-nodeShape">
+				<b>nodeShape</b>: Produce a triple <code>?shape rdf:type sh:NodeShape</code> where <code>?shape</code> is
+				derived from the <code>iri</code> using <a href="#rule-iri"><code>iri</code></a>.
+				Use <code>?shape</code> as context shape for the <a href="#rule-targetClass"><code>targetClass</code></a>
+				and <a href="#rule-nodeShapeBody"><code>nodeShapeBody</code></a>.
+			</p>
+			<p class="rule" id="rule-shapeClass">
+				<b>shapeClass</b>: Produce the triples <code>?shape rdf:type sh:NodeShape</code> and
+				<code>?shape rdf:type rdfs:Class</code> where <code>?shape</code> is
+				derived from the <code>iri</code> using <a href="#rule-iri"><code>iri</code></a>.
+				Use <code>?shape</code> as context shape for the <a href="#rule-nodeShapeBody"><code>nodeShapeBody</code></a>.
+			</p>
+			<p class="rule" id="rule-targetClass">
+				<b>targetClass</b>: For each <code>iri</code>, produce a triple <code>?shape sh:targetClass ?iri</code>
+				where <code>?iri</code> is derived from <a href="#rule-iri"><code>iri</code></a>.
+			</p>
+			<p class="rule" id="rule-nodeShapeBody">
+				<b>nodeShapeBody</b>: Handle each <a href="#rule-constraint"><code>constraint</code></a> using the context shape <code>?shape</code>.
+			</p>
+			<p class="rule" id="rule-constraint">
+				<b>constraint</b>: Handle each <a href="#rule-nodeOr"><code>nodeOr</code></a> or
+				<a href="#rule-propertyShape"><code>propertyShape</code></a> using the context shape <code>?shape</code>.
+			</p>
+			<p class="rule" id="rule-nodeOr">
+				<b>nodeOr</b>: If there is more than one <code>nodeNot</code>, then produce an RDF list <code>?or</code> where for each <code>nodeNot</code>,
+				there is a new blank node, and that blank node is used as context shape for the <a href="#rule-nodeNot"><code>nodeNot</code></a>.
+				Then produce a triple <code>?shape sh:or ?or</code>.
+				If there is only one <code>nodeNot</code>, handle the <a href="#rule-nodeNot"><code>nodeNot</code></a> using the context shape <code>?shape</code>.
+			</p>
+			<p class="rule" id="rule-nodeNot">
+				<b>nodeNot</b>: If there is a <code>negation</code>, produce a new blank node <code>?not</code> and produce a triple
+				<code>?shape sh:not ?not</code>. Then handle the <a href="#rule-nodeValue"><code>nodeValue</code></a> using <code>?not</code> as context shape.
+				If there is no <code>negation</code>, handle the <a href="#rule-nodeValue"><code>nodeValue</code></a> using the context shape <code>?shape</code>.
+			</p>
+			<p class="rule" id="rule-nodeValue">
+				<b>nodeValue</b>: Produce a triple <code>?shape ?predicate ?object</code> where <code>?predicate</code>
+				is the IRI produced by concatenating the <code>sh</code> namespace with string value of <code>nodeParam</code>
+				(for example <code>"minLength"</code> becomes <code>sh:minLength</code>),
+				and <code>?object</code> is derived from the <a href="#rule-iriOrLiteralOrArray"><code>iriOrLiteralOrArray</code></a>.
+			</p>
+			<p class="rule" id="rule-propertyShape">
+				<b>propertyShape</b>: Using a new blank node <code>?property</code>, produce a triple
+				<code>?shape sh:property ?property</code>.
+				Produce a triple <code>?property sh:path ?path</code> where <code>?path</code> is the result of <a href="#rule-path"><code>path</code></a>.
+				Use <code>?property</code> as context shape for <a href="#rule-propertyCount"><code>propertyCount</code></a> and <a href="#rule-propertyOr"><code>propertyOr</code></a>.
+			</p>
+			<p class="rule" id="rule-propertyCount">
+				<b>propertyCount</b>:
+				If <code>propertyMinCount</code> is not <code>"0"</code>, produce a triple <code>?property sh:minCount ?minCount</code>
+				using the <code>xsd:integer</code> derived from <code>propertyMinCount</code> as <code>?minCount</code>.
+				If <code>propertyMaxCount</code> is not <code>"*"</code>, produce a triple <code>?property sh:maxCount ?maxCount</code>
+				using the <code>xsd:integer</code> derived from <code>propertyMaxCount</code> as <code>?maxCount</code>.
+			</p>
+			<p class="rule" id="rule-propertyOr">
+				<b>propertyOr</b>: If there is more than one <code>propertyNot</code>, then produce an RDF list <code>?or</code> where for each <code>propertyNot</code>,
+				there is a new blank node, and that blank node is used as context shape for the <a href="#rule-propertyNot"><code>propertyNot</code></a>.
+				Then produce a triple <code>?property sh:or ?or</code>.
+				If there is only one <code>propertyNot</code>, handle the <a href="#rule-propertyNot"><code>propertyNot</code></a> using the context shape <code>?property</code>.
+			</p>
+			<p class="rule" id="rule-propertyNot">
+				<b>propertyNot</b>: If there is a <code>negation</code>, produce a new blank node <code>?not</code> and produce a triple
+				<code>?property sh:not ?not</code>. Then handle the <a href="#rule-propertyAtom"><code>propertyAtom</code></a> using <code>?not</code> as context shape.
+				If there is no <code>negation</code>, handle the <a href="#rule-propertyAtom"><code>propertyAtom</code></a> using the context shape <code>?property</code>.
+			</p>
+			<p class="rule" id="rule-propertyAtom">
+				<b>propertyAtom</b>: Use <code>?property</code> as context shape for any of the child elements.
+				For a nested <code>nodeShapeBody</code>, produce a new blank node <code>?node</code> and use that as the context shape <code>?shape</code>.
+				Then produce a triple <code>?property sh:node ?node</code>. 
+			</p>
+			<p class="rule" id="rule-propertyType">
+				<b>propertyType</b>: Let <code>?iri</code> be the IRI derived from the <code>propertyType</code> using <a href="#rule-iri"><code>iri</code></a>.
+				If <code>?iri</code> is one of the RDF datatypes supported by SPARQL 1.1 (such as <code>xsd:string</code>) then produce a triple
+				<code>?property sh:datatype ?iri</code>, otherwise <code>?property sh:class ?iri</code>.
+			</p>
+			<p class="rule" id="rule-nodeKind">
+				<b>nodeKind</b>: Produce a triple <code>?property sh:nodeKind ?nodeKind</code> where
+				<code>?nodeKind</code> is the IRI produced by concatenating the <code>sh</code> namespace
+				with the text value of <code>nodeKind</code> (e.g., <code>sh:Literal</code>).
+			</p>
+			<p class="rule" id="rule-shapeRef">
+				<b>shapeRef</b>: Produce a triple <code>?property sh:node ?node</code> where
+				<code>?node</code> is the IRI derived from the substring of <code>shapeRef</code> after the '@' character using <a href="#rule-iri"><code>iri</code></a>.
+			</p>
+			<p class="rule" id="rule-propertyValue">
+				<b>propertyValue</b>: Produce a triple <code>?property ?predicate ?object</code> where <code>?predicate</code>
+				is the IRI produced by concatenating the <code>sh</code> namespace with the string value of <code>propertyParam</code>,
+				and <code>?object</code> is derived from the <a href="#rule-iriOrLiteralOrArray"><code>iriOrLiteralOrArray</code></a>.
+			</p>
+			<p class="rule" id="rule-path">
+				<b>path</b>: If there is more than one <code>pathSequence</code>, produce a new RDF list <code>?list</code> where there is
+				one list member for the paths derived from each <a href="#rule-pathSequence"><code>pathSequence</code></a>.
+				Then produce a triple <code>?alt sh:alternativePath ?list</code> where <code>?alt</code> is a new blank node, and return <code>?alt</code>.
+				If there is only one <code>pathSequence</code>, return the path derived from <a href="#rule-pathSequence"><code>pathSequence</code></a>.
+			</p>
+			<p class="rule" id="rule-pathSequence">
+				<b>pathSequence</b>: If there is more than one <code>pathEltOrInverse</code>, produce a new blank node RDF list <code>?list</code>
+				where there is one list member for the path derived from each <a href="#rule-pathEltOrInverse"><code>pathEltOrInverse</code></a>. Return <code>?list</code>.
+				If there is only one <code>pathEltOrInverse</code>, return the path derived from <a href="#rule-pathEltOrInverse"><code>pathEltOrInverse</code></a>.
+			</p>
+			<p class="rule" id="rule-pathEltOrInverse">
+				<b>pathEltOrInverse</b>: If there is a <code>pathInverse</code>, produce a triple
+				<code>?path sh:inversePath ?inverse</code> where <code>?path</code> is a new blank node and <code>?inverse</code>
+				is the path derived from <a href="#rule-pathElt"><code>pathElt</code></a>. Return <code>?path</code>.
+				If there is only one <code>pathElt</code>, return the path derived from <a href="#rule-pathElt"><code>pathElt</code></a>.
+			</p>
+			<p class="rule" id="rule-pathElt">
+				<b>pathElt</b>: Let <code>?primary</code> be the path derived from <a href="#rule-pathPrimary"><code>pathPrimary</code></a>.
+				If <code>pathMod</code> does not exist, return <code>?primary</code>.
+				Otherwise, produce and return a new blank node <code>?path</code> with one of the following triples:
+				If <code>pathMod</code> equals "?" produce a triple <code>?path sh:zeroOrOnePath ?primary</code>.
+				If <code>pathMod</code> equals "+" produce a triple <code>?path sh:oneOrMorePath ?primary</code>.
+				If <code>pathMod</code> equals "*" produce a triple <code>?path sh:zeroOrMorePath ?primary</code>.
+			</p>
+			<p class="rule" id="rule-pathPrimary">
+				<b>pathPrimary</b>: If <code>iri</code> exists, return the predicate derived from that IRI.
+				Otherwise, return the path derived from <a href="#rule-path">path</a>.
+			</p>
+			<p class="rule" id="rule-iriOrLiteralOrArray">
+				<b>iriOrLiteralOrArray</b>: If there is an <code>array</code>, produce and return an RDF list
+				where each <a href="#rule-iriOrLiteral"><code>iriOrLiteral</code></a> is a member.
+				Otherwise, return <a href="#rule-iriOrLiteral"><code>iriOrLiteral</code></a> for <code>iriOrLiteral</code>.
+			</p>
+			<p class="rule" id="rule-iriOrLiteral">
+				<b>iriOrLiteral</b>: If there is an <code>iri</code>, return the node derived from <a href="#rule-iri"><code>iri</code></a>.
+				Otherwise, apply Turtle's parsing rules to turn the string <code>literal</code> into an RDF literal.
+			</p>
+			<p class="rule" id="rule-iri">
+				<b>iri</b>: If there is a <code>IRIREF</code>, return the result of <a href="#rule-IRIREF"><code>IRIREF</code></a>.
+				Otherwise, return an IRI applying the current prefix mapping on <code>prefixedName</code>.
+				Report an error if there is no matching prefix.
+			</p>
+			<p class="rule" id="rule-IRIREF">
+				<b>IRIREF</b>: Return the IRI consisting of the substring of <code>IRIREF</code> between the leading <code>&lt;</code>
+				and the trailing <code>&gt;</code>, turning relative IRIs into absolute IRIs using the current <code>?baseURI</code>.
+			</p>
+			<p>
+				Developers may find the <a href="https://github.com/w3c/data-shapes/tree/gh-pages/shacl-compact-syntax/tests">Test Cases</a> useful.
+				Each test consists of a <code>.shaclc</code> file and an associated <code>.ttl</code> file.
+				Parsing the <code>.shaclc</code> file must produce a graph that is isomorphic to the <code>.ttl</code> file.
+				The test cases are not normative.
+			</p>
+		</section>
+
+    <section class="appendix normative" id="iana-considerations">
+      <h2>IANA Considerations</h2>
+
+      <p>This section reviewed, approved, and registered with IANA by the Internet Engineering Steering Group (IESG),
+        see <a href="https://www.iana.org/assignments/media-types/text/shaclc">https://www.iana.org/assignments/media-types/text/shaclc</a>.
+      </p>
+
+      <h3 id="text-shaclc">text/shaclc</h3>
+      <dl>
+        <dt>Type name:</dt>
+        <dd>text</dd>
+        <dt>Subtype name:</dt>
+        <dd>shaclc</dd>
+        <dt>Required parameters:</dt>
+        <dd>None</dd>
+        <dt>Encoding considerations:</dt>
+        <dd>SHACL Compact Syntax (SHACLC) is a text language encoded in UTF-8.</dd>
+        <dt>Security considerations:</dt>
+        <dd>
+          <p>
+            Revealing the structure of an RDF graph can reveal information about the content of conformant data.
+            For instance, a schema with a predicate to describe cancer stage indicates that conforming graphs describe patients with cancer.
+          </p>
+          <p>
+            The process of testing a graph's conformance to a schema could draw significant system resources and be a vector for Denial of Service attacks.
+          </p>
+          <p>
+            <a href="https://www.w3.org/TR/turtle/#sec-mediaReg">RDF Turtle security considerations</a> about IRI spoofing may also apply here.
+          </p>
+        </dd>
+        <dt>Interoperability considerations:</dt>
+        <dd>Not Applicable</dd>
+        <dt>Published specification:</dt>
+        <dd><a href="https://w3c.github.io/shacl/shacl-compact-syntax/">This document</a></dd>
+        <dt>Applications that use this media type:</dt>
+        <dd>An implementations of SHACLC is part of the <a href="https://github.com/TopQuadrant/shacl">TopQuadrant SHACL API</a>
+        </dd>
+        <dt>Additional information:</dt>
+        <dd>
+          <dl>
+            <dt>Magic number(s):</dt>
+            SHACLC documents will likely have the words <code>PREFIX</code> or <code>BASE</code> (case sensitive) near the beginning of the document.
+            However, the same words may appear in Turtle and SPARQL documents.
+            <dd></dd>
+            <dt>File extension(s):</dt>
+            <dd>.shc, .shaclc</dd>
+            <dt>Macintosh file type code(s):</dt>
+            <dd>TEXT</dd>
+          </dl>
+        </dd>
+        <dt>Person &amp; email address to contact for further information:</dt>
+        <dd>Vladimir Alexiev &lt;vladimir.alexiev@ontotext.com&gt;</dd>
+        <dt>Intended usage:</dt>
+        <dd>Common</dd>
+        <dt>Restrictions on usage:</dt>
+        <dd>None</dd>
+        <dt>Author(s):</dt>
+        <dd>Holger Knublauch, TopQuadrant</dd>
+        <dt>Change controller:</dt>
+        <dd><a href="https://www.w3.org/community/shacl/">W3C SHACL Community Group</a>
+        </dd>
+      </dl>
+    </section>
+		
+		<section id="ack" class="appendix informative">
+			<h2>Acknowledgements</h2>
+			<p>
+				This document is heavily inspired by the <a href="http://shex.io/shex-semantics/#shexc">ShEx Compact Syntax</a>,
+				a version of which was provided as input to the RDF Data Shapes Working Group.
+				The IANA Considerations section has been adapted <a href="http://shex.io/shex-semantics/#iana-considerations">from the same document</a>.
+      </p>
+      <p>
+				The ShEx Compact Syntax was primarily developed by the following people:
+			</p>
+			<p>
+				Eric Prud'hommeaux,
+				Iovka Boneva,
+				Jose Labra,
+				Harold Solbrig
+			</p>
+		</section>
+		
 	</body>
 </html>

--- a/shacl12-compact-syntax/index.html
+++ b/shacl12-compact-syntax/index.html
@@ -7,10 +7,13 @@
 		<script class="remove">
 		
 			var respecConfig = {
-				edDraftURI: "https://w3c.github.io/shacl/shacl-compact-syntax/",
+				group: "wg/data-shapes",
+				github: "w3c/data-shapes",
+				edDraftURI: "https://w3c.github.io/data-shapes/shacl12-compact-syntax/",
+				specStatus: "ED",
+				shortName:  "shacl12-compact-syntax",
+				subjectPrefix: "[shacl12-compact-syntax]",
 				// issueBase: "http://www.w3.org/2014/data-shapes/track/issues/",
-				specStatus: "CG-DRAFT",
-				shortName:  "shacl-compact-syntax",
 				editors: [
 					{
 						name:       "Vladimir Alexiev",
@@ -41,7 +44,12 @@
 				wgURI:        "https://www.w3.org/community/shacl/",
 				wgPublicList: "public-shacl",
 				wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/73865/status",
-				noHighlightCSS: true
+				previousPublishDate: "2018-01-09",
+				previousMaturity: "CG-DRAFT",
+				prevRecShortname: "shacl-compact-syntax",
+				prevRecURI: "https://w3c.github.io/shacl/shacl-compact-syntax/",
+
+				wgPublicList: "public-shacl"
 			};
 		</script>
 		<style>

--- a/shacl12-compact-syntax/index.html
+++ b/shacl12-compact-syntax/index.html
@@ -278,7 +278,7 @@
 
 		<section id="sotd">
 			This specification was started by the RDF Data Shapes WG, was continued within the
-			SHACL Community Group and is now being picked back up in the Data Shapes WG.
+			SHACL Community Group, and is now being picked up by the Data Shapes WG.
 		</section>
 		
 		<section class="introductory">

--- a/shacl12-compact-syntax/index.html
+++ b/shacl12-compact-syntax/index.html
@@ -800,6 +800,9 @@ fragment PN_LOCAL_ESC: '\\' ('_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | '\'' 
 		<section id="ack" class="appendix informative">
 			<h2>Acknowledgements</h2>
 			<p>
+			<p>
+			This document is based on the <a href="https://w3c.github.io/shacl/shacl-compact-syntax/">SHACL Compact Syntax, Draft Community Group Report</a> written by <a href="http://knublauch.com/">Holger Knublauch</a> and <a href="https://github.com/VladimirAlexiev/my">Vladimir Alexiev</a>.
+			</p>
 				This document is heavily inspired by the <a href="http://shex.io/shex-semantics/#shexc">ShEx Compact Syntax</a>,
 				a version of which was provided as input to the RDF Data Shapes Working Group.
 				The IANA Considerations section has been adapted <a href="http://shex.io/shex-semantics/#iana-considerations">from the same document</a>.

--- a/shacl12-compact-syntax/index.html
+++ b/shacl12-compact-syntax/index.html
@@ -40,8 +40,8 @@
 					}
 				],
 				publishDate:  "2025-08-04",
-				wg:           "SHACL Community Group",
-				wgURI:        "https://www.w3.org/community/shacl/",
+				wg:           "Data Shapes Working Group",
+				wgURI:        "https://www.w3.org/groups/wg/data-shapes/",
 				wgPublicList: "public-shacl",
 				wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/73865/status",
 				previousPublishDate: "2018-01-09",

--- a/shacl12-compact-syntax/index.html
+++ b/shacl12-compact-syntax/index.html
@@ -36,7 +36,7 @@
 						w3cid:      46500
 					}
 				],
-				publishDate:  "2018-01-09",
+				publishDate:  "2025-08-04",
 				wg:           "SHACL Community Group",
 				wgURI:        "https://www.w3.org/community/shacl/",
 				wgPublicList: "public-shacl",

--- a/shacl12-compact-syntax/index.html
+++ b/shacl12-compact-syntax/index.html
@@ -13,7 +13,6 @@
 				specStatus: "ED",
 				shortName:  "shacl12-compact-syntax",
 				subjectPrefix: "[shacl12-compact-syntax]",
-				// issueBase: "http://www.w3.org/2014/data-shapes/track/issues/",
 				editors: [
 					{
 						name:       "Vladimir Alexiev",
@@ -24,6 +23,7 @@
 					},
 					{
 						name:       "Jesse Wright",
+						url: 			  "https://www.jeswr.org/#me",
 						company:    "University of Oxford",
 						companyURL: "https://www.cs.ox.ac.uk",
 						mailto:     "jesse@jeswr.org",
@@ -277,8 +277,8 @@
 		</section>
 
 		<section id="sotd">
-			This specification was started by the RDF Data Shapes WG but is now continued within the
-			SHACL Community Group.
+			This specification was started by the RDF Data Shapes WG, was continued within the
+			SHACL Community Group and is now being picked back up in the Data Shapes WG.
 		</section>
 		
 		<section class="introductory">
@@ -734,7 +734,7 @@ fragment PN_LOCAL_ESC: '\\' ('_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | '\'' 
 				and the trailing <code>&gt;</code>, turning relative IRIs into absolute IRIs using the current <code>?baseURI</code>.
 			</p>
 			<p>
-				Developers may find the <a href="https://github.com/w3c/data-shapes/tree/gh-pages/shacl-compact-syntax/tests">Test Cases</a> useful.
+				Developers may find the <a href="https://github.com/w3c/data-shapes/tree/gh-pages/shacl12-compact-syntax/tests">Test Cases</a> useful.
 				Each test consists of a <code>.shaclc</code> file and an associated <code>.ttl</code> file.
 				Parsing the <code>.shaclc</code> file must produce a graph that is isomorphic to the <code>.ttl</code> file.
 				The test cases are not normative.
@@ -774,7 +774,7 @@ fragment PN_LOCAL_ESC: '\\' ('_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | '\'' 
         <dt>Interoperability considerations:</dt>
         <dd>Not Applicable</dd>
         <dt>Published specification:</dt>
-        <dd><a href="https://w3c.github.io/shacl/shacl-compact-syntax/">This document</a></dd>
+        <dd><a href="https://w3c.github.io/data-shapes/shacl12-compact-syntax/">This document</a></dd>
         <dt>Applications that use this media type:</dt>
         <dd>An implementations of SHACLC is part of the <a href="https://github.com/TopQuadrant/shacl">TopQuadrant SHACL API</a>
         </dd>
@@ -792,22 +792,22 @@ fragment PN_LOCAL_ESC: '\\' ('_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | '\'' 
           </dl>
         </dd>
         <dt>Person &amp; email address to contact for further information:</dt>
-        <dd>Vladimir Alexiev &lt;vladimir.alexiev@ontotext.com&gt;</dd>
+				<dd>Jesse Wright &lt;jesse@jeswr.org&gt;</dd>
         <dt>Intended usage:</dt>
         <dd>Common</dd>
         <dt>Restrictions on usage:</dt>
         <dd>None</dd>
         <dt>Author(s):</dt>
-        <dd>Holger Knublauch, TopQuadrant</dd>
+        <dd>Vladimir Alexiev, Graphwise.ai</dd>
+				<dd>Jesse Wright, University of Oxford</dd>
         <dt>Change controller:</dt>
-        <dd><a href="https://www.w3.org/community/shacl/">W3C SHACL Community Group</a>
+        <dd><a href="https://www.w3.org/groups/wg/data-shapes/">W3C Data Shapes Working Group</a>
         </dd>
       </dl>
     </section>
 		
 		<section id="ack" class="appendix informative">
 			<h2>Acknowledgements</h2>
-			<p>
 			<p>
 			This document is based on the <a href="https://w3c.github.io/shacl/shacl-compact-syntax/">SHACL Compact Syntax, Draft Community Group Report</a> written by <a href="http://knublauch.com/">Holger Knublauch</a> and <a href="https://github.com/VladimirAlexiev/my">Vladimir Alexiev</a>.
 			</p>

--- a/shacl12-compact-syntax/index.html
+++ b/shacl12-compact-syntax/index.html
@@ -15,9 +15,9 @@
 					{
 						name:       "Vladimir Alexiev",
 						url:        "https://github.com/VladimirAlexiev/my",
-						company:    "Ontotext Corp",
-						companyURL: "http://ontotext.com",
-            w3cid: 	    56618
+						company:    "Graphwise.ai",
+						companyURL: "https://graphwise.ai/",
+						w3cid: 	    56618
 					},
 					{
 						name:       "Jesse Wright",

--- a/shacl12-compact-syntax/tests/valid/array-in.shaclc
+++ b/shacl12-compact-syntax/tests/valid/array-in.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/array-in>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property in=[ex:Instance1 true "string" 42] .
+}

--- a/shacl12-compact-syntax/tests/valid/array-in.ttl
+++ b/shacl12-compact-syntax/tests/valid/array-in.ttl
@@ -1,0 +1,19 @@
+@base <http://example.org/array-in> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:property ;
+		sh:in ( ex:Instance1 true "string" 42 ) ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/basic-shape-iri.shaclc
+++ b/shacl12-compact-syntax/tests/valid/basic-shape-iri.shaclc
@@ -1,0 +1,4 @@
+BASE <http://example.org/basic-shape-iri>
+
+shape <http://example.org/test#TestShape> {
+}

--- a/shacl12-compact-syntax/tests/valid/basic-shape-iri.ttl
+++ b/shacl12-compact-syntax/tests/valid/basic-shape-iri.ttl
@@ -1,0 +1,14 @@
+@base <http://example.org/basic-shape-iri> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/basic-shape-iri>
+	a owl:Ontology ;
+.
+
+<http://example.org/test#TestShape>
+	a sh:NodeShape ;
+.

--- a/shacl12-compact-syntax/tests/valid/basic-shape-with-target.shaclc
+++ b/shacl12-compact-syntax/tests/valid/basic-shape-with-target.shaclc
@@ -1,0 +1,6 @@
+BASE <http://example.org/basic-shape-with-target>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape -> ex:TestClass {
+}

--- a/shacl12-compact-syntax/tests/valid/basic-shape-with-target.ttl
+++ b/shacl12-compact-syntax/tests/valid/basic-shape-with-target.ttl
@@ -1,0 +1,16 @@
+@base <http://example.org/basic-shape-with-target> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/basic-shape-with-target>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:targetClass ex:TestClass ;
+.

--- a/shacl12-compact-syntax/tests/valid/basic-shape-with-targets.shaclc
+++ b/shacl12-compact-syntax/tests/valid/basic-shape-with-targets.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/basic-shape-with-targets>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape -> ex:TestClass1 ex:TestClass2 {
+	targetNode=ex:TestNode targetSubjectsOf=ex:subjectProperty targetObjectsOf=ex:objectProperty .
+}

--- a/shacl12-compact-syntax/tests/valid/basic-shape-with-targets.ttl
+++ b/shacl12-compact-syntax/tests/valid/basic-shape-with-targets.ttl
@@ -1,0 +1,19 @@
+@base <http://example.org/basic-shape-with-targets> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/basic-shape-with-targets>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:targetClass ex:TestClass1, ex:TestClass2 ;
+	sh:targetNode ex:TestNode ;
+	sh:targetObjectsOf ex:objectProperty ;
+	sh:targetSubjectsOf ex:subjectProperty ;
+.

--- a/shacl12-compact-syntax/tests/valid/basic-shape.shaclc
+++ b/shacl12-compact-syntax/tests/valid/basic-shape.shaclc
@@ -1,0 +1,6 @@
+BASE <http://example.org/basic-shape>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+}

--- a/shacl12-compact-syntax/tests/valid/basic-shape.ttl
+++ b/shacl12-compact-syntax/tests/valid/basic-shape.ttl
@@ -1,0 +1,15 @@
+@base <http://example.org/basic-shape> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/basic-shape>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+.

--- a/shacl12-compact-syntax/tests/valid/class.shaclc
+++ b/shacl12-compact-syntax/tests/valid/class.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/class>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property ex:TestClass .
+}

--- a/shacl12-compact-syntax/tests/valid/class.ttl
+++ b/shacl12-compact-syntax/tests/valid/class.ttl
@@ -1,0 +1,19 @@
+@base <http://example.org/class> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:property ;
+		sh:class ex:TestClass ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/comment.shaclc
+++ b/shacl12-compact-syntax/tests/valid/comment.shaclc
@@ -1,0 +1,8 @@
+BASE <http://example.org/comment>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape { # Rest is a comment
+}
+
+# Another comment

--- a/shacl12-compact-syntax/tests/valid/comment.ttl
+++ b/shacl12-compact-syntax/tests/valid/comment.ttl
@@ -1,0 +1,15 @@
+@base <http://example.org/comment> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+.

--- a/shacl12-compact-syntax/tests/valid/complex1.shaclc
+++ b/shacl12-compact-syntax/tests/valid/complex1.shaclc
@@ -1,0 +1,15 @@
+BASE <http://example.com/ns>
+
+IMPORTS <http://example.com/person-ontology>
+
+PREFIX ex: <http://example.com/ns#>
+
+shape ex:PersonShape -> ex:Person {
+	closed=true ignoredProperties=[rdf:type] .
+	ex:ssn xsd:string [0..1] pattern="^\\d{3}-\\d{2}-\\d{4}$" .
+	ex:worksFor IRI ex:Company [0..*] .
+	ex:address BlankNode [0..1] {
+		ex:city xsd:string [1..1] .
+		ex:postalCode xsd:integer|xsd:string [1..1] maxLength=5 .
+	} .
+}

--- a/shacl12-compact-syntax/tests/valid/complex1.ttl
+++ b/shacl12-compact-syntax/tests/valid/complex1.ttl
@@ -1,0 +1,48 @@
+@base <http://example.com/ns> .
+@prefix ex: <http://example.com/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.com/ns>
+	rdf:type owl:Ontology ;
+	owl:imports <http://example.com/person-ontology> .
+
+ex:PersonShape
+	a sh:NodeShape ;
+	sh:targetClass ex:Person ;
+	sh:closed true ;
+	sh:ignoredProperties ( rdf:type ) ;
+	sh:property [
+		sh:path ex:ssn ;
+		sh:maxCount 1 ;
+		sh:datatype xsd:string ;
+		sh:pattern "^\\d{3}-\\d{2}-\\d{4}$" ;
+	] ;
+	sh:property [
+		sh:path ex:worksFor ;
+		sh:class ex:Company ;
+		sh:nodeKind sh:IRI ;
+	] ;
+	sh:property [
+		sh:path ex:address ;
+		sh:maxCount 1 ;
+		sh:nodeKind sh:BlankNode ;
+		sh:node [
+			sh:property [
+				sh:path ex:city ;
+				sh:datatype xsd:string ;
+				sh:minCount 1 ;
+				sh:maxCount 1 ;
+			] ;
+			sh:property [
+				sh:path ex:postalCode ;
+				sh:or ( [ sh:datatype xsd:integer ] [ sh:datatype xsd:string ] ) ;
+				sh:minCount 1 ;
+				sh:maxCount 1 ;
+				sh:maxLength 5 ;
+			] ;
+		] ;
+	] .

--- a/shacl12-compact-syntax/tests/valid/complex2.shaclc
+++ b/shacl12-compact-syntax/tests/valid/complex2.shaclc
@@ -1,0 +1,15 @@
+BASE <http://example.com/ns>
+
+IMPORTS <http://example.com/person-ontology>
+
+PREFIX ex: <http://example.com/ns#>
+
+shapeClass ex:Person {
+	closed=true ignoredProperties=[rdf:type] .
+	ex:ssn xsd:string [0..1] pattern="^\\d{3}-\\d{2}-\\d{4}$" .
+	ex:worksFor IRI ex:Company [0..*] .
+	ex:address BlankNode [0..1] {
+		ex:city xsd:string [1..1] .
+		ex:postalCode xsd:integer|xsd:string [1..1] maxLength=5 .
+	} .
+}

--- a/shacl12-compact-syntax/tests/valid/complex2.ttl
+++ b/shacl12-compact-syntax/tests/valid/complex2.ttl
@@ -1,0 +1,47 @@
+@base <http://example.com/ns> .
+@prefix ex: <http://example.com/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.com/ns>
+	rdf:type owl:Ontology ;
+	owl:imports <http://example.com/person-ontology> .
+
+ex:Person
+	a sh:NodeShape, rdfs:Class ;
+	sh:closed true ;
+	sh:ignoredProperties ( rdf:type ) ;
+	sh:property [
+		sh:path ex:ssn ;
+		sh:maxCount 1 ;
+		sh:datatype xsd:string ;
+		sh:pattern "^\\d{3}-\\d{2}-\\d{4}$" ;
+	] ;
+	sh:property [
+		sh:path ex:worksFor ;
+		sh:class ex:Company ;
+		sh:nodeKind sh:IRI ;
+	] ;
+	sh:property [
+		sh:path ex:address ;
+		sh:maxCount 1 ;
+		sh:nodeKind sh:BlankNode ;
+		sh:node [
+			sh:property [
+				sh:path ex:city ;
+				sh:datatype xsd:string ;
+				sh:minCount 1 ;
+				sh:maxCount 1 ;
+			] ;
+			sh:property [
+				sh:path ex:postalCode ;
+				sh:or ( [ sh:datatype xsd:integer ] [ sh:datatype xsd:string ] ) ;
+				sh:minCount 1 ;
+				sh:maxCount 1 ;
+				sh:maxLength 5 ;
+			] ;
+		] ;
+	] .

--- a/shacl12-compact-syntax/tests/valid/count-0-1.shaclc
+++ b/shacl12-compact-syntax/tests/valid/count-0-1.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/count-0-1>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property [0..1] .
+}

--- a/shacl12-compact-syntax/tests/valid/count-0-1.ttl
+++ b/shacl12-compact-syntax/tests/valid/count-0-1.ttl
@@ -1,0 +1,19 @@
+@base <http://example.org/count-0-1> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:property ;
+		sh:maxCount 1 ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/count-0-unlimited.shaclc
+++ b/shacl12-compact-syntax/tests/valid/count-0-unlimited.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/count-0-unlimited>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property [0..*] .
+}

--- a/shacl12-compact-syntax/tests/valid/count-0-unlimited.ttl
+++ b/shacl12-compact-syntax/tests/valid/count-0-unlimited.ttl
@@ -1,0 +1,18 @@
+@base <http://example.org/count-0-unlimited> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:property ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/count-1-2.shaclc
+++ b/shacl12-compact-syntax/tests/valid/count-1-2.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/count-1-2>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property [1..2] .
+}

--- a/shacl12-compact-syntax/tests/valid/count-1-2.ttl
+++ b/shacl12-compact-syntax/tests/valid/count-1-2.ttl
@@ -1,0 +1,20 @@
+@base <http://example.org/count-1-2> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:property ;
+		sh:minCount 1 ;
+		sh:maxCount 2 ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/count-1-unlimited.shaclc
+++ b/shacl12-compact-syntax/tests/valid/count-1-unlimited.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/count-1-unlimited>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property [1..*] .
+}

--- a/shacl12-compact-syntax/tests/valid/count-1-unlimited.ttl
+++ b/shacl12-compact-syntax/tests/valid/count-1-unlimited.ttl
@@ -1,0 +1,19 @@
+@base <http://example.org/count-1-unlimited> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:property ;
+		sh:minCount 1 ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/datatype.shaclc
+++ b/shacl12-compact-syntax/tests/valid/datatype.shaclc
@@ -1,0 +1,8 @@
+BASE <http://example.org/datatype>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:stringProperty xsd:string .
+	ex:langProperty rdf:langString .
+}

--- a/shacl12-compact-syntax/tests/valid/datatype.ttl
+++ b/shacl12-compact-syntax/tests/valid/datatype.ttl
@@ -1,0 +1,23 @@
+@base <http://example.org/datatype> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:stringProperty ;
+		sh:datatype xsd:string ;
+	] ;
+	sh:property [
+		sh:path ex:langProperty ;
+		sh:datatype rdf:langString ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/directives.shaclc
+++ b/shacl12-compact-syntax/tests/valid/directives.shaclc
@@ -1,0 +1,6 @@
+BASE <http://example.org/directives>
+
+IMPORTS <http://example.org/graph1>
+IMPORTS <http://example.org/graph2>
+
+PREFIX ex: <http://example.org/directives#>

--- a/shacl12-compact-syntax/tests/valid/directives.ttl
+++ b/shacl12-compact-syntax/tests/valid/directives.ttl
@@ -1,0 +1,13 @@
+@base <http://example.org/directives> .
+@prefix ex: <http://example.org/directives#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/directives>
+	a owl:Ontology ;
+	owl:imports <http://example.org/graph1> ;
+	owl:imports <http://example.org/graph2> ;
+.

--- a/shacl12-compact-syntax/tests/valid/empty.ttl
+++ b/shacl12-compact-syntax/tests/valid/empty.ttl
@@ -1,0 +1,9 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:x-base:default>
+	a owl:Ontology ;
+.

--- a/shacl12-compact-syntax/tests/valid/nestedShape.shaclc
+++ b/shacl12-compact-syntax/tests/valid/nestedShape.shaclc
@@ -1,0 +1,9 @@
+BASE <http://example.org/nestedShape>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property IRI {
+		ex:nestedProperty [1..1] .
+	} .
+}

--- a/shacl12-compact-syntax/tests/valid/nestedShape.ttl
+++ b/shacl12-compact-syntax/tests/valid/nestedShape.ttl
@@ -1,0 +1,26 @@
+@base <http://example.org/nestedShape> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:property ;
+		sh:nodeKind sh:IRI ;
+		sh:node [
+			sh:property [
+				sh:path ex:nestedProperty ;
+				sh:minCount 1 ;
+				sh:maxCount 1 ;
+			] ;
+		] ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/node-or-2.shaclc
+++ b/shacl12-compact-syntax/tests/valid/node-or-2.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/node-or-2>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	datatype=xsd:string|datatype=rdf:langString .
+}

--- a/shacl12-compact-syntax/tests/valid/node-or-2.ttl
+++ b/shacl12-compact-syntax/tests/valid/node-or-2.ttl
@@ -1,0 +1,16 @@
+@base <http://example.org/node-or-2> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:or ( [ sh:datatype xsd:string ] [ sh:datatype rdf:langString ] ) ;
+.

--- a/shacl12-compact-syntax/tests/valid/node-or-3-not.shaclc
+++ b/shacl12-compact-syntax/tests/valid/node-or-3-not.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/node-or-3-not>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	datatype=xsd:string|!datatype=rdf:langString | class = ex:TestClass .
+}

--- a/shacl12-compact-syntax/tests/valid/node-or-3-not.ttl
+++ b/shacl12-compact-syntax/tests/valid/node-or-3-not.ttl
@@ -1,0 +1,20 @@
+@base <http://example.org/node-or-3-not> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:or ( 
+		[ sh:datatype xsd:string ] 
+		[ sh:not [ sh:datatype rdf:langString ] ]
+		[ sh:class ex:TestClass ]
+	) ;
+.

--- a/shacl12-compact-syntax/tests/valid/nodeKind.shaclc
+++ b/shacl12-compact-syntax/tests/valid/nodeKind.shaclc
@@ -1,0 +1,8 @@
+BASE <http://example.org/nodeKind>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:iriProperty IRI .
+	ex:literalProperty Literal .
+}

--- a/shacl12-compact-syntax/tests/valid/nodeKind.ttl
+++ b/shacl12-compact-syntax/tests/valid/nodeKind.ttl
@@ -1,0 +1,23 @@
+@base <http://example.org/nodeKind> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:iriProperty ;
+		sh:nodeKind sh:IRI ;
+	] ;
+	sh:property [
+		sh:path ex:literalProperty ;
+		sh:nodeKind sh:Literal ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/path-alternative.shaclc
+++ b/shacl12-compact-syntax/tests/valid/path-alternative.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/path-alternative>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property1|ex:property2 .
+}

--- a/shacl12-compact-syntax/tests/valid/path-alternative.ttl
+++ b/shacl12-compact-syntax/tests/valid/path-alternative.ttl
@@ -1,0 +1,18 @@
+@base <http://example.org/path-alternative> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path [ sh:alternativePath ( ex:property1 ex:property2 ) ] ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/path-complex.shaclc
+++ b/shacl12-compact-syntax/tests/valid/path-complex.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/path-complex>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	(rdf:type/rdfs:subClassOf*)|ex:property .
+}

--- a/shacl12-compact-syntax/tests/valid/path-complex.ttl
+++ b/shacl12-compact-syntax/tests/valid/path-complex.ttl
@@ -1,0 +1,18 @@
+@base <http://example.org/path-complex> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path [ sh:alternativePath ( ( rdf:type [ sh:zeroOrMorePath rdfs:subClassOf ] ) ex:property ) ] ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/path-inverse.shaclc
+++ b/shacl12-compact-syntax/tests/valid/path-inverse.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/path-inverse>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	^ex:property .
+}

--- a/shacl12-compact-syntax/tests/valid/path-inverse.ttl
+++ b/shacl12-compact-syntax/tests/valid/path-inverse.ttl
@@ -1,0 +1,18 @@
+@base <http://example.org/path-inverse> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path [ sh:inversePath ex:property ] ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/path-oneOrMore.shaclc
+++ b/shacl12-compact-syntax/tests/valid/path-oneOrMore.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/path-oneOrMore>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property+ .
+}

--- a/shacl12-compact-syntax/tests/valid/path-oneOrMore.ttl
+++ b/shacl12-compact-syntax/tests/valid/path-oneOrMore.ttl
@@ -1,0 +1,18 @@
+@base <http://example.org/path-oneOrMore> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path [ sh:oneOrMorePath ex:property ] ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/path-sequence.shaclc
+++ b/shacl12-compact-syntax/tests/valid/path-sequence.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/path-sequence>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property1/ex:property2 .
+}

--- a/shacl12-compact-syntax/tests/valid/path-sequence.ttl
+++ b/shacl12-compact-syntax/tests/valid/path-sequence.ttl
@@ -1,0 +1,18 @@
+@base <http://example.org/path-sequence> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ( ex:property1 ex:property2 ) ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/path-zeroOrMore.shaclc
+++ b/shacl12-compact-syntax/tests/valid/path-zeroOrMore.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/path-zeroOrMore>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property* .
+}

--- a/shacl12-compact-syntax/tests/valid/path-zeroOrMore.ttl
+++ b/shacl12-compact-syntax/tests/valid/path-zeroOrMore.ttl
@@ -1,0 +1,18 @@
+@base <http://example.org/path-zeroOrMore> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path [ sh:zeroOrMorePath ex:property ] ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/path-zeroOrOne.shaclc
+++ b/shacl12-compact-syntax/tests/valid/path-zeroOrOne.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/path-zeroOrOne>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property? .
+}

--- a/shacl12-compact-syntax/tests/valid/path-zeroOrOne.ttl
+++ b/shacl12-compact-syntax/tests/valid/path-zeroOrOne.ttl
@@ -1,0 +1,18 @@
+@base <http://example.org/path-zeroOrOne> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path [ sh:zeroOrOnePath ex:property ] ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/property-empty.shaclc
+++ b/shacl12-compact-syntax/tests/valid/property-empty.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/property-empty>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property .
+}

--- a/shacl12-compact-syntax/tests/valid/property-empty.ttl
+++ b/shacl12-compact-syntax/tests/valid/property-empty.ttl
@@ -1,0 +1,18 @@
+@base <http://example.org/property-empty> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/property-empty>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:property ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/property-not.shaclc
+++ b/shacl12-compact-syntax/tests/valid/property-not.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/property-not>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property !ex:Person .
+}

--- a/shacl12-compact-syntax/tests/valid/property-not.ttl
+++ b/shacl12-compact-syntax/tests/valid/property-not.ttl
@@ -1,0 +1,19 @@
+@base <http://example.org/property-not> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:property ;
+		sh:not [ sh:class ex:Person ] ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/property-or-2.shaclc
+++ b/shacl12-compact-syntax/tests/valid/property-or-2.shaclc
@@ -1,0 +1,8 @@
+BASE <http://example.org/property-or-2>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property1 xsd:string|rdf:langString .
+	ex:property2 xsd:string|ex:TestClass .
+}

--- a/shacl12-compact-syntax/tests/valid/property-or-2.ttl
+++ b/shacl12-compact-syntax/tests/valid/property-or-2.ttl
@@ -1,0 +1,23 @@
+@base <http://example.org/property-or-2> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:property1 ;
+		sh:or ( [ sh:datatype xsd:string ] [ sh:datatype rdf:langString ] ) ;
+	] ;
+	sh:property [
+		sh:path ex:property2 ;
+		sh:or ( [ sh:datatype xsd:string ] [ sh:class ex:TestClass ] ) ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/property-or-3.shaclc
+++ b/shacl12-compact-syntax/tests/valid/property-or-3.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/property-or-3>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property xsd:string|rdf:langString|@ex:OtherShape .
+}

--- a/shacl12-compact-syntax/tests/valid/property-or-3.ttl
+++ b/shacl12-compact-syntax/tests/valid/property-or-3.ttl
@@ -1,0 +1,19 @@
+@base <http://example.org/property-or-3> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:property ;
+		sh:or ( [ sh:datatype xsd:string ] [ sh:datatype rdf:langString ] [ sh:node ex:OtherShape ] ) ;
+	] ;
+.

--- a/shacl12-compact-syntax/tests/valid/shapeRef.shaclc
+++ b/shacl12-compact-syntax/tests/valid/shapeRef.shaclc
@@ -1,0 +1,7 @@
+BASE <http://example.org/shapeRef>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property @<http://example.org/test#OtherShape1> @ex:OtherShape2 .
+}

--- a/shacl12-compact-syntax/tests/valid/shapeRef.ttl
+++ b/shacl12-compact-syntax/tests/valid/shapeRef.ttl
@@ -1,0 +1,19 @@
+@base <http://example.org/shapeRef> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:property ;
+		sh:node ex:OtherShape1, ex:OtherShape2 ;
+	] ;
+.


### PR DESCRIPTION
As requested in today's call - this PR creates the stub shacl12-compact-syntax specification document; so that we can get approval to begin work on this specification document.

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/feat/shacl12-compact/shacl12-compact-syntax/index.html)

cc @VladimirAlexiev 
