### PR TITLE
add references to Compact Syntax and remove strikethroughs

### DIFF
--- a/shacl12-overview/index.html
+++ b/shacl12-overview/index.html
@@ -452,7 +452,7 @@
 				<dd>Profiling specification elements only</dd>
 			</dl>
 			<p class="note">
-				There is no SHACL-SHACL graph for SHACL Compact Syntax since that specification does not define Shapes in RDF.
+				There is no SHACL-SHACL graph for SHACL Compact Syntax since the specification defines an RDF syntax specialised for describing SHACL concepts - and does not introduce any new concepts itself.
 			</p>
 			<p>
 				Additionally, the union of the above shapes graphs is also provided:

--- a/shacl12-overview/index.html
+++ b/shacl12-overview/index.html
@@ -397,9 +397,11 @@
 				<dd>defines graph expressions used to determine focus nodes in SHACL</dd>
 				<dt><a href="https://w3c.github.io/data-shapes/shacl12-inf-rules/">SHACL 1.2 Inference Rules</a></dt>
 				<dd>defines SHACL's methods of rule-based inference</dd>
-				<dt><s><a href="https://w3c.github.io/data-shapes/shacl12-ui/">SHACL 1.2 UI</a></s></dt>
+				<dt><a href="https://w3c.github.io/data-shapes/shacl12-ui/">SHACL 1.2 UI</a></dt>
 				<dd>defines SHACL's use for User Interface generation</dd>
-				<dt><s><a href="https://w3c.github.io/data-shapes/shacl12-profiling/">SHACL 1.2 Profiling</a></s></dt>
+				<dt><a href="https://w3c.github.io/data-shapes/shacl12-compact-syntax/">SHACL 1.2 Compact Syntax</a></dt>
+				<dd>defines an alternative notation to the RDF-based notations for SHACL</dd>
+				<dt><a href="https://w3c.github.io/data-shapes/shacl12-profiling/">SHACL 1.2 Profiling</a></dt>
 				<dd>defines the use of SHACL for profiling data, including SHACL data</dd>
 			</dl>
 
@@ -449,6 +451,9 @@
 				<dt><a href="">SHACL-SHACL Profiling</a></dt>
 				<dd>Profiling specification elements only</dd>
 			</dl>
+			<p class="note">
+				There is no SHACL-SHACL graph for SHACL Compact Syntax since that specification does not define Shapes in RDF.
+			</p>
 			<p>
 				Additionally, the union of the above shapes graphs is also provided:
 			</p>

--- a/shacl12-overview/index.html
+++ b/shacl12-overview/index.html
@@ -400,7 +400,7 @@
 				<dt><a href="https://w3c.github.io/data-shapes/shacl12-ui/">SHACL 1.2 UI</a></dt>
 				<dd>defines SHACL's use for User Interface generation</dd>
 				<dt><a href="https://w3c.github.io/data-shapes/shacl12-compact-syntax/">SHACL 1.2 Compact Syntax</a></dt>
-				<dd>defines an alternative notation to the RDF-based notations for SHACL</dd>
+				<dd>defines an RDF syntax for expressing SHACL concepts</dd>
 				<dt><a href="https://w3c.github.io/data-shapes/shacl12-profiling/">SHACL 1.2 Profiling</a></dt>
 				<dd>defines the use of SHACL for profiling data, including SHACL data</dd>
 			</dl>


### PR DESCRIPTION
A small PR to add in references to SHACL Compact Syntax we somehow all missed!