### PR TITLE
Rearranged node expression (meta) classes and added the current funct…

### DIFF
--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1011,26 +1011,6 @@ sh:node
 	rdfs:isDefinedBy sh: .
 
 
-sh:NodeByExpressionConstraintComponent
-	a sh:ConstraintComponent ;
-	rdfs:label "Node by expression constraint component"@en ;
-	rdfs:comment "A constraint component that can be used to verify that all value nodes conform to the node shape(s) produced by the given node expression."@en ;
-	sh:parameter sh:NodeByExpressionConstraintComponent-nodeByExpression ;
-	rdfs:isDefinedBy sh: .
-
-sh:NodeByExpressionConstraintComponent-nodeByExpression
-	a sh:Parameter ;
-	sh:path sh:nodeByExpression ;
-	rdfs:isDefinedBy sh: .
-
-sh:nodeByExpression
-	a rdf:Property ;
-	rdfs:label "node by expression"@en ;
-	rdfs:comment "Links a shape to node expressions, indicating the node shape(s) that all value nodes must conform to."@en ;
-	# rdfs:range sh:NodeShape ; (node expression)
-	rdfs:isDefinedBy sh: .
-
-
 sh:NodeKindConstraintComponent
 	a sh:ConstraintComponent ;
 	rdfs:label "Node-kind constraint component"@en ;
@@ -1335,18 +1315,18 @@ sh:xone
 
 # Node Expressions ------------------------------------------------------------
 
-sh:NodeExpression
+sh:NodeExpressionFunction
 	a rdfs:Class ;
-	rdfs:label "Node expression"@en ;
-	rdfs:comment "The base class of node expression functions."@en ;
-	rdfs:subClassOf rdfs:Resource ;
+	rdfs:label "Node expression function"@en ;
+	rdfs:comment "The base (meta) class of node expression functions."@en ;
+	rdfs:subClassOf rdfs:Class ;
 	rdfs:isDefinedBy sh: .
 
-sh:NamedParameterExpression
+sh:NamedParameterExpressionFunction
 	a rdfs:Class ;
-	rdfs:label "Named parameter expression"@en ;
+	rdfs:label "Named parameter expression function"@en ;
 	rdfs:comment "The base class of node expression functions that take named parameters."@en ;
-	rdfs:subClassOf sh:NodeExpression ;
+	rdfs:subClassOf sh:NodeExpressionFunction ;
 	rdfs:subClassOf sh:Parameterizable ;
 	rdfs:isDefinedBy sh: .
 
@@ -1354,13 +1334,35 @@ sh:keyParameter
     a rdf:Property ;
 	rdfs:label "key parameter"@en ;
 	rdfs:comment "Set to true for the parameter of a named parameter expression function that uniquely identifies it."@en ;
+	rdfs:domain sh:Parameter ;
 	rdfs:range xsd:boolean ;
+	rdfs:isDefinedBy sh: .
+
+sh:ListParameterExpressionFunction
+	a rdfs:Class ;
+	rdfs:label "List parameter expression function"@en ;
+	rdfs:comment "The base class of node expression functions that take a list of parameters."@en ;
+	rdfs:subClassOf sh:NodeExpressionFunction ;
+	rdfs:isDefinedBy sh: .
+
+sh:NodeExpression
+	a rdfs:Class ;
+	rdfs:label "Node expression"@en ;
+	rdfs:comment "The base class of node expression (instances)."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:NamedParameterExpression
+	a rdfs:Class ;
+	rdfs:label "Named parameter expression"@en ;
+	rdfs:comment "The base class of node expressions (instances) that take named parameters."@en ;
+	rdfs:subClassOf sh:NodeExpression ;
 	rdfs:isDefinedBy sh: .
 
 sh:ListParameterExpression
 	a rdfs:Class ;
 	rdfs:label "List parameter expression"@en ;
-	rdfs:comment "The base class of node expression functions that take a list of parameters."@en ;
+	rdfs:comment "The base class of node expressions (instances) that take a list of parameters."@en ;
 	rdfs:subClassOf sh:NodeExpression ;
 	rdfs:isDefinedBy sh: .
 
@@ -1505,7 +1507,7 @@ sh:SPARQLConstraint
 # SPARQL-based Node Expressions -----------------------------------------------
 
 sh:SelectExpression
-	a rdfs:Class ;
+	a sh:NamedParameterExpressionFunction ;
 	rdfs:label "Select expression"@en ;
 	rdfs:comment "The class of node expressions based on SPARQL SELECT queries."@en ;
 	rdfs:subClassOf sh:NamedParameterExpression ;
@@ -1532,7 +1534,7 @@ sh:SelectExpression-prefixes
 	rdfs:isDefinedBy sh: .
 
 sh:SPARQLExprExpression
-	a rdfs:Class ;
+	a sh:NamedParameterExpressionFunction ;
 	rdfs:label "SPARQL expr expression"@en ;
 	rdfs:comment "The class of node expressions based on SPARQL expressions (sh:sparqlExpr)."@en ;
 	rdfs:subClassOf sh:NamedParameterExpression ;
@@ -1564,6 +1566,88 @@ sh:sparqlExpr
 	rdfs:comment "The SPARQL expression that is executed during evaluation of a node expression."@en ;
 	rdfs:domain sh:SPARQLExprExpression ;
 	rdfs:range xsd:string ;
+	rdfs:isDefinedBy sh: .
+
+
+# SPARQL-based Result Annotations ---------------------------------------------
+
+sh:resultAnnotation
+	a rdf:Property ;
+	rdfs:label "result annotation"@en ;
+	rdfs:comment "Links a SPARQL validator with zero or more sh:ResultAnnotation instances, defining how to derive additional result properties based on the variables of the SELECT query."@en ;
+	rdfs:domain sh:SPARQLSelectValidator ;
+	rdfs:range sh:ResultAnnotation ;
+	rdfs:isDefinedBy sh: .
+
+sh:ResultAnnotation
+	a rdfs:Class ;
+	rdfs:label "Result annotation"@en ;
+	rdfs:comment "A class of result annotations, which define the rules to derive the values of a given annotation property as extra values for a validation result."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:annotationProperty
+	a rdf:Property ;
+	rdfs:label "annotation property"@en ;
+	rdfs:comment "The annotation property that shall be set."@en ;
+	rdfs:domain sh:ResultAnnotation ;
+	rdfs:range rdf:Property ;
+	rdfs:isDefinedBy sh: .
+
+sh:annotationValue
+	a rdf:Property ;
+	rdfs:label "annotation value"@en ;
+	rdfs:comment "The (default) values of the annotation property."@en ;
+	rdfs:domain sh:ResultAnnotation ;
+	rdfs:isDefinedBy sh: .
+
+sh:annotationVarName
+	a rdf:Property ;
+	rdfs:label "annotation variable name"@en ;
+	rdfs:comment "The name of the SPARQL variable from the SELECT clause that shall be used for the values."@en ;
+	rdfs:domain sh:ResultAnnotation ;
+	rdfs:range xsd:string ;
+	rdfs:isDefinedBy sh: .
+
+
+# Constraints based on Node Expressions ---------------------------------------
+
+sh:ExpressionConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Expression constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to verify that a given node expression produces true for all value nodes."@en ;
+	sh:parameter sh:ExpressionConstraintComponent-expression ;
+	rdfs:isDefinedBy sh: .
+
+sh:ExpressionConstraintComponent-expression
+	a sh:Parameter ;
+	sh:path sh:expression ;
+	rdfs:isDefinedBy sh: .
+
+sh:expression
+	a rdf:Property ;
+	rdfs:label "expression"@en ;
+	rdfs:comment "The node expression that must return true for the value nodes."@en ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:NodeByExpressionConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Node by expression constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to verify that all value nodes conform to the node shape(s) produced by the given node expression."@en ;
+	sh:parameter sh:NodeByExpressionConstraintComponent-nodeByExpression ;
+	rdfs:isDefinedBy sh: .
+
+sh:NodeByExpressionConstraintComponent-nodeByExpression
+	a sh:Parameter ;
+	sh:path sh:nodeByExpression ;
+	rdfs:isDefinedBy sh: .
+
+sh:nodeByExpression
+	a rdf:Property ;
+	rdfs:label "node by expression"@en ;
+	rdfs:comment "Links a shape to node expressions, indicating the node shape(s) that all value nodes must conform to."@en ;
+	# rdfs:range sh:NodeShape ; (node expression)
 	rdfs:isDefinedBy sh: .
 
 
@@ -1616,7 +1700,7 @@ sh:PropertyGroup
 
 
 # -----------------------------------------------------------------------------
-# SHACL ADVANCED FEATURES -----------------------------------------------------
+# SHACL ADVANCED FEATURES (will likely be marked deprecated with 1.2)
 # -----------------------------------------------------------------------------
 	
 
@@ -1690,47 +1774,6 @@ sh:SPARQLFunction
 	rdfs:subClassOf sh:SPARQLSelectExecutable ;
 	rdfs:isDefinedBy sh: .
 
-
-# Result Annotations ----------------------------------------------------------
-
-sh:resultAnnotation
-	a rdf:Property ;
-	rdfs:label "result annotation"@en ;
-	rdfs:comment "Links a SPARQL validator with zero or more sh:ResultAnnotation instances, defining how to derive additional result properties based on the variables of the SELECT query."@en ;
-	rdfs:domain sh:SPARQLSelectValidator ;
-	rdfs:range sh:ResultAnnotation ;
-	rdfs:isDefinedBy sh: .
-
-sh:ResultAnnotation
-	a rdfs:Class ;
-	rdfs:label "Result annotation"@en ;
-	rdfs:comment "A class of result annotations, which define the rules to derive the values of a given annotation property as extra values for a validation result."@en ;
-	rdfs:subClassOf rdfs:Resource ;
-	rdfs:isDefinedBy sh: .
-
-sh:annotationProperty
-	a rdf:Property ;
-	rdfs:label "annotation property"@en ;
-	rdfs:comment "The annotation property that shall be set."@en ;
-	rdfs:domain sh:ResultAnnotation ;
-	rdfs:range rdf:Property ;
-	rdfs:isDefinedBy sh: .
-
-sh:annotationValue
-	a rdf:Property ;
-	rdfs:label "annotation value"@en ;
-	rdfs:comment "The (default) values of the annotation property."@en ;
-	rdfs:domain sh:ResultAnnotation ;
-	rdfs:isDefinedBy sh: .
-
-sh:annotationVarName
-	a rdf:Property ;
-	rdfs:label "annotation variable name"@en ;
-	rdfs:comment "The name of the SPARQL variable from the SELECT clause that shall be used for the values."@en ;
-	rdfs:domain sh:ResultAnnotation ;
-	rdfs:range xsd:string ;
-	rdfs:isDefinedBy sh: .
-
 	
 # Node Expressions ------------------------------------------------------------
 
@@ -1748,27 +1791,6 @@ sh:intersection
 
 sh:union
 	rdfs:comment "Deprecated with SHACL 1.2: replaced by shnex:union."@en .
-
-
-# Expression Constraints ------------------------------------------------------
-
-sh:ExpressionConstraintComponent
-	a sh:ConstraintComponent ;
-	rdfs:label "Expression constraint component"@en ;
-	rdfs:comment "A constraint component that can be used to verify that a given node expression produces true for all value nodes."@en ;
-	sh:parameter sh:ExpressionConstraintComponent-expression ;
-	rdfs:isDefinedBy sh: .
-
-sh:ExpressionConstraintComponent-expression
-	a sh:Parameter ;
-	sh:path sh:expression ;
-	rdfs:isDefinedBy sh: .
-
-sh:expression
-	a rdf:Property ;
-	rdfs:label "expression"@en ;
-	rdfs:comment "The node expression that must return true for the value nodes."@en ;
-	rdfs:isDefinedBy sh: .
 
 
 # Rules -----------------------------------------------------------------------

--- a/shacl12-vocabularies/shnex.ttl
+++ b/shacl12-vocabularies/shnex.ttl
@@ -25,29 +25,511 @@ shnex:
 	owl:imports <http://www.w3.org/ns/shacl#> .
 
 
-# THIS IS COMPLETELY UNFINISHED
-
-shnex:filterShape
-	a rdf:Property ;
-	rdfs:label "filter shape"@en ;
-	rdfs:comment "The shape that all input nodes of the expression need to conform to."@en ;
-	rdfs:range sh:Shape ;
-	rdfs:isDefinedBy shnex: .
-
 shnex:nodes
 	a rdf:Property ;
 	rdfs:label "nodes"@en ;
-	rdfs:comment "The node expression producing the input nodes of a filter shape expression."@en ;
-	rdfs:isDefinedBy shnex: .
+	rdfs:comment "Used by various node expression functions to produce input nodes."@en ;
+	rdfs:isDefinedBy shnex: ;
+.
 
+
+# Count Expressions -----------------------------------------------------------
+
+shnex:CountExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "Count expression"@en ;
+	rdfs:comment "A SHACL node expression that returns the number of nodes returned by a given node expression (sh:count)."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:CountExpression-count ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:CountExpression-count
+	a sh:Parameter ;
+	sh:path shnex:count ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:count
+	a rdf:Property ;
+	rdfs:label "count"@en ;
+	rdfs:comment "In Count Expressions, this property specifies the node expression of which the results shall be counted."@en ;
+	rdfs:domain shnex:CountExpression ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# Distinct Expressions --------------------------------------------------------
+
+shnex:DistinctExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "Distinct expression"@en ;
+	rdfs:comment "A SHACL node expression that can be used to returns only the distinct members of the results of another node expression."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:DistinctExpression-distinct ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:DistinctExpression-distinct
+	a sh:Parameter ;
+	sh:path shnex:distinct ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:distinct
+	a rdf:Property ;
+	rdfs:label "distinct"@en ;
+	rdfs:comment "In Distinct Expressions, this property specifies the node expression that shall be evaluated."@en ;
+	rdfs:domain shnex:DistinctExpression ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# Exists Expressions ----------------------------------------------------------
+
+shnex:ExistsExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "Exists expression"@en ;
+	rdfs:comment "A SHACL node expression that can be used to check that a given node expression returns at least one node."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:ExistsExpression-exists ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:ExistsExpression-exists
+	a sh:Parameter ;
+	sh:path shnex:exists ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:exists
+	a rdf:Property ;
+	rdfs:label "exists"@en ;
+	rdfs:comment "In Exists Expressions, this property specifies the node expression that shall be evaluated."@en ;
+	rdfs:domain shnex:ExistsExpression ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# FilterShape Expressions -----------------------------------------------------
+
+shnex:FilterShapeExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "FilterShape expression"@en ;
+	rdfs:comment "A SHACL node expression that returns the values of a given node expression (sh:nodes) except for those that do not conform to a given filter shape."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:FilterShapeExpression-filterShape ;
+	sh:parameter shnex:FilterShapeExpression-nodes ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:FilterShapeExpression-filterShape
+	a sh:Parameter ;
+	sh:path shnex:filterShape ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:FilterShapeExpression-nodes
+	a sh:Parameter ;
+	sh:path shnex:nodes ;
+	sh:name "nodes"@en ;
+	sh:description "A node expression that produces the input nodes."@en ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:filterShape
+	a rdf:Property ;
+	rdfs:label "filter shape"@en ;
+	rdfs:comment "In FilterShape Expressions, this property specifies the shape that the input values (sh:nodes) must conform to."@en ;
+	rdfs:domain shnex:FilterShapeExpression ;
+	rdfs:range sh:Shape ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# If Expressions --------------------------------------------------------------
+
+shnex:IfExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "If expression"@en ;
+	rdfs:comment "A SHACL node expression that evaluates a condition (sh:if) and then either returns the results of the sh:then or sh:else expression."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:IfExpression-if ;
+	sh:parameter shnex:IfExpression-then ;
+	sh:parameter shnex:IfExpression-else ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:IfExpression-if
+	a sh:Parameter ;
+	sh:path shnex:if ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:IfExpression-then
+	a sh:Parameter ;
+	sh:path shnex:then ;
+	sh:optional true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:IfExpression-else
+	a sh:Parameter ;
+	sh:path shnex:else ;
+	sh:optional true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:if
+	a rdf:Property ;
+	rdfs:label "if"@en ;
+	rdfs:comment "In If Expressions, this property specifies the node expression that must return true to reach the sh:then branch."@en ;
+	rdfs:domain shnex:IfExpression ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:then
+	a rdf:Property ;
+	rdfs:label "then"@en ;
+	rdfs:comment "In If Expressions, this property specifies the node expression that is evaluated when the sh:if has returned true."@en ;
+	rdfs:domain shnex:IfExpression ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:else
+	a rdf:Property ;
+	rdfs:label "else"@en ;
+	rdfs:comment "In If Expressions, this property specifies the node expression that is evaluated when the sh:if has not returned true (as its only value)."@en ;
+	rdfs:domain shnex:IfExpression ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# InstancesOf Expressions -----------------------------------------------------
+
+shnex:InstancesOfExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "InstancesOf expression"@en ;
+	rdfs:comment "A SHACL node expression that returns the instances of a given class (and its transitive subclasses)."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:InstancesOfExpression-instancesOf ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:InstancesOfExpression-instancesOf
+	a sh:Parameter ;
+	sh:path shnex:instancesOf ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:instancesOf
+	a rdf:Property ;
+	rdfs:label "instances of"@en ;
+	rdfs:comment "In InstancesOf Expressions, this property specifies the class of which the instances shall be returned."@en ;
+	rdfs:domain shnex:InstancesOfExpression ;
+	rdfs:range rdfs:Class ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# Intersection Expressions ----------------------------------------------------
+
+shnex:IntersectionExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "Intersection expression"@en ;
+	rdfs:comment "A SHACL node expression that can be used to returns the nodes that are found in the results of all the listed node expression."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:IntersectionExpression-intersection ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:IntersectionExpression-intersection
+	a sh:Parameter ;
+	sh:path shnex:intersection ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
 shnex:intersection
 	a rdf:Property ;
 	rdfs:label "intersection"@en ;
-	rdfs:comment "A list of node expressions that shall be intersected."@en ;
-	rdfs:isDefinedBy shnex: .
+	rdfs:comment "In Intersection Expressions, this property specifies the list of node expressions that shall be intersected."@en ;
+	rdfs:domain shnex:IntersectionExpression ;
+	rdfs:range rdf:List ;
+	rdfs:isDefinedBy shnex: ;
+.
 
+
+# Limit Expressions -----------------------------------------------------------
+
+shnex:LimitExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "Limit expression"@en ;
+	rdfs:comment "A SHACL node expression that returns the first X values of a given node expression (sh:nodes), where X is specified using sh:limit."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:LimitExpression-limit ;
+	sh:parameter shnex:LimitExpression-nodes ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:LimitExpression-limit
+	a sh:Parameter ;
+	sh:path shnex:limit ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:LimitExpression-nodes
+	a sh:Parameter ;
+	sh:path shnex:nodes ;
+	sh:name "nodes"@en ;
+	sh:description "A node expression that produces the input nodes."@en ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:limit
+	a rdf:Property ;
+	rdfs:label "limit"@en ;
+	rdfs:comment "In Limit Expressions, this property specifies the maximum number of nodes (sh:nodes) that shall be returned."@en ;
+	rdfs:domain shnex:LimitExpression ;
+	rdfs:range xsd:integer ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# List Expressions ------------------------------------------------------------
+
+shnex:ListExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "List expression"@en ;
+	rdfs:comment "A SHACL node expression describing an RDF list, represented by a blank node with rdf:first and rdf:rest triples."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:ListExpression-first ;
+	sh:parameter shnex:ListExpression-rest ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:ListExpression-first
+	a sh:Parameter ;
+	sh:path rdf:first ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:ListExpression-rest
+	a sh:Parameter ;
+	sh:path rdf:rest ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# Max Expressions -------------------------------------------------------------
+
+shnex:MaxExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "Max expression"@en ;
+	rdfs:comment "A SHACL node expression that returns the largest of the nodes returned by a given node expression (sh:max)."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:MaxExpression-max ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:MaxExpression-max
+	a sh:Parameter ;
+	sh:path shnex:max ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:max
+	a rdf:Property ;
+	rdfs:label "max"@en ;
+	rdfs:comment "In Max Expressions, this property specifies the node expression of which the maximum shall be returned."@en ;
+	rdfs:domain shnex:MaxExpression ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# Min Expressions -------------------------------------------------------------
+
+shnex:MinExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "Min expression"@en ;
+	rdfs:comment "A SHACL node expression that returns the smallest of the nodes returned by a given node expression (sh:min)."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:MinExpression-min ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:MinExpression-min
+	a sh:Parameter ;
+	sh:path shnex:min ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:min
+	a rdf:Property ;
+	rdfs:label "min"@en ;
+	rdfs:comment "In Min Expressions, this property specifies the node expression of which the minimum shall be returned."@en ;
+	rdfs:domain shnex:MinExpression ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# Minus Expressions -----------------------------------------------------------
+
+shnex:MinusExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "Minus expression"@en ;
+	rdfs:comment "A SHACL node expression that returns the values of a given node expression (sh:nodes) except for those returned by another node expression (sh:minus)."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:MinusExpression-minus ;
+	sh:parameter shnex:MinusExpression-nodes ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:MinusExpression-minus
+	a sh:Parameter ;
+	sh:path shnex:minus ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:MinusExpression-nodes
+	a sh:Parameter ;
+	sh:path shnex:nodes ;
+	sh:name "nodes"@en ;
+	sh:description "A node expression that produces the input nodes."@en ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:minus
+	a rdf:Property ;
+	rdfs:label "minus"@en ;
+	rdfs:comment "In Minus Expressions, this property specifies the node expression that produces the values that shall be removed from the input nodes (sh:nodes)."@en ;
+	rdfs:domain shnex:MinusExpression ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# Offset Expressions ----------------------------------------------------------
+
+shnex:OffsetExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "Offset expression"@en ;
+	rdfs:comment "A SHACL node expression that skips the first X values of a given node expression (sh:nodes), where X is specified using sh:offset."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:OffsetExpression-offset ;
+	sh:parameter shnex:OffsetExpression-nodes ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:OffsetExpression-offset
+	a sh:Parameter ;
+	sh:path shnex:offset ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:OffsetExpression-nodes
+	a sh:Parameter ;
+	sh:path shnex:nodes ;
+	sh:name "nodes"@en ;
+	sh:description "A node expression that produces the input nodes."@en ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:offset
+	a rdf:Property ;
+	rdfs:label "offset"@en ;
+	rdfs:comment "In Offset Expressions, this property specifies the number of nodes (sh:nodes) that shall be skipped."@en ;
+	rdfs:domain shnex:OffsetExpression ;
+	rdfs:range xsd:integer ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# Path Expressions ------------------------------------------------------------
+
+shnex:PathExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "Path expression"@en ;
+	rdfs:comment "A SHACL node expression that returns the values of a given property path at the focus node, or a list of provided focus nodes."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:PathExpression-path ;
+	sh:parameter shnex:PathExpression-nodes ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:PathExpression-path
+	a sh:Parameter ;
+	sh:path shnex:path ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:PathExpression-nodes
+	a sh:Parameter ;
+	sh:path shnex:nodes ;
+	sh:name "focus nodes"@en ;
+	sh:description "An optional node expression that produces the focus node(s)."@en ;
+	sh:optional true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:path
+	a rdf:Property ;
+	rdfs:label "path"@en ;
+	rdfs:comment "In Path Expressions, this property specifies the property path."@en ;
+	rdfs:domain shnex:PathExpression ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# Sum Expressions -------------------------------------------------------------
+
+shnex:SumExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "Sum expression"@en ;
+	rdfs:comment "A SHACL node expression that returns the sum of the nodes returned by a given node expression (sh:sum)."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:SumExpression-sum ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:SumExpression-sum
+	a sh:Parameter ;
+	sh:path shnex:sum ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:sum
+	a rdf:Property ;
+	rdfs:label "sum"@en ;
+	rdfs:comment "In Sum Expressions, this property specifies the node expression of which the sum shall be returned."@en ;
+	rdfs:domain shnex:SumExpression ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# Union Expressions -----------------------------------------------------------
+
+shnex:UnionExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "Union expression"@en ;
+	rdfs:comment "A SHACL node expression that can be used to returns the nodes that are found in either of the results of the listed node expression."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:UnionExpression-union ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:UnionExpression-union
+	a sh:Parameter ;
+	sh:path shnex:union ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
 shnex:union
 	a rdf:Property ;
 	rdfs:label "union"@en ;
-	rdfs:comment "A list of node expressions that shall be used together."@en ;
-	rdfs:isDefinedBy shnex: .
+	rdfs:comment "In Union Expressions, this property specifies the list of node expressions that shall be unioned."@en ;
+	rdfs:domain shnex:UnionExpression ;
+	rdfs:range rdf:List ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# Var Expressions -------------------------------------------------------------
+
+shnex:VarExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "Var expression"@en ;
+	rdfs:comment "A SHACL node expression that can be used to get the value of a variable such as 'focusNode'."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:VarExpression-var ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:VarExpression-var
+	a sh:Parameter ;
+	sh:path shnex:var ;
+	sh:datatype xsd:string ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:var
+	a rdf:Property ;
+	rdfs:label "var"@en ;
+	rdfs:comment "In Var Expressions, this property specifies the name of the variable to get."@en ;
+	rdfs:isDefinedBy shnex: ;
+	rdfs:domain shnex:VarExpression ;
+	rdfs:range xsd:string ;
+.


### PR DESCRIPTION
…ions to shnex.ttl

sh:Expression/NodeByExpression and annotations were just moved around within the document

This is quite geeky stuff due to the meta-levels: 

- The metaclasses such as sh:NamedParameterExpressionFunction
- The actual node expression functions are then instances of sh:NamedParameterExpression, these declare the parameters such as sh:filterName and sh:nodes
- The instances of those are the blank nodes (with values for sh:filterShape), although their rdf:type is usually never asserted

I hope I got these metalevels correct, so please double check anyone :)

Closes #504

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-504/shacl12-node-expr/index.html)
