### PR TITLE
#177: Update SHACL-SHACL to review `sh:singleLine` usage

### DIFF
--- a/shacl12-vocabularies/shacl-shacl.ttl
+++ b/shacl12-vocabularies/shacl-shacl.ttl
@@ -108,10 +108,10 @@ shsh:ShapeShape
 	sh:targetSubjectsOf sh:qualifiedMinCount ;
 	sh:targetSubjectsOf sh:qualifiedValueShape ;
 	sh:targetSubjectsOf sh:qualifiedValueShapesDisjoint ;
+	sh:targetSubjectsOf sh:singleLine ;
 	sh:targetSubjectsOf sh:uniqueLang ;
 	sh:targetSubjectsOf sh:uniqueMembers ;
 	sh:targetSubjectsOf sh:xone ;
-  sh:targetSubjectsOf sh:singleLine ;
 
 	sh:targetObjectsOf sh:memberShape ; # memberShape-node
 	sh:targetObjectsOf sh:node ;        # node-node

--- a/shacl12-vocabularies/shacl-shacl.ttl
+++ b/shacl12-vocabularies/shacl-shacl.ttl
@@ -76,6 +76,8 @@ shsh:ShapeShape
 		sh:not, sh:or, sh:pattern, sh:property, sh:qualifiedMaxCount, sh:qualifiedMinCount, sh:qualifiedValueShape,
 		sh:qualifiedValueShape, sh:qualifiedValueShapesDisjoint, sh:qualifiedValueShapesDisjoint, sh:uniqueLang, sh:xone,
 		sh:minListLength, sh:maxListLength, sh:uniqueMembers ;
+	sh:targetSubjectsOf sh:singleLine ;
+
 
 	sh:targetObjectsOf sh:memberShape ; # memberShape-node
 	sh:targetObjectsOf sh:node ;        # node-node
@@ -259,6 +261,11 @@ shsh:ShapeShape
 		sh:datatype xsd:string ;        # pattern-datatype
 		sh:maxCount 1 ;                 # multiple-parameters
 		# Not implemented: syntax rule pattern-regex
+	] ;
+	sh:property [
+		sh:path sh:singleLine ;
+		sh:datatype xsd:boolean ;	# singleLine-datatype
+		sh:maxCount 1 ;                 # multiple-parameters
 	] ;
 	sh:property [
 		sh:path sh:flags ;


### PR DESCRIPTION
This PR is a follow-on to #268, and just updates SHACL-SHACL to test syntax for #177 .