### PR TITLE
Common spec elements

### DIFF
--- a/shacl12-common/local-biblio.js
+++ b/shacl12-common/local-biblio.js
@@ -1,0 +1,109 @@
+var localBibliography = {
+  ISO24707: {
+    id: "ISO24707",
+    title: "Information technology — Common Logic (CL) — A framework for a family of logic-based languages",
+    date: "2018-07",
+    href: "https://www.iso.org/standard/66249.html",
+    status: "Published",
+    publisher: "ISO/EIC"
+  },
+  HORST04: {
+    id: "HORST04",
+    title: "Extending the RDFS Entailment Lemma",
+    authors: ["Herman J. ter Horst"],
+    date: "2004",
+    isbn: "978-3-540-30475-3",
+    href: "https://doi.org/10.1007/978-3-540-30475-3_7",
+    status: "Conference Proceeding",
+    publisher: "Springer, Berlin, Heidelberg"
+  },
+  HORST05: {
+    id: "HORST05",
+    title: "Completeness, Decidability and Complexity of Entailment for RDF Schema and a Semantic Extension Involving the OWL Vocabulary",
+    authors: ["Herman J. ter Horst"],
+    date: "2005",
+    href: "https://dx.doi.org/10.2139/ssrn.3199251",
+    status: "Conference Proceeding",
+    publisher: "Journal of Web Semantics"
+  },
+  SAFETY: {
+    title: "Saftety of recursive horn clauses with infinite relations",
+    href: "http://arxiv.org/abs/cs.LO/9809032",
+    authors: [
+      "R. Ramakrishnan",
+      "F. Bancilhon",
+      "A. Silberschatz"
+    ],
+    date: "1987",
+    publisher: "ACM New York"
+  },
+  SAX: {
+    title: "SAX – The Simple API for XML",
+    href: "https://accu.org/journals/overload/7/34/cornish_515/",
+    authors: ["Steve Cornish"],
+    date: "October 1999",
+  },
+  STRIPEDRDF: {
+    id: "STRIPEDRDF",
+    title: "RDF: Understanding the Striped RDF/XML Syntax",
+    editors: ["D. Brickley"],
+    date: "2001",
+    href: "http://www.w3.org/2001/10/stripes/",
+    status: "Team Submission",
+    publisher: "W3C"
+  },
+  "RDF-STAR-CG": {
+    title: "RDF-star and SPARQL-star",
+    href: "https://w3c.github.io/rdf-star/cg-spec/2021-12-17.html",
+    authors: [
+      "Olaf Hartig",
+      "Pierre-Antoine Champin",
+      "Gregg Kellogg",
+      "Andy Seaborne"
+    ],
+    rawDate: "2021-12-17",
+    status: "Final Community Group Report",
+    publisher: "W3C"
+  },
+  "RDF12-NEW": {
+    "authors": [
+        "David Wood"
+    ],
+    "href": "https://w3c.github.io/rdf-new/spec/",
+    "title": "What’s New in RDF 1.2",
+    "rawDate": "2022-01-01",
+    "status": "DNOTE",
+    "publisher": "W3C"
+  },
+  "RDF12-PRIMER": {
+    "authors": [
+        "Guus Schreiber",
+        "Yves Raimond"
+    ],
+    "href": "https://w3c.github.io/rdf-primer/spec/",
+    "title": "RDF 1.2 Primer",
+    "rawDate": "2022-01-01",
+    "status": "DNOTE",
+    "publisher": "W3C"
+  },
+ "SPARQL12-NEW": {
+    "authors": [
+        "The W3C RDF &amp; SPARQL Working Group"
+    ],
+    "href": "https://w3c.github.io/sparql-new/spec/",
+    "title": "What’s New in SPARQL 1.2",
+    "rawDate": "2022-01-01",
+    "status": "WD",
+    "publisher": "W3C"
+  },
+  "SPARQL12-CONCEPTS": {
+    "authors": [
+        "The W3C RDF &amp; SPARQL Working Group"
+    ],
+    "href": "https://w3c.github.io/sparql-concepts/spec/",
+    "title": "SPARQL 1.2 Concepts",
+    "rawDate": "2022-01-01",
+    "status": "WD",
+    "publisher": "W3C"
+  },
+};

--- a/shacl12-common/local-biblio.js
+++ b/shacl12-common/local-biblio.js
@@ -27,8 +27,8 @@ var localBibliography = {
     publisher: "Journal of Web Semantics"
   },
   SAFETY: {
-    title: "Saftety of recursive horn clauses with infinite relations",
-    href: "http://arxiv.org/abs/cs.LO/9809032",
+    title: "Safety of recursive horn clauses with infinite relations",
+    href: "https://doi.org/10.1145/28659.28694",
     authors: [
       "R. Ramakrishnan",
       "F. Bancilhon",

--- a/shacl12-common/specifications.html
+++ b/shacl12-common/specifications.html
@@ -1,0 +1,46 @@
+			<h2>SHACL Specifications</h2>
+			<p>
+				This specification is part of the SHACL 1.2 family of specifications. See the <a href="https://w3c.github.io/data-shapes/shacl12-overview/">SHACL 1.2 Overview</a> for a more detailed introduction to them.
+			</p>
+			<p>
+				The specifications are as follows:
+			</p>
+			<dl>
+				<dt><a href="https://w3c.github.io/data-shapes/shacl12-overview/">SHACL 1.2 Overview</a></dt>
+				<dd>overviews the set of SHACL specifications</dd>
+				<dt><a href="https://w3c.github.io/data-shapes/shacl12-core/">SHACL 1.2 Core</a></dt>
+				<dd>defines the Core of SHACL</dd>
+				<dt><a href="https://w3c.github.io/data-shapes/shacl12-sparql/">SHACL 1.2 SPARQL Extensions</a></dt>
+				<dd>defines SPARQL-related extensions of the SHACL</dd>
+				<dt><a href="https://w3c.github.io/data-shapes/shacl12-node-expr/">SHACL 1.2 Node Expressions</a></dt>
+				<dd>defines graph expressions used to determine focus nodes in SHACL</dd>
+				<dt><a href="https://w3c.github.io/data-shapes/shacl12-inf-rules/">SHACL 1.2 Inference Rules</a></dt>
+				<dd>defines SHACL's methods of rule-based inference</dd>
+				<dt><a href="https://w3c.github.io/data-shapes/shacl12-ui/">SHACL 1.2 UI</a></dt>
+				<dd>defines SHACL's use for User Interface generation</dd>
+				<dt><a href="https://w3c.github.io/data-shapes/shacl12-compact-syntax/">SHACL 1.2 Compact Syntax</a></dt>
+				<dd>defines an RDF syntax for expressing SHACL concepts</dd>
+        <dt><a href="https://w3c.github.io/data-shapes/shacl12-profiling/">SHACL 1.2 Profiling</a></dt>
+				<dd>defines the use of SHACL for profiling data, including SHACL data</dd>
+			</dl>
+
+      <!--
+      <dl>
+        <dt data-transform="noSelfCite">[[[SHACL12-OVERVIEW]]]</dt>
+        <dd>overviews the set of SHACL specifications</dd>
+        <dt data-transform="noSelfCite">[[[SHACL12-CORE]]]</dt>
+        <dd>defines the Core of SHACL</dd>
+        <dt data-transform="noSelfCite">[[[SHACL12-SPARQL]]]</dt>
+        <dd>defines SPARQL-related extensions of the SHACL</dd>
+        <dt data-transform="noSelfCite">[[[SHACL12-NODE-EXPR]]]</dt>
+        <dd>defines graph expressions used to determine focus nodes in SHACL</dd>
+        <dt data-transform="noSelfCite">[[[SHACL12-INF-RULES]]]</dt>
+        <dd>defines SHACL's methods of rule-based inference</dd>
+        <dt data-transform="noSelfCite">[[[SHACL12-CS]]]</dt>
+        <dd>defines an RDF syntax for expressing SHACL concepts</dd>
+        <dt data-transform="noSelfCite">[[[SHACL12-UI]]]</dt>
+        <dd>defines SHACL's use for User Interface generation</dd>
+        <dt data-transform="noSelfCite">[[[SHACL12-PROFILING]]]</dt>
+        <dd>defines the use of SHACL for profiling data, including SHACL data</dd>
+      </dl>
+      -->

--- a/shacl12-compact-syntax/index.html
+++ b/shacl12-compact-syntax/index.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html>
 	<head>
+    <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark">
 		<title>SHACL Compact Syntax</title>
-		<meta charset="utf-8">
 		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" async class="remove"></script>
 		<script class="remove">
 		
@@ -253,7 +254,6 @@
 		</style>
 	</head>
 	<body>
-
 		<section id="abstract">
 			<p>
 				The Shapes Constraint Language (SHACL) [[!shacl]] is a language for validating RDF graphs against a set of conditions.
@@ -271,6 +271,8 @@
 			This specification was started by the RDF Data Shapes WG, was continued within the
 			SHACL Community Group, and is now being picked up by the Data Shapes WG.
 		</section>
+
+    <section id="specifications" class="introductory" data-include="../shacl12-common/specifications.html"></section>
 		
 		<section class="introductory">
 			<h2>Document Outline</h2>
@@ -816,6 +818,5 @@ fragment PN_LOCAL_ESC: '\\' ('_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | '\'' 
 				Harold Solbrig
 			</p>
 		</section>
-		
 	</body>
 </html>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -1,6 +1,9 @@
-<!DOCTYPE html><html><head>
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark">
 		<title>SHACL 1.2 Core</title>
-		<meta charset="utf-8">
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer=""></script>
 		<script class="remove">
 		
@@ -444,7 +447,6 @@
 		</style>
 	</head>
 	<body>
-
 		<section id="abstract">
 			<p>
 				This document defines the Core of the SHACL Shapes Constraint Language.
@@ -461,6 +463,8 @@
 
 		<section id="sotd">
 		</section>
+
+    <section id="specifications" class="introductory" data-include="../shacl12-common/specifications.html"></section>
 
 		<section class="introductory">
 			<h2>Document Outline</h2>
@@ -7764,5 +7768,5 @@ ex:NameGroup
 				<li>Generalized <a href="#order"></a> to also allow xsd:integers; see <a href="https://github.com/w3c/data-shapes/issues/479">Issue 479</a></li>
 			</ul>
 		</section>
-
-</body></html>
+  </body>
+</html>

--- a/shacl12-inf-rules/index.html
+++ b/shacl12-inf-rules/index.html
@@ -2,6 +2,7 @@
 <html lang="en-US">
   <head>
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark">
     <title>SHACL 1.2 Inference Rules</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
@@ -462,6 +463,8 @@
     </section>
 
     <section id="sotd"></section>
+
+    <section id="specifications" class="introductory" data-include="../shacl12-common/specifications.html"></section>
 
     <section id="introduction">
       <h2>Introduction</h2>
@@ -1140,7 +1143,6 @@ result is GI
 </pre>
       </section>
     </section>
-
 
     <section id="shapes-rules-grammar">
       <h2>Shapes Rules Language Grammar</h2>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -2,6 +2,7 @@
 <html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark">
 		<title>SHACL 1.2 Node Expressions</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script class="remove">
@@ -410,7 +411,6 @@
 			}
 		</style>
 	</head>
-
 	<body>
 		<section id="abstract">
 			<p>This document describes Shapes Constraint Language (SHACL) Node Expressions.</p>
@@ -422,6 +422,8 @@
 		</section>
 
 		<section id="sotd"></section>
+
+    <section id="specifications" class="introductory" data-include="../shacl12-common/specifications.html"></section>
 
 		<section id="introduction">
 			<h2>Introduction</h2>

--- a/shacl12-overview/index.html
+++ b/shacl12-overview/index.html
@@ -335,7 +335,6 @@
 			}
 		</style>
 	</head>
-
 	<body>
 		<section id="abstract">
 			<p>
@@ -424,7 +423,7 @@
 			<p class="todo">TODO: This section will describe...</p>
 		</section>
 
-        <section id="governance">
+    <section id="governance">
 		    <h3>Governance</h3>
 			<p class="todo">TODO: This section will describe the governance arrangements in place for the continued maintenance of SHACL-SHACL resources, i.e., handling updates beyond the time frame of the Working Group's Charter.</p>
         </section>

--- a/shacl12-profiling/index.html
+++ b/shacl12-profiling/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<title>SHACL 1.2 Profiling</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+    <script src="../shacl12-common/local-biblio.js" class="remove"></script>
 		<script class="remove">
 
 			function prepareSyntaxRules() {
@@ -436,33 +437,7 @@
 
 		<section id="sotd"></section>
 
-		<section class="introductory">
-			<h2>SHACL Specifications</h2>
-			<p>
-				This specification is part of the SHACL 1.2 family of specifications. See the SHACL 1.2 Overview for a more detailed introduction to all of them.
-			</p>
-			<p>
-				The specifications are as follows:
-			</p>
-			<dl>
-				<dt><a href="https://w3c.github.io/data-shapes/shacl12-overview/">SHACL 1.2 Overview</a></dt>
-				<dd>overviews the set of SHACL specifications</dd>
-				<dt><a href="https://w3c.github.io/data-shapes/shacl12-core/">SHACL 1.2 Core</a></dt>
-				<dd>defines the Core of SHACL</dd>
-				<dt><a href="https://w3c.github.io/data-shapes/shacl12-sparql/">SHACL 1.2 SPARQL Extensions</a></dt>
-				<dd>defines SPARQL-related extensions of the SHACL</dd>
-				<dt><a href="https://w3c.github.io/data-shapes/shacl12-node-expr/">SHACL 1.2 Node Expressions</a></dt>
-				<dd>defines graph expressions used to determine focus nodes in SHACL</dd>
-				<dt><a href="https://w3c.github.io/data-shapes/shacl12-inf-rules/">SHACL 1.2 Inference Rules</a></dt>
-				<dd>defines SHACL's methods of rule-based inference</dd>
-				<dt><a href="https://w3c.github.io/data-shapes/shacl12-ui/">SHACL 1.2 UI</a></dt>
-				<dd>defines SHACL's use for User Interface generation</dd>
-				<dt><a href="https://w3c.github.io/data-shapes/shacl12-compact-syntax/">SHACL 1.2 Compact Syntax</a></dt>
-				<dd>defines an RDF syntax for expressing SHACL concepts</dd>
-				<dt>SHACL 1.2 Profiling (this specification)</dt>
-				<dd>defines the use of SHACL for profiling data, including SHACL data</dd>
-			</dl>
-		</section>
+    <section id="specifications" class="introductory" data-include="../shacl12-common/specifications.html"></section>
 
 		<section class="introductory">
 			<h2>Document Outline</h2>
@@ -829,6 +804,9 @@
 		<section id="profiles-of-shacl">
 			<h2>Profiles of SHACL</h2>
 			<p>Content.</p>
+      <p class="todo">
+        Remove this reference test: [[RDF12-PRIMER]]
+      </p>
 		</section>
 
 		<section id="profiling-with-shacl">

--- a/shacl12-profiling/index.html
+++ b/shacl12-profiling/index.html
@@ -2,6 +2,7 @@
 <html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark">
 		<title>SHACL 1.2 Profiling</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script src="../shacl12-common/local-biblio.js" class="remove"></script>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html>
 	<head>
+    <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark">
 		<title>SHACL 1.2 SPARQL Extensions</title>
-		<meta charset="utf-8">
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
 		<script class="remove">
 		
@@ -399,7 +400,6 @@
 		</style>
 	</head>
 	<body>
-
 		<section id="abstract">
 			<p>
 				This document defines SPARQL-related extensions of the SHACL Shapes Constraint Language.
@@ -418,6 +418,8 @@
 
 		<section id="sotd">
 		</section>
+
+    <section id="specifications" class="introductory" data-include="../shacl12-common/specifications.html"></section>
 
 		<section id="introduction">
 			<h2>Introduction</h2>
@@ -2283,8 +2285,6 @@ WHERE {
 				<li>Clarified that VALUES clauses are only disallowed when they mention <a href="#pre-binding">pre-bound variables</a> and removed the restriction on sub-SELECTs, see <a href="https://github.com/w3c/data-shapes/issues/159">Issue 159</a></li>
 				<li>Removed support for the optional pre-bound variables <code>shapesGraph</code> and <code>currentShape</code>, see <a href="https://github.com/w3c/data-shapes/issues/426">Issue 426</a></li>
 			</ul>
-		</section>		
-		  
+		</section>
 	</body>
-
 </html>


### PR DESCRIPTION
This PR adds a common list of specifications to all documents following the mecahnisms used by the RDF group.

Temporary links for all docs are use - GitHub, not W3C permalinks - until we actually have all the spec registered in SpecRef. Assumed SpecRef links are ready, commended out, here:  https://github.com/w3c/data-shapes/blob/common-spec-elements/shacl12-common/specifications.html