### PR TITLE
#479: Clarified that sh:order can take xsd:integers

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -7492,7 +7492,7 @@ ex:RainbowPony ex:color ex:Pink .
 				<p>
 					Property shapes may have one <a>value</a> for the property <code>sh:order</code>
 					to indicate the relative order of the property shape for purposes such as form building.
-					The values of <code>sh:order</code> are decimals.
+					The values of <code>sh:order</code> are <a>literals</a> with <a>datatype</a> <code>xsd:decimal</code> or <code>xsd:integer</code>.
 					<code>sh:order</code> is not used for validation purposes
 					and may be used with any type of subjects.
 					If present at property shapes, the recommended use of <code>sh:order</code> is to sort the
@@ -7970,6 +7970,7 @@ ex:NameGroup
 				<li>The values of <a href="#ClassConstraintComponent"><code>sh:class</code></a> and <a href="#DatatypeConstraintComponent"><code>sh:datatype</code></a> can now also be lists, indicating a union of choices; see <a href="https://github.com/w3c/data-shapes/issues/160">Issue 160</a></li>
 				<li>Added the new constraint component <a href="#ReifierShapeShapeConstraintComponent"><code>sh:ReifierShape</code></a>; see <a href="https://github.com/w3c/data-shapes/issues/300">Issue 300</a></li>
 				<li>Added parameter <a href="#subClassOfInShapesGraph"></a> to look up rdfs:subClassOf triples in the union of the shapes graph and the data graph; see <a href="https://github.com/w3c/data-shapes/issues/185">Issue 185</a></li>
+				<li>Generalized <a href="#order"></a> to also allow xsd:integers; see <a href="https://github.com/w3c/data-shapes/issues/479">Issue 479</a></li>
 			</ul>
 		</section>
 


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #479

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-479/shacl12-core/index.html)
