### PR TITLE
Make references to original SHACL consistent

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -7738,7 +7738,7 @@ ex:NameGroup
 			<h2>Acknowledgements</h2>
 			<p>
 				The original SHACL core specification was produced by the RDF Data Shapes Working Group.
-				See its <a href="https://www.w3.org/TR/shacl/#ack">Acknowledgements section</a>.
+				See its <a href="https://www.w3.org/TR/2017/REC-shacl-20170720/#ack">Acknowledgements section</a>.
 			</p>
 		</section>
 

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -7737,8 +7737,8 @@ ex:NameGroup
 		<section id="ack" class="appendix informative">
 			<h2>Acknowledgements</h2>
 			<p>
-				The original 1.0 version of SHACL was produced by the RDF Data Shapes Working Group.
-				See its <a href="https://www.w3.org/TR/shacl/#ack">SHACL 1.0 Acknowledgements section</a>.
+				The original SHACL core specification was produced by the RDF Data Shapes Working Group.
+				See its <a href="https://www.w3.org/TR/shacl/#ack">Acknowledgements section</a>.
 			</p>
 		</section>
 
@@ -7753,7 +7753,7 @@ ex:NameGroup
 		</section>
 
 		<section class="appendix informative" id="changes-12">
-			<h2>Changes between SHACL 1.0 Core and SHACL 1.2 Core</h2>
+			<h2>Changes between the original SHACL Core and SHACL 1.2 Core</h2>
 			<ul>
 				<li>Introduced <a>node expressions</a> as an extension point to dynamically compute lists of nodes. Generalized <code>sh:targetNode</code>, <code>sh:deactivated</code> and <code>sh:defaultValue</code>, and introduced <code>sh:values</code> to support node expressions.</li>
 				<li>Added the new constraint component <a href="#SingleLineConstraintComponent"><code>sh:singleLine</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/177">Issue 177</a></li>

--- a/shacl12-overview/index.html
+++ b/shacl12-overview/index.html
@@ -379,7 +379,7 @@
         While SHACL 1.2 does aim to cater for all aspects of [[[rdf12-concepts]]] and [[[sparql12-query]]], those specifications are not finalised while this note remains here, so coverage may not yet be complete.</p>
       </p>
       <p>
-        The original SHACL specifications were published in 2015 and were aligned with [[[rdf11-concepts]]] and [[[sparql11-query]]]. They are listed in the <a href="#shacl-orig">SHACL 2015</a> section below. The SHACL 1.2 specifications are also listed below, in the <a href="#shacl-1.2">SHACL 1.2</a> section.
+        The original SHACL specifications were published in 2017 and were aligned with [[[rdf11-concepts]]] and [[[sparql11-query]]]. They are listed in the <a href="#shacl-orig">SHACL Original</a> section below. The SHACL 1.2 specifications are also listed below, in the <a href="#shacl-1.2">SHACL 1.2</a> section.
       </p>
       <p>
         Following are the major new things in SHACL 1.2 and the specifications in which they appear.
@@ -564,7 +564,7 @@
         <h3>
           SHACL Original
         </h3>
-        <p><em>The original SHACL specifications published in 2015 are listed below. They are now deprecated in favor of the SHACL 1.2 specifications, listed above.</em></p>
+        <p><em>The original SHACL specifications published in 2017 are listed below. They are now deprecated in favor of the SHACL 1.2 specifications, listed above.</em></p>
         <dl>
           <dt><a href="https://www.w3.org/TR/2017/REC-shacl-20170720/">SHACL</a></dt>
           <dd>the original SHACL Shapes Constraint Language definition</dd>

--- a/shacl12-overview/index.html
+++ b/shacl12-overview/index.html
@@ -373,10 +373,13 @@
 		<section id="whatsnew">
 			<h2>What's New in SHACL 1.2</h2>
       <p>
-        SHACL 1.2 covers <a href="https://www.w3.org/TR/rdf12-new/">new developments in RDF 1.2 and SPARQL 1.2</a>, formalizes versions of original SHACL documents published only as Notes, and takes SHACL into new areas such as rules for inferencing and profile definition.
+        SHACL 1.2 covers <a href="https://www.w3.org/TR/rdf12-new/">new developments</a> in RDF 1.2 and <a href="https://www.w3.org/TR/sparql12-new/">new developments</a> in SPARQL 1.2. It formalizes versions of original SHACL documents published only as Notes, and takes SHACL into new areas such as rules for inferencing and profile definition.
+      </p>
+      <p class="note">
+        While SHACL 1.2 does aim to cater for all aspects of [[[rdf12-concepts]]] and [[[sparql12-query]]], those specifications are not finalised while this note remains here, so coverage may not yet be complete.</p>
       </p>
       <p>
-        The original SHACL specifications, published in 2015 and now considered SHACL 1.1 as they were aligned with RDF 1.1, are listed in the <a href="#shacl-1.1">SHACL 1.1</a> section below. The SHACL 1.2 specifications are also listed below, in the <a href="#shacl-1.2">SHACL 1.2</a> section.
+        The original SHACL specifications were published in 2015 and were aligned with [[[rdf11-concepts]]] and [[[sparql11-query]]]. They are listed in the <a href="#shacl-orig">SHACL 2015</a> section below. The SHACL 1.2 specifications are also listed below, in the <a href="#shacl-1.2">SHACL 1.2</a> section.
       </p>
       <p>
         Following are the major new things in SHACL 1.2 and the specifications in which they appear.
@@ -399,7 +402,7 @@
               Derived Properties
             </td>
             <td>
-              In SHACL 1.1, shapes and constraints could only operate on asserted triples in a graph, and inferencing was left as an optional pre-processing step using languages like RDF Schema and OWL. SHACL 1.2 introduces its own inferencing and reasoning capabilities, which make SHACL more self-contained and cover different use cases than RDFS/OWL.
+              In the original SHACL specifications, shapes and constraints could only operate on asserted triples in a graph, and inferencing was left as an optional pre-processing step using languages like RDF Schema and OWL. SHACL 1.2 introduces its own inferencing and reasoning capabilities, which make SHACL more self-contained and cover different use cases than RDFS/OWL.
             </td>
             <td>
               <a href="https://www.w3.org/TR/shacl12-core/">Core</a>,<br />
@@ -411,7 +414,7 @@
               Flexible Target Nodes
             </td>
             <td>
-              In SHACL 1.2, node expressions can be used in more places than derived properties, to which they were limited in SHACL 1.1. Particularly, they can now also be used to compute the target nodes of a shape. This provides greater flexibility than the built-in target types such as <code>sh:targetClass</code> and <code>sh:targetSubjectsOf</code>.
+              In SHACL 1.2, node expressions can be used in more places than derived properties, to which they were limited in the original SHACL specifications. Particularly, they can now also be used to compute the target nodes of a shape. This provides greater flexibility than the built-in target types such as <code>sh:targetClass</code> and <code>sh:targetSubjectsOf</code>.
             </td>
             <td>
               <a href="https://www.w3.org/TR/shacl12-node-expr/">Node Expr</a>
@@ -424,7 +427,7 @@
                 The new <em>Inferencing Rules</em> specification allows the representation and execution of <a href="https://en.wikipedia.org/wiki/Datalog">Datalog</a>-like inference rules which have a straight-forward mapping to SPARQL <code>CONSTRUCT</code> statements for execution, and integrate with other SHACL features such as node expressions.
               </p>
               <p>
-                This work was inspired by the SPARQL-based rules introduced by the <a href="https://www.w3.org/TR/shacl-af/">SHACL 1.1 Advanced Features</a> note (commonly referred to as "SHACL-AF") and older technologies such as <a href="https://spinrdf.org/">SPIN</a>.
+                This work was inspired by the SPARQL-based rules introduced by the <a href="https://www.w3.org/TR/shacl-af/">SHACL Advanced Features</a> note (commonly referred to as "SHACL-AF") and older technologies such as <a href="https://spinrdf.org/">SPIN</a>.
               </p>
             </td>
             <td>
@@ -436,7 +439,7 @@
               Better Syntax for Unions of Datatypes and Classes
             </td>
             <td>
-              In SHACL 1.1, when you wanted to express that the datatype of a property was either <code>xsd:string</code>, <code>rdf:langString</code>, or <code>rdf:HTML</code>, you needed to use a verbose, repetitive construct. In SHACL 1.2, this can be written as a single list.
+              In the original SHACL specifications, when you wanted to express that the datatype of a property was either <code>xsd:string</code>, <code>rdf:langString</code>, or <code>rdf:HTML</code>, you needed to use a verbose, repetitive construct. In SHACL 1.2, this can be written as a single list.
             </td>
             <td>
               <a href="https://www.w3.org/TR/shacl12-core/">Core</a>
@@ -458,7 +461,7 @@
               Use of Reification in Constraint Definitions
             </td>
             <td>
-              In SHACL 1.1, the severity and messages of a constraint had to be declared for the surrounding shape, sometimes requiring artificial intermediate shapes to be introduced to change only the severity or a message. SHACL 1.2 syntax is more flexible, allowing severity and messages to be directly attached to individual constraint triples.
+              In the original SHACL specifications, the severity and messages of a constraint had to be declared for the surrounding shape, sometimes requiring artificial intermediate shapes to be introduced to change only the severity or a message. SHACL 1.2 syntax is more flexible, allowing severity and messages to be directly attached to individual constraint triples.
             </td>
             <td>
               <a href="https://www.w3.org/TR/shacl12-core/">Core</a>
@@ -493,7 +496,7 @@
             </td>
             <td>
               <p>
-                The SHACL Community Group, which formed after the publication of SHACL 1.1, produced an informal <a href="https://w3c.github.io/shacl/shacl-compact-syntax/">SHACL Compact Syntax Report</a> which defines a compact syntax (sometimes referred to as SHACL-C) for core elements of SHACL 1.1.
+                The SHACL Community Group, which formed after the publication of the original SHACL specifications, produced an informal <a href="https://w3c.github.io/shacl/shacl-compact-syntax/">SHACL Compact Syntax Report</a> which defines a compact syntax (sometimes referred to as SHACL-C) for core elements of the original SHACL specifications.
               </p>
               <p>
                 We now have a formalization of that syntax with updates to aline with the other SHACL 1.2 specifications.
@@ -508,7 +511,7 @@
               A formal SHACL UI
             </td>
             <td>
-              Industry has used SHACL 1.1 for user interface generation since publication, with non-W3C extensions such as <a href="https://www.datashapes.org/">DASH</a>. This is now formalized in a new specification.
+              Industry has used the original SHACL specifications for user interface generation since publication, with non-W3C extensions such as <a href="https://www.datashapes.org/">DASH</a>. This is now formalized in a new specification.
             </td>
             <td>
               <a href="https://www.w3.org/TR/shacl12-ui/">UI</a>
@@ -557,11 +560,11 @@
           <dd>defines the use of SHACL for profiling data, including SHACL data</dd>
         </dl>
       </section>
-      <section id="shacl-1.1">
+      <section id="shacl-orig">
         <h3>
-          SHACL 1.1
+          SHACL Original
         </h3>
-        <p><em>The original SHACL specifications listed below, now referred to as SHACL 1.1, are deprecated in favor of the SHACL 1.2 specifications, listed above.</em></p>
+        <p><em>The original SHACL specifications published in 2015 are listed below. They are now deprecated in favor of the SHACL 1.2 specifications, listed above.</em></p>
         <dl>
           <dt><a href="https://www.w3.org/TR/2017/REC-shacl-20170720/">SHACL</a></dt>
           <dd>the original SHACL Shapes Constraint Language definition</dd>

--- a/shacl12-overview/index.html
+++ b/shacl12-overview/index.html
@@ -427,7 +427,7 @@
                 The new <em>Inferencing Rules</em> specification allows the representation and execution of <a href="https://en.wikipedia.org/wiki/Datalog">Datalog</a>-like inference rules which have a straight-forward mapping to SPARQL <code>CONSTRUCT</code> statements for execution, and integrate with other SHACL features such as node expressions.
               </p>
               <p>
-                This work was inspired by the SPARQL-based rules introduced by the <a href="https://www.w3.org/TR/shacl-af/">SHACL Advanced Features</a> note (commonly referred to as "SHACL-AF") and older technologies such as <a href="https://spinrdf.org/">SPIN</a>.
+                This work was inspired by the SPARQL-based rules introduced by the <a href="https://www.w3.org/TR/2017/NOTE-shacl-af-20170608/">SHACL Advanced Features</a> note (commonly referred to as "SHACL-AF") and older technologies such as <a href="https://spinrdf.org/">SPIN</a>.
               </p>
             </td>
             <td>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2261,8 +2261,9 @@ WHERE {
 		<section id="ack" class="appendix informative">
 			<h2>Acknowledgements</h2>
 			<p>
-				The original 1.0 version of SHACL was produced by the RDF Data Shapes Working Group.
-				See its <a href="https://www.w3.org/TR/shacl/#ack">SHACL 1.0 Acknowledgements section</a>.
+				Original SHACL core specifications were produced by the RDF Data Shapes Working Group.
+				See the <a href="https://www.w3.org/TR/shacl/#ack">Core specification's Acknowledgements section</a> and
+        the <a href="https://www.w3.org/TR/shacl-af/#ack">Advanced Features specification's Acknowledgements section</a>.
 			</p>
 		</section>
 
@@ -2277,7 +2278,7 @@ WHERE {
 		</section>
 
 		<section class="appendix informative" id="changes-12">
-			<h2>Changes between SHACL 1.0 SPARQL and SHACL 1.2 SPARQL Extensions</h2>
+			<h2>Changes between the original SHACL specifications and SHACL 1.2 SPARQL</h2>
 			<ul>
 				<li>Added the <a>node expression function</a> <a href="#SelectExpression"><code>sh:SelectExpression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/288">Issue 288</a></li>
 				<li>Added support for <a>annotation properties</a>, see <a href="https://github.com/w3c/data-shapes/issues/327">Issue 327</a></li>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2262,8 +2262,8 @@ WHERE {
 			<h2>Acknowledgements</h2>
 			<p>
 				Original SHACL core specifications were produced by the RDF Data Shapes Working Group.
-				See the <a href="https://www.w3.org/TR/shacl/#ack">Core specification's Acknowledgements section</a> and
-        the <a href="https://www.w3.org/TR/shacl-af/#ack">Advanced Features specification's Acknowledgements section</a>.
+				See the <a href="https://www.w3.org/TR/2017/REC-shacl-20170720/#ack">Core specification's Acknowledgements section</a> and
+        the <a href="https://www.w3.org/TR/2017/NOTE-shacl-af-20170608/#ack">Advanced Features specification's Acknowledgements section</a>.
 			</p>
 		</section>
 


### PR DESCRIPTION
This de-brands the original SHACL as SHACL 1.0 as that versioning was never originally used and is problematic given that SHACL 1.2 is linked to RDF 1.2 while the original SHACL specification was linked to RDF 1.1.