### PR TITLE
Issue 559: Added sh:codeIdentifer annotation property for code generators

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -7356,7 +7356,7 @@ ex:RainbowPony ex:color ex:Pink .
 				this section covers properties that are ignored by SHACL processors.
 				The use of these so-called <dfn data-lt="non-validating property">non-validating properties</dfn>
 				is entirely optional and is not subject to formal interpretation contracts.
-				They MAY be used for purposes such as form building or predictable printing of RDF files.
+				They MAY be used for purposes such as form building, code generation or predictable printing of RDF files.
 			</p>
 			<section id="name">
 				<h3>sh:name and sh:description</h3>
@@ -7373,14 +7373,23 @@ ex:RainbowPony ex:color ex:Pink .
 					multiple <a>values</a>, but should only have one <a>value</a> per language tag.
 				</p>
 			</section>
-			<section id="fieldName">
-				<h3>sh:fieldName</h3>
+			<section id="codeIdentifier">
+				<h3>sh:codeIdentifier</h3>
 				<p>
-					Property shapes may have one <a>value</a> for <code>sh:fieldName</code>
-					to suggest a name that can be used for a representation of the property in APIs, query languages
+					Shapes may have one <a>value</a> for <code>sh:codeIdentifier</code>
+					to suggest a name that can be used for a representation of the shape in APIs, query languages
 					and similar programmatic access.
-					The values of <code>sh:fieldName</code> are <a>literals</a> with <a>datatype</a> <code>xsd:string</code>
+					The values of <code>sh:codeIdentifier</code> are <a>literals</a> with <a>datatype</a> <code>xsd:string</code>
 					where the string matches the regular expression <code>^[a-zA-Z_][a-zA-Z0-9_]*$</code>.
+				</p>
+				<p>
+					There are no strict rules in SHACL Core how these values should be used.
+					At the time of writing, a typical use case would be to generate GraphQL query
+					schemas from shapes, mapping property shapes to GraphQL fields.
+					By default such schema generators could use the <a>local name</a> of the
+					<code>sh:path</code>, but it should use the <code>sh:codeIdentifier</code> if present.
+					In the case of complex path expressions an explicit <code>sh:codeIdentifier</code> is strongly recommended.
+					Similar requirements exist for API generators, for example in Java, JavaScript or Python.
 				</p>
 			</section>
 			<section id="order">
@@ -7867,7 +7876,7 @@ ex:NameGroup
 				<li>Added the new constraint component <a href="#ReifierShapeShapeConstraintComponent"><code>sh:ReifierShape</code></a>; see <a href="https://github.com/w3c/data-shapes/issues/300">Issue 300</a></li>
 				<li>Added parameter <a href="#subClassOfInShapesGraph"></a> to look up rdfs:subClassOf triples in the union of the shapes graph and the data graph; see <a href="https://github.com/w3c/data-shapes/issues/185">Issue 185</a></li>
 				<li>Generalized <a href="#order"></a> to also allow xsd:integers; see <a href="https://github.com/w3c/data-shapes/issues/479">Issue 479</a></li>
-				<li>Added annotation property <a href="#fieldName"></a>; see <a href="https://github.com/w3c/data-shapes/issues/559">Issue 559</a></li>
+				<li>Added annotation property <a href="#codeIdentifier"></a>; see <a href="https://github.com/w3c/data-shapes/issues/559">Issue 559</a></li>
 			</ul>
 		</section>
   </body>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -7373,6 +7373,16 @@ ex:RainbowPony ex:color ex:Pink .
 					multiple <a>values</a>, but should only have one <a>value</a> per language tag.
 				</p>
 			</section>
+			<section id="fieldName">
+				<h3>sh:fieldName</h3>
+				<p>
+					Property shapes may have one <a>value</a> for <code>sh:fieldName</code>
+					to suggest a name that can be used for a representation of the property in APIs, query languages
+					and similar programmatic access.
+					The values of <code>sh:fieldName</code> are <a>literals</a> with <a>datatype</a> <code>xsd:string</code>
+					where the string matches the regular expression <code>^[a-zA-Z_][a-zA-Z0-9_]*$</code>.
+				</p>
+			</section>
 			<section id="order">
 				<h3>sh:order</h3>
 				<p>
@@ -7857,6 +7867,7 @@ ex:NameGroup
 				<li>Added the new constraint component <a href="#ReifierShapeShapeConstraintComponent"><code>sh:ReifierShape</code></a>; see <a href="https://github.com/w3c/data-shapes/issues/300">Issue 300</a></li>
 				<li>Added parameter <a href="#subClassOfInShapesGraph"></a> to look up rdfs:subClassOf triples in the union of the shapes graph and the data graph; see <a href="https://github.com/w3c/data-shapes/issues/185">Issue 185</a></li>
 				<li>Generalized <a href="#order"></a> to also allow xsd:integers; see <a href="https://github.com/w3c/data-shapes/issues/479">Issue 479</a></li>
+				<li>Added annotation property <a href="#fieldName"></a>; see <a href="https://github.com/w3c/data-shapes/issues/559">Issue 559</a></li>
 			</ul>
 		</section>
   </body>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -7379,12 +7379,11 @@ ex:RainbowPony ex:color ex:Pink .
 					Shapes may have one <a>value</a> for <code>sh:codeIdentifier</code>
 					to suggest a name that can be used for a representation of the shape in APIs, query languages
 					and similar programmatic access.
-					The values of <code>sh:codeIdentifier</code> are <a>literals</a> with <a>datatype</a> <code>xsd:string</code>
+					The value of <code>sh:codeIdentifier</code> is a <a>literal</a> with <a>datatype</a> <code>xsd:string</code>
 					where the string matches the regular expression <code>^[a-zA-Z_][a-zA-Z0-9_]*$</code>.
 				</p>
-				<p>
-					There are no strict rules in SHACL Core how these values should be used.
-					At the time of writing, a typical use case would be to generate GraphQL query
+				<p class="note">
+					A typical use case would be to generate GraphQL query
 					schemas from shapes, mapping property shapes to GraphQL fields.
 					By default such schema generators could use the local name of the
 					<code>sh:path</code>, but it should use the <code>sh:codeIdentifier</code> if present.

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -7350,7 +7350,7 @@ ex:RainbowPony ex:color ex:Pink .
 		</section>
 				
 		<section id="nonValidation" class="informative">
-			<h2>Non-Validating Property Shape Characteristics</h2>
+			<h2>Non-Validating Shape Characteristics</h2>
 			<p>
 				While the previous sections introduced properties that represent validation conditions,
 				this section covers properties that are ignored by SHACL processors.

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -7386,7 +7386,7 @@ ex:RainbowPony ex:color ex:Pink .
 					There are no strict rules in SHACL Core how these values should be used.
 					At the time of writing, a typical use case would be to generate GraphQL query
 					schemas from shapes, mapping property shapes to GraphQL fields.
-					By default such schema generators could use the <a>local name</a> of the
+					By default such schema generators could use the local name of the
 					<code>sh:path</code>, but it should use the <code>sh:codeIdentifier</code> if present.
 					In the case of complex path expressions an explicit <code>sh:codeIdentifier</code> is strongly recommended.
 					Similar requirements exist for API generators, for example in Java, JavaScript or Python.

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -965,7 +965,7 @@ ex:Person-displayName
 					<div class="def" id="VarExpression-evaluation">
 						<div class="def-header">EVALUATION OF EMPTY EXPRESSIONS</div>
 						<p>
-							The <a>output nodes</a> of an <a>empty expression</a> is the empty list.
+							An <a>empty expression</a> has the empty list <code>[]</code> as its <a>output nodes</a>.
 						</p>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1680,6 +1680,14 @@ sh:nodeByExpression
 
 # Non-validating constraint properties ----------------------------------------
 
+sh:codeIdentifier
+	a rdf:Property ;
+	rdfs:label "code identifier"@en ;
+	rdfs:comment "A hint on how code generators should represent the associated shape."@en ;
+	rdfs:domain sh:Shape ;
+	rdfs:range: xsd:string ;
+	rdfs:isDefinedBy sh: .
+
 sh:defaultValue
 	a rdf:Property ;
 	rdfs:label "default value"@en ;


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #559

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-559/shacl12-core/index.html)
