### PR TITLE
#588: Fixed order of definitions so that shacl-subclass and shacl-typ…

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -306,17 +306,17 @@
 				<div class="def">
 				<div class="term-def-header">SHACL Subclass, SHACL superclass</div>
 					<div>
-						A <a>node</a> <code>Sub</code> in an <a>RDF graph</a> is a <dfn data-lt="subclasses|subclass|SHACL subclasses">SHACL subclass</dfn> of another <a>node</a> <code>Super</code>
+						A <a>node</a> <code>Sub</code> in an <a>RDF graph</a> is a <dfn data-lt="SHACL subclass|subclass|subclasses">SHACL subclass</dfn> of another <a>node</a> <code>Super</code>
 						in the <a>graph</a> if there is a sequence of <a>triples</a> in the <a>graph</a> each with predicate <code>rdfs:subClassOf</code> such that the <a>subject</a> of the first <a>triple</a> is <code>Sub</code>,
 						the <a>object</a> of the last triple is <code>Super</code>, and the <a>object</a> of each <a>triple</a> except the last is the <a>subject</a> of the next.
 						If <code>Sub</code> is a <a>SHACL subclass</a> of <code>Super</code> in an <a>RDF graph</a> then <code>Super</code>
-						is a <dfn data-lt="superclass|superclasses|SHACL superclasses|">SHACL superclass</dfn> of <code>Sub</code> in the <a>graph</a>.
+						is a <dfn data-lt="SHACL superclass|superclass|superclasses">SHACL superclass</dfn> of <code>Sub</code> in the <a>graph</a>.
 					</div>
 				</div>
 				<div class="def">
 					<div class="term-def-header">SHACL Type</div>
 					<div>
-						The <dfn data-lt="type|types|SHACL type">SHACL types</dfn> of an <a>RDF term</a> in an <a>RDF graph</a> is the set of its <a>values</a> for <code>rdf:type</code> in the
+						The <dfn data-lt="SHACL type|type|types">SHACL types</dfn> of an <a>RDF term</a> in an <a>RDF graph</a> is the set of its <a>values</a> for <code>rdf:type</code> in the
 						<a>graph</a> as well as the <a>SHACL superclasses</a> of these <a>values</a> in the <a>graph</a>.
 						Note that some SHACL implementations can be parameterized so that the <code>rdfs:subClassOf</code> triples
 						that determine the <a>SHACL subclasses</a> may be queried from the <a>shapes graph</a> in addition to the <a>data graph</a>.


### PR DESCRIPTION
…e is used first

<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #588

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-588/shacl12-core/index.html)
