### PR TITLE
#472: Deleted triple-can-be-skipped and target-can-be-skipped

### DIFF
--- a/shacl12-compact-syntax/index.html
+++ b/shacl12-compact-syntax/index.html
@@ -141,25 +141,16 @@
 			.focus-node-selected {
 				color: blue;
 			}
+
 			.focus-node-error {
 				color: red;
 			}
-
-			.triple-can-be-skipped {
-				color: grey;
-			}
+			
 			.focus-node-error {
 				color: red;
 			}
 			
 			.rule {
-			}
-
-			.target-can-be-skipped{
-				color: darkslategray;
-				font-style: italic;
-				data-tooltip: "Custom tooltip text." ;
-				data-tooltip-position: "bottom" ;
 			}
 			
 			.component-class {

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -253,22 +253,15 @@
 			.focus-node-selected {
 				color: blue;
 			}
+
 			.focus-node-error {
 				color: red;
 			}
 
-			.triple-can-be-skipped {
-				color: grey;
-			}
 			.focus-node-error {
 				color: red;
 			}
 
-			.target-can-be-skipped {
-				color: darkslategray;
-				font-style: italic;
-			}
-			
 			.component-class {
 				font-weight: bold;
 				font-size: 16px;
@@ -688,8 +681,7 @@
 					<div class="turtle">
 # This box represents an input shapes graph
 
-# Triples that can be omitted are marked as grey, e.g. --
-<span class="triple-can-be-skipped">&lt;s&gt; ex:p &lt;o&gt; .</span>
+&lt;s&gt; ex:p &lt;o&gt; .
 						</div>
 				  <div class="jsonld">
 						<pre class="text">// This box represents an input shapes graph</pre>
@@ -1850,7 +1842,7 @@ ex:Bob ex:livesIn ex:NewYork .
 							<div class="turtle">
 ex:MyShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:MyInstance ;</span>
+	sh:targetNode ex:MyInstance ;
 	sh:property [    # _:b1
 		# Violations of sh:minCount and sh:datatype are produced as warnings
 		sh:path ex:myProperty ;
@@ -2032,7 +2024,7 @@ ex:MyInstance
 							<div class="turtle">
 ex:MyShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:MyInstance ;</span>
+	sh:targetNode ex:MyInstance ;
 	sh:property [    # _:b1
 		sh:path ex:myProperty ;
 		sh:minCount 1 {| sh:severity sh:Info |} ;
@@ -2092,7 +2084,7 @@ ex:MyShape
 							<div class="turtle">
 ex:MyShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:MyInstance ;</span>
+	sh:targetNode ex:MyInstance ;
 	sh:property [
 		sh:path ex:myProperty ;
 		sh:maxLength 10 {|
@@ -2162,7 +2154,7 @@ ex:MyShape
 							<div class="turtle">
 ex:PersonShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Person ;</span>
+	sh:targetClass ex:Person ;
 	sh:property ex:PersonShape-name .
 
 ex:PersonShape-name
@@ -2227,7 +2219,7 @@ ex:JohnDoe a ex:Person .
 							<div class="turtle">
 ex:PersonShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Person ;</span>
+	sh:targetClass ex:Person ;
 	sh:property ex:PersonShape-name .
 
 ex:PersonShape-name
@@ -3272,7 +3264,7 @@ ex:SomeClass-alternativePathExample
 							<div class="turtle">
 ex:ClassExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:Bob, ex:Alice, ex:Carol ;</span>
+	sh:targetNode ex:Bob, ex:Alice, ex:Carol ;
 	sh:property [
 		sh:path ex:address ;
 		sh:class ex:PostalAddress ;
@@ -3351,7 +3343,7 @@ ex:Bob ex:address [ a ex:PostalAddress ; ex:city ex:Berlin ] .
 							<div class="turtle">
 ex:ClassListExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Person ;</span>
+	sh:targetClass ex:Person ;
 	sh:property [
 		sh:path ex:pet ;
 		sh:class ( ex:Cat ex:Dog ) ;
@@ -3427,7 +3419,7 @@ ex:Alice a ex:Person ; ex:pet ex:Tessie, ex:Rusty .
 							<div class="turtle">
 ex:DatatypeExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:Alice, ex:Bob, ex:Carol ;</span>
+	sh:targetNode ex:Alice, ex:Bob, ex:Carol ;
 	sh:property [
 		sh:path ex:age ;
 		sh:datatype xsd:integer ;
@@ -3504,7 +3496,7 @@ ex:Alice ex:age "23"^^xsd:integer .
 							<div class="turtle">
 ex:TextExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:Estonia, ex:GreatBritain ;</span>
+	sh:targetNode ex:Estonia, ex:GreatBritain ;
 	sh:property [
 		sh:path rdfs:label ;
 		sh:datatype ( xsd:string rdf:langString ) ;
@@ -3573,7 +3565,7 @@ ex:Estonia rdfs:label "Estonia", "Estland"@de .
 							<div class="turtle">
 ex:NodeKindExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetObjectsOf ex:knows ;</span>
+	sh:targetObjectsOf ex:knows ;
 	sh:nodeKind sh:IRI .
 							</div>
 							<div class="jsonld">
@@ -3664,7 +3656,7 @@ ex:Bob ex:knows ex:Alice .
 							<div class="turtle">
 ex:MinCountExampleShape
 	a sh:PropertyShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:Alice, ex:Bob ;</span>
+	sh:targetNode ex:Alice, ex:Bob ;
 	sh:path ex:name ;
 	sh:minCount 1 .
 							</div>
@@ -3757,7 +3749,7 @@ ex:MinCountExampleShape
 							<div class="turtle">
 ex:MaxCountExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:Bob ;</span>
+	sh:targetNode ex:Bob ;
 	sh:property [
 		sh:path ex:birthDate ;
 		sh:maxCount 1 ;
@@ -3812,7 +3804,7 @@ ex:Bob ex:birthDate "May 5th 1990" .
 						<div class="turtle">
 ex:NumericRangeExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:Bob, ex:Alice, ex:Ted ;</span>
+	sh:targetNode ex:Bob, ex:Alice, ex:Ted ;
 	sh:property [
 		sh:path ex:age ;
 		sh:minInclusive 0 ;
@@ -4120,7 +4112,7 @@ ex:Bob ex:age 23 .
 							<div class="turtle">
 ex:PasswordExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:Bob, ex:Alice ;</span>
+	sh:targetNode ex:Bob, ex:Alice ;
 	sh:property [
 		sh:path ex:password ;
 		sh:minLength 8 ;
@@ -4233,7 +4225,7 @@ ex:Bob ex:password "123456789" .
 							<div class="turtle">
 ex:PatternExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:Bob, ex:Alice, ex:Carol ;</span>
+	sh:targetNode ex:Bob, ex:Alice, ex:Carol ;
 	sh:property [
 		sh:path ex:bCode ;
 		sh:pattern "^B" ;    # starts with 'B'
@@ -4457,7 +4449,7 @@ ex:SingleLineExampleShape
 							<div class="turtle">
 ex:NewZealandLanguagesShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:Mountain, ex:Berg ;</span>
+	sh:targetNode ex:Mountain, ex:Berg ;
 	sh:property [
 		sh:path ex:prefLabel ;
 		sh:languageIn ( "en" "mi" ) ;
@@ -4590,7 +4582,7 @@ ex:Mountain
 							<div class="turtle">
 ex:UniqueLangExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:Alice, ex:Bob ;</span>
+	sh:targetNode ex:Alice, ex:Bob ;
 	sh:property [
 		sh:path ex:label ;
 		sh:uniqueLang true ;
@@ -4728,7 +4720,7 @@ ex:Alice
 							<div class="turtle">
 ex:AgendaShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Agenda ;</span>
+	sh:targetClass ex:Agenda ;
 	sh:property [
 		sh:path ex:speakerOrder ;
 		sh:memberShape [
@@ -4851,7 +4843,7 @@ ex:agenda1 a ex:Agenda ;
 							<div class="turtle">
 ex:PersonShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Person ;</span>
+	sh:targetClass ex:Person ;
 	sh:property [
 		sh:path ex:skills ;
 		sh:minListLength 1 ;
@@ -4956,7 +4948,7 @@ ex:person1 a ex:Person ;
 							<div class="turtle">
 ex:PersonShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Person ;</span>
+	sh:targetClass ex:Person ;
 	sh:property [
 		sh:path ex:hobbies ;
 		sh:maxListLength 2 ;
@@ -5069,7 +5061,7 @@ ex:person1 a ex:Person ;
 							<div class="turtle">
 ex:PersonShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Person ;</span>
+	sh:targetClass ex:Person ;
 	sh:property [
 		sh:path ex:preferences ;
 		sh:uniqueMembers true ;
@@ -5190,7 +5182,7 @@ ex:person1 a ex:Person ;
 							<div class="turtle">
 ex:EqualExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:Bob ;</span>
+	sh:targetNode ex:Bob ;
 	sh:property [
 		sh:path ex:firstName ;
 		sh:equals ex:givenName ;
@@ -5281,7 +5273,7 @@ ex:Bob
 							<div class="turtle">
 ex:DisjointExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:USA, ex:Germany ;</span>
+	sh:targetNode ex:USA, ex:Germany ;
 	sh:property [
 		sh:path ex:prefLabel ;
 		sh:disjoint ex:altLabel ;
@@ -5506,7 +5498,7 @@ ex:LessThanExampleShape
 							<div class="turtle">
 ex:NotExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:InvalidInstance1 ;</span>
+	sh:targetNode ex:InvalidInstance1 ;
 	sh:not [
 		a sh:PropertyShape ;
 		sh:path ex:property ;
@@ -5610,7 +5602,7 @@ ex:SuperShape
 
 ex:ExampleAndShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:ValidInstance, ex:InvalidInstance ;</span>
+	sh:targetNode ex:ValidInstance, ex:InvalidInstance ;
 	sh:and (
 		ex:SuperShape
 		[
@@ -5752,7 +5744,7 @@ ex:ValidInstance
 							<div class="turtle">
 ex:OrConstraintExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:Bob ;</span>
+	sh:targetNode ex:Bob ;
 	sh:or (
 		[
 			sh:path ex:firstName ;
@@ -5818,7 +5810,7 @@ ex:Bob ex:firstName "Robert" .
 							<div class="turtle">
 ex:PersonAddressShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Person ;</span>
+	sh:targetClass ex:Person ;
 	sh:property [
 		sh:path ex:address ;
 		sh:or (
@@ -5976,7 +5968,7 @@ ex:shapeRoot a sh:NodeShape;
 							<div class="turtle">
 ex:XoneConstraintExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Person ;</span>
+	sh:targetClass ex:Person ;
 	sh:xone (
 		[
 			sh:property [
@@ -6145,7 +6137,7 @@ ex:AddressShape
 
 ex:PersonShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Person ;</span>
+	sh:targetClass ex:Person ;
 	sh:property [   # _:b1
 		sh:path ex:address ;
 		sh:minCount 1 ;
@@ -6446,7 +6438,7 @@ ex:RetosAddress
 							<div class="turtle">
 ex:QualifiedValueShapeExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:QualifiedValueShapeExampleValidResource ;</span>
+	sh:targetNode ex:QualifiedValueShapeExampleValidResource ;
 	sh:property [
 		sh:path ex:parent ;
 		sh:minCount 2 ;
@@ -6548,7 +6540,7 @@ ex:Jane
 							<div class="turtle">
 ex:HandShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Hand ;</span>
+	sh:targetClass ex:Hand ;
 	sh:property [
 		sh:path ex:digit ;
 		sh:maxCount 5 ;
@@ -6898,7 +6890,7 @@ ex:AddressShape
 
 ex:PersonShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Person ;</span>
+	sh:targetClass ex:Person ;
 	sh:property [   # _:b1
 		sh:path ex:address ;
 		sh:minCount 1 ;
@@ -7146,7 +7138,7 @@ for each rdf:type T of the value node in the data graph
 							<div class="turtle">
 ex:ClosedShapeExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:Alice, ex:Bob ;</span>
+	sh:targetNode ex:Alice, ex:Bob ;
 	sh:closed true ;
 	sh:ignoredProperties (rdf:type) ;
 	sh:property [
@@ -7273,7 +7265,7 @@ ex:Alice
 							<div class="turtle">
 ex:StanfordGraduate
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:Alice ;</span>
+	sh:targetNode ex:Alice ;
 	sh:property [
 		sh:path ex:alumniOf ;
 		sh:hasValue ex:Stanford ;
@@ -7367,7 +7359,7 @@ ex:Alice
 							<div class="turtle">
 ex:InExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetNode ex:RainbowPony ;</span>
+	sh:targetNode ex:RainbowPony ;
 	sh:property [
 		sh:path ex:color ;
 		sh:in ( ex:Pink ex:Purple ) ;
@@ -7975,19 +7967,5 @@ ex:NameGroup
 				<li>Added parameter <a href="#subClassOfInShapesGraph"></a> to look up rdfs:subClassOf triples in the union of the shapes graph and the data graph; see <a href="https://github.com/w3c/data-shapes/issues/185">Issue 185</a></li>
 			</ul>
 		</section>
-	
-
-	<script type="text/javascript">
-
-		tooltip = "Targets are not the only way to initiate validation, SHACL also allows specific nodes to be validated against specific shapes.";
-		var t = document.getElementsByClassName("target-can-be-skipped");
-		for (var i = 0; i < t.length; i++) {
-			t[i].title = tooltip;
-		}
-		
-	</script>
-
-
-
 
 </body></html>

--- a/shacl12-inf-rules/index.html
+++ b/shacl12-inf-rules/index.html
@@ -146,20 +146,13 @@
 			.focus-node-selected {
 				color: blue;
 			}
+
 			.focus-node-error {
 				color: red;
 			}
 
-			.triple-can-be-skipped {
-				color: grey;
-			}
 			.focus-node-error {
 				color: red;
-			}
-
-			.target-can-be-skipped {
-				color: darkslategray;
-				font-style: italic;
 			}
 
 			.component-class {

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -224,20 +224,13 @@
 			.focus-node-selected {
 				color: blue;
 			}
+
 			.focus-node-error {
 				color: red;
 			}
 
-			.triple-can-be-skipped {
-				color: grey;
-			}
 			.focus-node-error {
 				color: red;
-			}
-
-			.target-can-be-skipped {
-				color: darkslategray;
-				font-style: italic;
 			}
 			
 			.component-class {

--- a/shacl12-overview/index.html
+++ b/shacl12-overview/index.html
@@ -147,17 +147,8 @@
 				color: red;
 			}
 
-			.triple-can-be-skipped {
-				color: grey;
-			}
-
 			.focus-node-error {
 				color: red;
-			}
-
-			.target-can-be-skipped {
-				color: darkslategray;
-				font-style: italic;
 			}
 
 			.component-class {

--- a/shacl12-profiling/index.html
+++ b/shacl12-profiling/index.html
@@ -231,20 +231,13 @@
 			.focus-node-selected {
 				color: blue;
 			}
+
 			.focus-node-error {
 				color: red;
 			}
 
-			.triple-can-be-skipped {
-				color: grey;
-			}
 			.focus-node-error {
 				color: red;
-			}
-
-			.target-can-be-skipped {
-				color: darkslategray;
-				font-style: italic;
 			}
 
 			.component-class {
@@ -697,8 +690,7 @@
 					<div class="turtle">
 # This box represents an input shapes graph
 
-# Triples that can be omitted are marked as grey, e.g. --
-<span class="triple-can-be-skipped">&lt;s&gt; &lt;p&gt; &lt;o&gt; .</span>
+&lt;s&gt; &lt;p&gt; &lt;o&gt; .
 						</div>
 				  <div class="jsonld">
 						<pre class="text">// This box represents an input shapes graph</pre>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -227,20 +227,13 @@
 			.focus-node-selected {
 				color: blue;
 			}
+
 			.focus-node-error {
 				color: red;
 			}
 
-			.triple-can-be-skipped {
-				color: grey;
-			}
 			.focus-node-error {
 				color: red;
-			}
-
-			.target-can-be-skipped {
-				color: darkslategray;
-				font-style: italic;
 			}
 			
 			.component-class {
@@ -581,8 +574,7 @@
 					<div class="turtle">
 # This box represents an input shapes graph
 
-# Triples that can be omitted are marked as grey e.g.
-<span class="triple-can-be-skipped">&lt;s&gt; ex:p &lt;o&gt; .</span>
+&lt;s&gt; ex:p &lt;o&gt; .
 					</div>
 					<div class="jsonld">
 						<pre class="text">// This box represents an input shapes graph</pre>
@@ -711,7 +703,7 @@
 						<div class="turtle">
 ex:LanguageExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Country ;</span>
+	sh:targetClass ex:Country ;
 	sh:sparql [
 		a sh:SPARQLConstraint ;   # This triple is optional
 		sh:message "Values are literals with German language tag." ;
@@ -856,7 +848,7 @@ ex:ValidCountry a ex:Country ;
 						<div class="turtle">
 ex:LanguageExamplePropertyShape
 	a sh:PropertyShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Country ;</span>
+	sh:targetClass ex:Country ;
 	sh:path ex:germanLabel ;
 	sh:sparql [
 		a sh:SPARQLConstraint ;   # This triple is optional
@@ -1389,7 +1381,7 @@ ex:LanguageConstraintComponentUsingSELECT
 								<div class="turtle">
 ex:LanguageExampleShape
 	a sh:NodeShape ;
-	<span class="target-can-be-skipped">sh:targetClass ex:Country ;</span>
+	sh:targetClass ex:Country ;
 	sh:property [
 		sh:path ex:germanLabel ;
 		ex:lang "de" ;
@@ -2066,7 +2058,7 @@ ex:Resource-uriLength
 				<div class="def def-sparql">
 					<div class="def-header">POTENTIAL DEFINITION IN SPARQL</div>
 <pre class="def-sparql-body">
-SELECT DISTINCT ?this    <span class="triple-can-be-skipped"># ?this is the focus node</span>
+SELECT DISTINCT ?this    # ?this is the focus node
 WHERE {
 	?this rdf:type/rdfs:subClassOf* $targetClass .
 }</pre>
@@ -2082,7 +2074,7 @@ WHERE {
 				<div class="def def-sparql">
 					<div class="def-header">POTENTIAL DEFINITION IN SPARQL</div>
 <pre class="def-sparql-body">
-SELECT DISTINCT ?this    <span class="triple-can-be-skipped"># ?this is the focus node</span>
+SELECT DISTINCT ?this    # ?this is the focus node
 WHERE {
 	?this $targetSubjectsOf ?any .
 }</pre>
@@ -2098,7 +2090,7 @@ WHERE {
 				<div class="def def-sparql">
 					<div class="def-header">POTENTIAL DEFINITION IN SPARQL</div>
 <pre class="def-sparql-body">
-SELECT DISTINCT ?this    <span class="triple-can-be-skipped"># ?this is the focus node</span>
+SELECT DISTINCT ?this    # ?this is the focus node
 WHERE {
 	?any $targetObjectsOf ?this .
 }</pre>


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #472

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-472/shacl12-core/index.html)
