### PR TITLE
mark SHACL-C fragments in core as informative

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -678,10 +678,11 @@
 					References to the SHACL vocabulary, e.g., via <code>owl:imports</code> should include the <code>#</code>.
 				</p>
 				<p>
-					Throughout the document, color-coded boxes containing RDF graphs in Turtle and JSON-LD will appear.
+					Throughout the document, color-coded boxes containing RDF graphs in Turtle, JSON-LD and SHACL-C will appear.
 					These fragments of Turtle documents use the prefix bindings given above.
 					The JSON-LD document fragments use the context given above.
 					Only the Turtle documents may highlight certain parts.
+					<i>The SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i>
 				</p>
 
 				<div class="shapes-graph">
@@ -908,7 +909,7 @@ ex:PersonShape
 	}
 }</pre>
 						</div>
-					<div class="shaclc"><pre class="shaclc">shape ex:PersonShape -&gt; ex:Person {
+					<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:PersonShape -&gt; ex:Person {
 	closed=true ignoredProperties=[rdf:type] .
 	ex:ssn xsd:string [0..1] pattern="^\\d{3}-\\d{2}-\\d{4}$" .
 	ex:worksFor IRI ex:Company .
@@ -1333,7 +1334,7 @@ ex:MultiplePatternsShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:MultiplePatternsShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:MultiplePatternsShape {
 	ex:name pattern="^Start" flags="i" .
 	ex:name pattern="End$" .
 }</pre></div></div>
@@ -1430,7 +1431,7 @@ ex:PersonShape
 	}
 }</pre>
 								</div>
-							<div class="shaclc"><pre class="shaclc">shape ex:PersonShape {
+							<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:PersonShape {
 	targetNode=ex:Alice .
 }</pre></div></div>
 							<div class="data-graph">
@@ -1485,7 +1486,7 @@ ex:PersonShape
 	}
 }</pre>
 								</div>
-							<div class="shaclc"><pre class="shaclc">shape ex:PersonShape -&gt; ex:Person {
+							<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:PersonShape -&gt; ex:Person {
 }</pre></div></div>
 
 							<div class="data-graph">
@@ -1609,7 +1610,7 @@ ex:Person
 	]
 }</pre>
 								</div>
-							<div class="shaclc"><pre class="shaclc">shapeClass ex:Person {
+							<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shapeClass ex:Person {
 }</pre></div></div>
 							<div class="data-graph">
 								<div class="turtle">
@@ -1682,7 +1683,7 @@ ex:TargetSubjectsOfExampleShape
 	}
 }</pre>
 								</div>
-							<div class="shaclc"><pre class="shaclc">shape ex:TargetSubjectsOfExampleShape {
+							<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:TargetSubjectsOfExampleShape {
 	targetSubjectsOf=ex:knows .
 }</pre></div></div>
 							<div class="data-graph">
@@ -1746,7 +1747,7 @@ ex:TargetObjectsOfExampleShape
 	}
 }</pre>
 								</div>
-							<div class="shaclc"><pre class="shaclc">shape ex:TargetObjectsOfExampleShape {
+							<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:TargetObjectsOfExampleShape {
 	targetObjectsOf=ex:knows .
 }</pre></div></div>
 							<div class="data-graph">
@@ -1911,7 +1912,7 @@ ex:MyShape
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:MyShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:MyShape {
 	targetNode=ex:MyInstance .
 	ex:myProperty xsd:string [1..*] severity=Warning .
 	ex:myProperty maxLength=10 message="Too many characters"@en message="Zu viele Zeichen"@de .
@@ -3303,7 +3304,7 @@ ex:ClassExampleShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:ClassExampleShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:ClassExampleShape {
 	targetNode=ex:Bob targetNode=ex:Alice targetNode=ex:Carol .
 	ex:address ex:PostalAddress .
 }</pre></div></div>
@@ -3458,7 +3459,7 @@ ex:DatatypeExampleShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:DatatypeExampleShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:DatatypeExampleShape {
 	targetNode=ex:Alice targetNode=ex:Bob targetNode=ex:Carol .
 	ex:age xsd:integer .
 }</pre></div></div>
@@ -3588,7 +3589,7 @@ ex:NodeKindExampleShape
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:NodeKindExampleShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:NodeKindExampleShape {
 	targetObjectsOf=ex:knows nodeKind=IRI .
 }</pre></div></div>
 						<div class="data-graph">
@@ -3781,7 +3782,7 @@ ex:MaxCountExampleShape
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:MaxCountExampleShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:MaxCountExampleShape {
 	targetNode=ex:Bob .
 	ex:birthDate [0..1] .
 }</pre></div></div>
@@ -3849,7 +3850,7 @@ ex:NumericRangeExampleShape
 	]
 }</pre>
 						</div>
-					<div class="shaclc"><pre class="shaclc">shape ex:NumericRangeExampleShape {
+					<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:NumericRangeExampleShape {
 	targetNode=ex:Bob targetNode=ex:Alice targetNode=ex:Ted .
 	ex:age minInclusive=0 maxInclusive=150 .
 }</pre></div></div>
@@ -4154,7 +4155,7 @@ ex:PasswordExampleShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:PasswordExampleShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:PasswordExampleShape {
 	targetNode=ex:Bob targetNode=ex:Alice .
 	ex:password minLength=8 maxLength=10 .
 }</pre></div></div>
@@ -4264,7 +4265,7 @@ ex:PatternExampleShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:PatternExampleShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:PatternExampleShape {
 	targetNode=ex:Bob targetNode=ex:Alice targetNode=ex:Carol .
 	ex:bCode pattern="^B" flags="i" .
 }</pre></div></div>
@@ -4488,7 +4489,7 @@ ex:NewZealandLanguagesShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:NewZealandLanguagesShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:NewZealandLanguagesShape {
 	targetNode=ex:Mountain targetNode=ex:Berg .
 	ex:prefLabel languageIn=["en" "mi"] .
 }</pre></div></div>
@@ -4619,7 +4620,7 @@ ex:UniqueLangExampleShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:UniqueLangExampleShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:UniqueLangExampleShape {
 	targetNode=ex:Alice targetNode=ex:Bob .
 	ex:label uniqueLang=true .
 }</pre></div></div>
@@ -5213,7 +5214,7 @@ ex:EqualExampleShape
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:EqualExampleShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:EqualExampleShape {
 	targetNode=ex:Bob .
 	ex:firstName equals=ex:givenName .
 }</pre></div></div>
@@ -5309,7 +5310,7 @@ ex:DisjointExampleShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:DisjointExampleShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:DisjointExampleShape {
 	targetNode=ex:USA targetNode=ex:Germany .
 	ex:prefLabel disjoint=ex:altLabel .
 }</pre></div></div>
@@ -5408,7 +5409,7 @@ ex:LessThanExampleShape
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:LessThanExampleShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:LessThanExampleShape {
 	ex:startDate lessThan=ex:endDate .
 }</pre></div></div>
 					</aside>
@@ -5859,7 +5860,7 @@ ex:PersonAddressShape
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:PersonAddressShape -&gt; ex:Person {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:PersonAddressShape -&gt; ex:Person {
 	ex:address xsd:string|ex:Address .
 }</pre></div></div>
 						<div class="data-graph">
@@ -6193,7 +6194,7 @@ ex:PersonShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:AddressShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:AddressShape {
 	ex:postalCode xsd:string [0..1] .
 }
 shape ex:PersonShape -&gt; ex:Person {
@@ -7193,7 +7194,7 @@ ex:ClosedShapeExampleShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:ClosedShapeExampleShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:ClosedShapeExampleShape {
 	targetNode=ex:Alice targetNode=ex:Bob closed=true ignoredProperties=[rdf:type] .
 	ex:firstName .
 	ex:lastName .
@@ -7296,7 +7297,7 @@ ex:StanfordGraduate
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:StanfordGraduate {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:StanfordGraduate {
 	targetNode=ex:Alice .
 	ex:alumniOf hasValue=ex:Stanford .
 }</pre></div></div>
@@ -7397,7 +7398,7 @@ ex:InExampleShape
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><pre class="shaclc">shape ex:InExampleShape {
+						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:InExampleShape {
 	targetNode=ex:RainbowPony .
 	ex:color in=[ex:Pink ex:Purple] .
 }</pre></div></div>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -83,6 +83,10 @@
 					tabs.prepend(selectors);
 				}
 
+				for (const block of document.querySelectorAll('.shaclc')) {
+					block.innerHTML = `<i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i>${block.innerHTML}`;
+				}
+
 				// Add example button selection logic
 				for (const button of document.querySelectorAll(".ds-selector-tabs .selectors button")) {
 					button.onclick = () => {
@@ -909,7 +913,7 @@ ex:PersonShape
 	}
 }</pre>
 						</div>
-					<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:PersonShape -&gt; ex:Person {
+					<div class="shaclc"><pre class="shaclc">shape ex:PersonShape -&gt; ex:Person {
 	closed=true ignoredProperties=[rdf:type] .
 	ex:ssn xsd:string [0..1] pattern="^\\d{3}-\\d{2}-\\d{4}$" .
 	ex:worksFor IRI ex:Company .
@@ -1334,7 +1338,7 @@ ex:MultiplePatternsShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:MultiplePatternsShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:MultiplePatternsShape {
 	ex:name pattern="^Start" flags="i" .
 	ex:name pattern="End$" .
 }</pre></div></div>
@@ -1431,7 +1435,7 @@ ex:PersonShape
 	}
 }</pre>
 								</div>
-							<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:PersonShape {
+							<div class="shaclc"><pre class="shaclc">shape ex:PersonShape {
 	targetNode=ex:Alice .
 }</pre></div></div>
 							<div class="data-graph">
@@ -1486,7 +1490,7 @@ ex:PersonShape
 	}
 }</pre>
 								</div>
-							<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:PersonShape -&gt; ex:Person {
+							<div class="shaclc"><pre class="shaclc">shape ex:PersonShape -&gt; ex:Person {
 }</pre></div></div>
 
 							<div class="data-graph">
@@ -1610,7 +1614,7 @@ ex:Person
 	]
 }</pre>
 								</div>
-							<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shapeClass ex:Person {
+							<div class="shaclc"><pre class="shaclc">shapeClass ex:Person {
 }</pre></div></div>
 							<div class="data-graph">
 								<div class="turtle">
@@ -1683,7 +1687,7 @@ ex:TargetSubjectsOfExampleShape
 	}
 }</pre>
 								</div>
-							<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:TargetSubjectsOfExampleShape {
+							<div class="shaclc"><pre class="shaclc">shape ex:TargetSubjectsOfExampleShape {
 	targetSubjectsOf=ex:knows .
 }</pre></div></div>
 							<div class="data-graph">
@@ -1747,7 +1751,7 @@ ex:TargetObjectsOfExampleShape
 	}
 }</pre>
 								</div>
-							<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:TargetObjectsOfExampleShape {
+							<div class="shaclc"><pre class="shaclc">shape ex:TargetObjectsOfExampleShape {
 	targetObjectsOf=ex:knows .
 }</pre></div></div>
 							<div class="data-graph">
@@ -1912,7 +1916,7 @@ ex:MyShape
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:MyShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:MyShape {
 	targetNode=ex:MyInstance .
 	ex:myProperty xsd:string [1..*] severity=Warning .
 	ex:myProperty maxLength=10 message="Too many characters"@en message="Zu viele Zeichen"@de .
@@ -3304,7 +3308,7 @@ ex:ClassExampleShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:ClassExampleShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:ClassExampleShape {
 	targetNode=ex:Bob targetNode=ex:Alice targetNode=ex:Carol .
 	ex:address ex:PostalAddress .
 }</pre></div></div>
@@ -3459,7 +3463,7 @@ ex:DatatypeExampleShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:DatatypeExampleShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:DatatypeExampleShape {
 	targetNode=ex:Alice targetNode=ex:Bob targetNode=ex:Carol .
 	ex:age xsd:integer .
 }</pre></div></div>
@@ -3589,7 +3593,7 @@ ex:NodeKindExampleShape
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:NodeKindExampleShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:NodeKindExampleShape {
 	targetObjectsOf=ex:knows nodeKind=IRI .
 }</pre></div></div>
 						<div class="data-graph">
@@ -3782,7 +3786,7 @@ ex:MaxCountExampleShape
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:MaxCountExampleShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:MaxCountExampleShape {
 	targetNode=ex:Bob .
 	ex:birthDate [0..1] .
 }</pre></div></div>
@@ -3850,7 +3854,7 @@ ex:NumericRangeExampleShape
 	]
 }</pre>
 						</div>
-					<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:NumericRangeExampleShape {
+					<div class="shaclc"><pre class="shaclc">shape ex:NumericRangeExampleShape {
 	targetNode=ex:Bob targetNode=ex:Alice targetNode=ex:Ted .
 	ex:age minInclusive=0 maxInclusive=150 .
 }</pre></div></div>
@@ -4155,7 +4159,7 @@ ex:PasswordExampleShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:PasswordExampleShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:PasswordExampleShape {
 	targetNode=ex:Bob targetNode=ex:Alice .
 	ex:password minLength=8 maxLength=10 .
 }</pre></div></div>
@@ -4265,7 +4269,7 @@ ex:PatternExampleShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:PatternExampleShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:PatternExampleShape {
 	targetNode=ex:Bob targetNode=ex:Alice targetNode=ex:Carol .
 	ex:bCode pattern="^B" flags="i" .
 }</pre></div></div>
@@ -4489,7 +4493,7 @@ ex:NewZealandLanguagesShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:NewZealandLanguagesShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:NewZealandLanguagesShape {
 	targetNode=ex:Mountain targetNode=ex:Berg .
 	ex:prefLabel languageIn=["en" "mi"] .
 }</pre></div></div>
@@ -4620,7 +4624,7 @@ ex:UniqueLangExampleShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:UniqueLangExampleShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:UniqueLangExampleShape {
 	targetNode=ex:Alice targetNode=ex:Bob .
 	ex:label uniqueLang=true .
 }</pre></div></div>
@@ -5214,7 +5218,7 @@ ex:EqualExampleShape
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:EqualExampleShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:EqualExampleShape {
 	targetNode=ex:Bob .
 	ex:firstName equals=ex:givenName .
 }</pre></div></div>
@@ -5310,7 +5314,7 @@ ex:DisjointExampleShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:DisjointExampleShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:DisjointExampleShape {
 	targetNode=ex:USA targetNode=ex:Germany .
 	ex:prefLabel disjoint=ex:altLabel .
 }</pre></div></div>
@@ -5409,7 +5413,7 @@ ex:LessThanExampleShape
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:LessThanExampleShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:LessThanExampleShape {
 	ex:startDate lessThan=ex:endDate .
 }</pre></div></div>
 					</aside>
@@ -5860,7 +5864,7 @@ ex:PersonAddressShape
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:PersonAddressShape -&gt; ex:Person {
+						<div class="shaclc"><pre class="shaclc">shape ex:PersonAddressShape -&gt; ex:Person {
 	ex:address xsd:string|ex:Address .
 }</pre></div></div>
 						<div class="data-graph">
@@ -6194,7 +6198,7 @@ ex:PersonShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:AddressShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:AddressShape {
 	ex:postalCode xsd:string [0..1] .
 }
 shape ex:PersonShape -&gt; ex:Person {
@@ -7194,7 +7198,7 @@ ex:ClosedShapeExampleShape
 	]
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:ClosedShapeExampleShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:ClosedShapeExampleShape {
 	targetNode=ex:Alice targetNode=ex:Bob closed=true ignoredProperties=[rdf:type] .
 	ex:firstName .
 	ex:lastName .
@@ -7297,7 +7301,7 @@ ex:StanfordGraduate
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:StanfordGraduate {
+						<div class="shaclc"><pre class="shaclc">shape ex:StanfordGraduate {
 	targetNode=ex:Alice .
 	ex:alumniOf hasValue=ex:Stanford .
 }</pre></div></div>
@@ -7398,7 +7402,7 @@ ex:InExampleShape
 	}
 }</pre>
 							</div>
-						<div class="shaclc"><i>SHACL-C specification is unstable - SHACL-C document fragments in this document are informative</i><pre class="shaclc">shape ex:InExampleShape {
+						<div class="shaclc"><pre class="shaclc">shape ex:InExampleShape {
 	targetNode=ex:RainbowPony .
 	ex:color in=[ex:Pink ex:Purple] .
 }</pre></div></div>


### PR DESCRIPTION
Closes #474

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-474/shacl12-core/index.html)
