### PR TITLE
Unify example namespace prefixes under shacl12-test-suite

### DIFF
--- a/shacl12-test-suite/tests/core/complex/personexample.ttl
+++ b/shacl12-test-suite/tests/core/complex/personexample.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/complex/personexample.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/misc/deactivated-001.ttl
+++ b/shacl12-test-suite/tests/core/misc/deactivated-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/deactivated-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/misc/deactivated-002.ttl
+++ b/shacl12-test-suite/tests/core/misc/deactivated-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/deactivated-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/misc/message-001.ttl
+++ b/shacl12-test-suite/tests/core/misc/message-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/message-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/misc/severity-001.ttl
+++ b/shacl12-test-suite/tests/core/misc/severity-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/severity-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/misc/severity-002.ttl
+++ b/shacl12-test-suite/tests/core/misc/severity-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/misc/severity-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/and-001.ttl
+++ b/shacl12-test-suite/tests/core/node/and-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/and-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/and-002.ttl
+++ b/shacl12-test-suite/tests/core/node/and-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/and-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/class-001.ttl
+++ b/shacl12-test-suite/tests/core/node/class-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/class-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/class-002.ttl
+++ b/shacl12-test-suite/tests/core/node/class-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/class-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/class-003.ttl
+++ b/shacl12-test-suite/tests/core/node/class-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/class-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/closed-001.ttl
+++ b/shacl12-test-suite/tests/core/node/closed-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/closed-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/closed-002.ttl
+++ b/shacl12-test-suite/tests/core/node/closed-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/closed-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/datatype-001.ttl
+++ b/shacl12-test-suite/tests/core/node/datatype-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/datatype-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/datatype-002.ttl
+++ b/shacl12-test-suite/tests/core/node/datatype-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/datatype-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/datatype-003.ttl
+++ b/shacl12-test-suite/tests/core/node/datatype-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/datatype-003.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/disjoint-001.ttl
+++ b/shacl12-test-suite/tests/core/node/disjoint-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/disjoint-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/equals-001.ttl
+++ b/shacl12-test-suite/tests/core/node/equals-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/equals-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/expression-001.ttl
+++ b/shacl12-test-suite/tests/core/node/expression-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/expression-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/hasValue-001.ttl
+++ b/shacl12-test-suite/tests/core/node/hasValue-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/hasValue-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/in-001.ttl
+++ b/shacl12-test-suite/tests/core/node/in-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/in-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/languageIn-001.ttl
+++ b/shacl12-test-suite/tests/core/node/languageIn-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/languageIn-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/maxExclusive-001.ttl
+++ b/shacl12-test-suite/tests/core/node/maxExclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/maxExclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/maxInclusive-001.ttl
+++ b/shacl12-test-suite/tests/core/node/maxInclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/maxInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/maxLength-001.ttl
+++ b/shacl12-test-suite/tests/core/node/maxLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/maxLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/maxListLength-001.ttl
+++ b/shacl12-test-suite/tests/core/node/maxListLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/maxListLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/memberShape-001.ttl
+++ b/shacl12-test-suite/tests/core/node/memberShape-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/memberShape-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/minExclusive-001.ttl
+++ b/shacl12-test-suite/tests/core/node/minExclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minExclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/minInclusive-001.ttl
+++ b/shacl12-test-suite/tests/core/node/minInclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/minInclusive-002.ttl
+++ b/shacl12-test-suite/tests/core/node/minInclusive-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/minInclusive-003.ttl
+++ b/shacl12-test-suite/tests/core/node/minInclusive-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/minLength-001.ttl
+++ b/shacl12-test-suite/tests/core/node/minLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/minListLength-001.ttl
+++ b/shacl12-test-suite/tests/core/node/minListLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/minListLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/node-001.ttl
+++ b/shacl12-test-suite/tests/core/node/node-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/node-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/nodeKind-001.ttl
+++ b/shacl12-test-suite/tests/core/node/nodeKind-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/nodeKind-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/not-001.ttl
+++ b/shacl12-test-suite/tests/core/node/not-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/not-001#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/not-002.ttl
+++ b/shacl12-test-suite/tests/core/node/not-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/not-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/or-001.ttl
+++ b/shacl12-test-suite/tests/core/node/or-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/or-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/pattern-001.ttl
+++ b/shacl12-test-suite/tests/core/node/pattern-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/pattern-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/pattern-002.ttl
+++ b/shacl12-test-suite/tests/core/node/pattern-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/pattern-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/qualified-001-data.ttl
+++ b/shacl12-test-suite/tests/core/node/qualified-001-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i a ex:C1 .
 ex:j a ex:C1 , ex:C2 .

--- a/shacl12-test-suite/tests/core/node/qualified-001-shapes.ttl
+++ b/shacl12-test-suite/tests/core/node/qualified-001-shapes.ttl
@@ -1,6 +1,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s1 a sh:NodeShape ;
   sh:targetClass ex:C1 ;

--- a/shacl12-test-suite/tests/core/node/qualified-001.ttl
+++ b/shacl12-test-suite/tests/core/node/qualified-001.ttl
@@ -6,7 +6,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 <> a mf:Manifest ;
   mf:entries (

--- a/shacl12-test-suite/tests/core/node/uniqueMembers-001.ttl
+++ b/shacl12-test-suite/tests/core/node/uniqueMembers-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/uniqueMembers-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/xone-001.ttl
+++ b/shacl12-test-suite/tests/core/node/xone-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/node/xone-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/node/xone-duplicate-data.ttl
+++ b/shacl12-test-suite/tests/core/node/xone-duplicate-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i a ex:C1 .
 ex:j a ex:C1 , ex:C2 .

--- a/shacl12-test-suite/tests/core/node/xone-duplicate-shapes.ttl
+++ b/shacl12-test-suite/tests/core/node/xone-duplicate-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s1 a sh:NodeShape ;
   sh:targetClass ex:C1 ;

--- a/shacl12-test-suite/tests/core/node/xone-duplicate.ttl
+++ b/shacl12-test-suite/tests/core/node/xone-duplicate.ttl
@@ -6,7 +6,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 <> a mf:Manifest ;
   mf:entries (

--- a/shacl12-test-suite/tests/core/path/path-alternative-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-alternative-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-alternative-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-complex-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-complex-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-complex-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-complex-002-data.ttl
+++ b/shacl12-test-suite/tests/core/path/path-complex-002-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:j ex:p ex:i .
 

--- a/shacl12-test-suite/tests/core/path/path-complex-002-shapes.ttl
+++ b/shacl12-test-suite/tests/core/path/path-complex-002-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s1 a sh:PropertyShape ;
  sh:targetNode ex:i ;

--- a/shacl12-test-suite/tests/core/path/path-complex-002.ttl
+++ b/shacl12-test-suite/tests/core/path/path-complex-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-inverse-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-inverse-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-inverse-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-oneOrMore-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-oneOrMore-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-oneOrMore-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-sequence-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-sequence-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-sequence-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-sequence-002.ttl
+++ b/shacl12-test-suite/tests/core/path/path-sequence-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-sequence-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-sequence-duplicate-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-sequence-duplicate-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-sequence-duplicate-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-unused-001-data.ttl
+++ b/shacl12-test-suite/tests/core/path/path-unused-001-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i a ex:C .
 

--- a/shacl12-test-suite/tests/core/path/path-unused-001-shapes.ttl
+++ b/shacl12-test-suite/tests/core/path/path-unused-001-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 

--- a/shacl12-test-suite/tests/core/path/path-unused-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-unused-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://example.org/shacl/tests/> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-zeroOrMore-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-zeroOrMore-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-zeroOrMore-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/path/path-zeroOrOne-001.ttl
+++ b/shacl12-test-suite/tests/core/path/path-zeroOrOne-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-zeroOrOne-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/and-001.ttl
+++ b/shacl12-test-suite/tests/core/property/and-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/and-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/class-001.ttl
+++ b/shacl12-test-suite/tests/core/property/class-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/class-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/class-002.ttl
+++ b/shacl12-test-suite/tests/core/property/class-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/class-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/datatype-001.ttl
+++ b/shacl12-test-suite/tests/core/property/datatype-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/datatype-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/datatype-002.ttl
+++ b/shacl12-test-suite/tests/core/property/datatype-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/datatype-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/datatype-003.ttl
+++ b/shacl12-test-suite/tests/core/property/datatype-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/datatype-003.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/datatype-004.ttl
+++ b/shacl12-test-suite/tests/core/property/datatype-004.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/datatype-004.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/datatype-ill-formed-data.ttl
+++ b/shacl12-test-suite/tests/core/property/datatype-ill-formed-data.ttl
@@ -1,5 +1,5 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i ex:p "300"^^xsd:byte .
 ex:i ex:p "55"^^xsd:integer .

--- a/shacl12-test-suite/tests/core/property/datatype-ill-formed-shapes.ttl
+++ b/shacl12-test-suite/tests/core/property/datatype-ill-formed-shapes.ttl
@@ -1,6 +1,6 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s a sh:PropertyShape ;
   sh:targetNode ex:i ;

--- a/shacl12-test-suite/tests/core/property/datatype-ill-formed.ttl
+++ b/shacl12-test-suite/tests/core/property/datatype-ill-formed.ttl
@@ -6,7 +6,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 <> rdf:type mf:Manifest ;
    mf:entries (

--- a/shacl12-test-suite/tests/core/property/disjoint-001.ttl
+++ b/shacl12-test-suite/tests/core/property/disjoint-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/disjoint-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/equals-001.ttl
+++ b/shacl12-test-suite/tests/core/property/equals-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/equals-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/hasValue-001.ttl
+++ b/shacl12-test-suite/tests/core/property/hasValue-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/hasValue-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/in-001.ttl
+++ b/shacl12-test-suite/tests/core/property/in-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/in-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/languageIn-001.ttl
+++ b/shacl12-test-suite/tests/core/property/languageIn-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/languageIn-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/lessThan-001.ttl
+++ b/shacl12-test-suite/tests/core/property/lessThan-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/lessThan-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/lessThan-002.ttl
+++ b/shacl12-test-suite/tests/core/property/lessThan-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/lessThan-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/lessThanOrEquals-001.ttl
+++ b/shacl12-test-suite/tests/core/property/lessThanOrEquals-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/lessThanOrEquals-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/maxCount-001.ttl
+++ b/shacl12-test-suite/tests/core/property/maxCount-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxCount-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/maxCount-002.ttl
+++ b/shacl12-test-suite/tests/core/property/maxCount-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxCount-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/maxExclusive-001.ttl
+++ b/shacl12-test-suite/tests/core/property/maxExclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxExclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/maxInclusive-001.ttl
+++ b/shacl12-test-suite/tests/core/property/maxInclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxInclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/maxLength-001.ttl
+++ b/shacl12-test-suite/tests/core/property/maxLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/maxListLength-001.ttl
+++ b/shacl12-test-suite/tests/core/property/maxListLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/maxListLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/memberShape-001.ttl
+++ b/shacl12-test-suite/tests/core/property/memberShape-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/memberShape-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/minCount-001.ttl
+++ b/shacl12-test-suite/tests/core/property/minCount-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minCount-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/minCount-002.ttl
+++ b/shacl12-test-suite/tests/core/property/minCount-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minCount-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/minExclusive-001.ttl
+++ b/shacl12-test-suite/tests/core/property/minExclusive-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minExclusive-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/minExclusive-002.ttl
+++ b/shacl12-test-suite/tests/core/property/minExclusive-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minExclusive-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/minLength-001.ttl
+++ b/shacl12-test-suite/tests/core/property/minLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/minListLength-001.ttl
+++ b/shacl12-test-suite/tests/core/property/minListLength-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/minListLength-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/node-001.ttl
+++ b/shacl12-test-suite/tests/core/property/node-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/node-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/node-002.ttl
+++ b/shacl12-test-suite/tests/core/property/node-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/node-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/nodeKind-001.ttl
+++ b/shacl12-test-suite/tests/core/property/nodeKind-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/nodeKind-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/not-001.ttl
+++ b/shacl12-test-suite/tests/core/property/not-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/not-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/or-001.ttl
+++ b/shacl12-test-suite/tests/core/property/or-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/or-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/or-datatypes-001.ttl
+++ b/shacl12-test-suite/tests/core/property/or-datatypes-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/or-datatypes-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/pattern-001.ttl
+++ b/shacl12-test-suite/tests/core/property/pattern-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/pattern-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/pattern-002.ttl
+++ b/shacl12-test-suite/tests/core/property/pattern-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/pattern-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/property-001.ttl
+++ b/shacl12-test-suite/tests/core/property/property-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/property-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/qualifiedMinCountDisjoint-001.ttl
+++ b/shacl12-test-suite/tests/core/property/qualifiedMinCountDisjoint-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/qualifiedMinCountDisjoint-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/qualifiedValueShape-001.ttl
+++ b/shacl12-test-suite/tests/core/property/qualifiedValueShape-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/qualifiedValueShape-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/qualifiedValueShapesDisjoint-001.ttl
+++ b/shacl12-test-suite/tests/core/property/qualifiedValueShapesDisjoint-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/qualifiedValueShapesDisjoint-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/singleLine-001.ttl
+++ b/shacl12-test-suite/tests/core/property/singleLine-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/singleLine-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/uniqueLang-001.ttl
+++ b/shacl12-test-suite/tests/core/property/uniqueLang-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/uniqueLang-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/uniqueLang-002-data.ttl
+++ b/shacl12-test-suite/tests/core/property/uniqueLang-002-data.ttl
@@ -1,3 +1,3 @@
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:i ex:message "HI"@en, "Hi"@en .

--- a/shacl12-test-suite/tests/core/property/uniqueLang-002-shapes.ttl
+++ b/shacl12-test-suite/tests/core/property/uniqueLang-002-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:s1 a sh:PropertyShape ;

--- a/shacl12-test-suite/tests/core/property/uniqueLang-002.ttl
+++ b/shacl12-test-suite/tests/core/property/uniqueLang-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/path/path-complex-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/property/uniqueMembers-001.ttl
+++ b/shacl12-test-suite/tests/core/property/uniqueMembers-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/property/uniqueMembers-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/multipleTargets-001.ttl
+++ b/shacl12-test-suite/tests/core/targets/multipleTargets-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/multipleTargets-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/targetClass-001.ttl
+++ b/shacl12-test-suite/tests/core/targets/targetClass-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetClass-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/targetClassImplicit-001.ttl
+++ b/shacl12-test-suite/tests/core/targets/targetClassImplicit-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetClassImplicit-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/targetClassImplicit-002.ttl
+++ b/shacl12-test-suite/tests/core/targets/targetClassImplicit-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetClassImplicit-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/targetNode-001.ttl
+++ b/shacl12-test-suite/tests/core/targets/targetNode-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetNode-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/targetObjectsOf-001.ttl
+++ b/shacl12-test-suite/tests/core/targets/targetObjectsOf-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetObjectsOf-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/targetSubjectsOf-001.ttl
+++ b/shacl12-test-suite/tests/core/targets/targetSubjectsOf-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/targets/targetSubjectsOf-002.ttl
+++ b/shacl12-test-suite/tests/core/targets/targetSubjectsOf-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/core/validation-reports/shared-data.ttl
+++ b/shacl12-test-suite/tests/core/validation-reports/shared-data.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 ex:i ex:p ex:j .
 ex:i ex:q ex:j .
 ex:j ex:r ex:k .

--- a/shacl12-test-suite/tests/core/validation-reports/shared-shapes.ttl
+++ b/shacl12-test-suite/tests/core/validation-reports/shared-shapes.ttl
@@ -1,5 +1,5 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 ex:s1 a sh:NodeShape ;
   sh:targetNode ex:i ;

--- a/shacl12-test-suite/tests/core/validation-reports/shared.ttl
+++ b/shacl12-test-suite/tests/core/validation-reports/shared.ttl
@@ -6,7 +6,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix ex: <http://example.org/shacl-test/> .
+@prefix ex: <http://example.com/ns#> .
 
 # This test case is under discussion, as there are different interpretations
 # on whether the nested sh:property constraint that is reached twice should

--- a/shacl12-test-suite/tests/sparql/component/nodeValidator-001.ttl
+++ b/shacl12-test-suite/tests/sparql/component/nodeValidator-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/component/nodeValidator-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -8,7 +8,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://datashapes.org/sh/tests/sparql/component/nodeValidator-001.test>
+<http://example.com/ns#>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
       sh:namespace "http://datashapes.org/sh/tests/sparql/component/nodeValidator-001.test#"^^xsd:anyURI ;
@@ -30,7 +30,7 @@ ex:TestConstraintComponent
         FILTER NOT EXISTS {
             $this ex:property ?requiredParam .
       }}""" ;
-      sh:prefixes <http://datashapes.org/sh/tests/sparql/component/nodeValidator-001.test> ;
+      sh:prefixes <http://example.com/ns#> ;
     ] ;
   sh:parameter [
       sh:path ex:optionalParam ;

--- a/shacl12-test-suite/tests/sparql/component/optional-001.ttl
+++ b/shacl12-test-suite/tests/sparql/component/optional-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/component/optional-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -8,7 +8,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://datashapes.org/sh/tests/sparql/component/optional-001.test>
+<http://example.com/ns#>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
       sh:namespace "http://datashapes.org/sh/tests/sparql/component/optional-001.test#"^^xsd:anyURI ;
@@ -40,7 +40,7 @@ ex:TestConstraintComponent
       sh:ask """ASK {
     FILTER ($value != $requiredParam && $value != COALESCE(?optionalParam, \"Three\")) .
 }""" ;
-      sh:prefixes <http://datashapes.org/sh/tests/sparql/component/optional-001.test> ;
+      sh:prefixes <http://example.com/ns#> ;
     ] ;
 .
 ex:TestShape1

--- a/shacl12-test-suite/tests/sparql/component/propertyValidator-select-001.ttl
+++ b/shacl12-test-suite/tests/sparql/component/propertyValidator-select-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/component/propertyValidator-select-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -32,7 +32,7 @@ ex:LanguageConstraintComponentUsingSELECT
   sh:propertyValidator [
       rdf:type sh:SPARQLSelectValidator ;
       sh:message "Values are literals with language \"{?lang}\"" ;
-      sh:prefixes <http://datashapes.org/sh/tests/sparql/component/LanguageConstraintComponentUsingSELECT.test> ;
+      sh:prefixes <http://example.com/ns#> ;
       sh:select """
 			SELECT DISTINCT $this ?value
 			WHERE {

--- a/shacl12-test-suite/tests/sparql/component/validator-001.ttl
+++ b/shacl12-test-suite/tests/sparql/component/validator-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/component/validator-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -8,7 +8,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://datashapes.org/sh/tests/sparql/component/validator-001.test>
+<http://example.com/ns#>
   owl:imports <http://datashapes.org/dash> ;
 .
 ex:ConstraintComponent

--- a/shacl12-test-suite/tests/sparql/node/prefixes-001.ttl
+++ b/shacl12-test-suite/tests/sparql/node/prefixes-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/node/prefixes-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -8,7 +8,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://datashapes.org/sh/tests/sparql/node/prefixes-001.test>
+<http://example.com/ns#>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
       sh:namespace "http://datashapes.org/sh/tests/sparql/node/prefixes-001.test#"^^xsd:anyURI ;
@@ -19,7 +19,7 @@ ex:InvalidResource1
   ex:property <http://test.com/ns#Value> ;
 .
 ex:TestPrefixes
-  owl:imports <http://datashapes.org/sh/tests/sparql/node/prefixes-001.test> ;
+  owl:imports <http://example.com/ns#> ;
   sh:declare [
       sh:namespace "http://test.com/ns#"^^xsd:anyURI ;
       sh:prefix "test" ;

--- a/shacl12-test-suite/tests/sparql/node/sparql-001.ttl
+++ b/shacl12-test-suite/tests/sparql/node/sparql-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/node/sparql-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -27,7 +27,7 @@ ex:TestShape
 .
 ex:TestShape-sparql
   sh:message "Cannot have a label" ;
-  sh:prefixes <http://datashapes.org/sh/tests/sparql/node/sparql-001.test> ;
+  sh:prefixes <http://example.com/ns#> ;
   sh:select """
   	SELECT $this ?path ?value
 	WHERE {

--- a/shacl12-test-suite/tests/sparql/node/sparql-002.ttl
+++ b/shacl12-test-suite/tests/sparql/node/sparql-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/node/sparql-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -8,7 +8,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://datashapes.org/sh/tests/sparql/node/sparql-002.test>
+<http://example.com/ns#>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
       sh:namespace "http://datashapes.org/sh/tests/sparql/node/sparql-002.test#"^^xsd:anyURI ;
@@ -23,7 +23,7 @@ ex:LanguageExampleShape
   rdf:type sh:NodeShape ;
   rdf:type sh:SPARQLConstraint ;
   sh:message "Values are literals with German language tag." ;
-  sh:prefixes <http://datashapes.org/sh/tests/sparql/node/sparql-002.test> ;
+  sh:prefixes <http://example.com/ns#> ;
   sh:select """
 			SELECT $this (ex:germanLabel AS ?path) ?value
 			WHERE {

--- a/shacl12-test-suite/tests/sparql/node/sparql-003.ttl
+++ b/shacl12-test-suite/tests/sparql/node/sparql-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/node/sparql-003.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -8,7 +8,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://datashapes.org/sh/tests/sparql/node/sparql-003.test>
+<http://example.com/ns#>
   sh:declare [
       rdf:type sh:PrefixDeclaration ;
       sh:namespace "http://datashapes.org/sh/tests/sparql/node/sparql-003.test#"^^xsd:anyURI ;
@@ -23,7 +23,7 @@ ex:LanguageExampleShape
   rdf:type sh:NodeShape ;
   rdf:type sh:SPARQLConstraint ;
   sh:message "Values are literals with German language tag." ;
-  sh:prefixes <http://datashapes.org/sh/tests/sparql/node/sparql-003.test> ;
+  sh:prefixes <http://example.com/ns#> ;
   sh:select """
 			SELECT $this (ex:germanLabel AS ?path)
 			WHERE {

--- a/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-001.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-002.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-002.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-003.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-003.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-003.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-004.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-004.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-004.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-005.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-005.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-005.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-006.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-006.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-006.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-007.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/pre-binding-007.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-007.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-001.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-001.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-002.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-002.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-002.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-003.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-003.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-003.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-004.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-004.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-004.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-005.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-005.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-005.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-006.ttl
+++ b/shacl12-test-suite/tests/sparql/pre-binding/unsupported-sparql-006.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-006.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/property/property-select-001.ttl
+++ b/shacl12-test-suite/tests/sparql/property/property-select-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://example.org/ns#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/property/property-sparqlExpr-001.ttl
+++ b/shacl12-test-suite/tests/sparql/property/property-sparqlExpr-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://example.org/ns#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/property/sparql-001.ttl
+++ b/shacl12-test-suite/tests/sparql/property/sparql-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://datashapes.org/sh/tests/sparql/property/sparql-001.test#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/shacl12-test-suite/tests/sparql/targets/targetNode-select-001.ttl
+++ b/shacl12-test-suite/tests/sparql/targets/targetNode-select-001.ttl
@@ -1,5 +1,5 @@
 @prefix dash: <http://datashapes.org/dash#> .
-@prefix ex: <http://example.org/ns#> .
+@prefix ex: <http://example.com/ns#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -14,7 +14,7 @@ ex:ChildShape
 	rdfs:comment "This shape applies to all persons under 18 years of age." ;
 	sh:targetNode [
 		sh:select """
-			PREFIX ex: <http://example.org/ns#>
+			PREFIX ex: <http://example.com/ns#>
 			SELECT ?person
 			WHERE {
 				?person a/rdfs:subClassOf* ex:Person .


### PR DESCRIPTION
Replacement for #390: Use `http://example.com/ns#` for `ex:` everywhere but without changing line endings.

Closes #276

Closes #362