### PR TITLE
Issue 615: Only show language in tab group if its div exists

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -74,12 +74,13 @@
 					const selectors = document.createElement("div");
 					selectors.classList.add("selectors");
 
-					// Check if shaclc div exists in this tab group
+					// Check if JSON-LD or shaclc div exists in this tab group
+					const hasJsonld = tabs.querySelector(".jsonld");
 					const hasShaclc = tabs.querySelector(".shaclc");
 
 					selectors.innerHTML = `
 						<button class="selected" data-selects="turtle">Turtle</button>
-						<button data-selects="jsonld">JSON-LD</button>
+						${hasJsonld ? '<button data-selects="jsonld">JSON-LD</button>' : ''}
 						${hasShaclc ? '<button data-selects="shaclc">SHACL-C</button>' : ''}
 					`
 
@@ -1332,7 +1333,7 @@ ex:Bob ex:livesIn ex:NewYork .
 							because it is the <a>object</a> of a <a>triple</a> that has <code>ex:knows</code> as its <a>predicate</a>.
 						</p>
 					</section>
-					
+
 					<section id="targetWhere">
 						<h4>Where Targets (sh:targetWhere)</h4>
 						<p class="syntax">
@@ -1382,7 +1383,7 @@ ex:Alice a ex:Person .
 <span class="focus-node-selected">ex:Bob</span> a ex:Person ;
     ex:age 21 .
 								</div>
-	
+
 						</aside>
 						<p>
 							In this example, only <code>ex:Bob</code> is a focus node of <code>ex:AdultPerson</code>
@@ -1403,7 +1404,7 @@ ex:Alice a ex:Person .
 							In the worst case, an engine will need to iterate over all nodes in the data graph to filter them one-by-one.
 						</p>
 					</section>
-					
+
 					<section id="explicit-shape-target">
 						<h4>Explicit shape targets (sh:shape)</h4>
 						<p class="syntax">

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -73,9 +73,15 @@
 				for (const tabs of document.querySelectorAll(".ds-selector-tabs")) {
 					const selectors = document.createElement("div");
 					selectors.classList.add("selectors");
+
+					// Check if JSON-LD or shaclc div exists in this tab group
+					const hasJsonld = tabs.querySelector(".jsonld");
+					const hasShaclc = tabs.querySelector(".shaclc");
+
 					selectors.innerHTML = `
 						<button class="selected" data-selects="turtle">Turtle</button>
-						<button data-selects="jsonld">JSON-LD</button>
+						${hasJsonld ? '<button data-selects="jsonld">JSON-LD</button>' : ''}
+						${hasShaclc ? '<button data-selects="shaclc">SHACL-C</button>' : ''}
 					`
 
 					tabs.prepend(selectors);

--- a/shacl12-profiling/index.html
+++ b/shacl12-profiling/index.html
@@ -74,9 +74,15 @@
 				for (const tabs of document.querySelectorAll(".ds-selector-tabs")) {
 					const selectors = document.createElement("div");
 					selectors.classList.add("selectors");
+
+					// Check if JSON-LD or shaclc div exists in this tab group
+					const hasJsonld = tabs.querySelector(".jsonld");
+					const hasShaclc = tabs.querySelector(".shaclc");
+
 					selectors.innerHTML = `
 						<button class="selected" data-selects="turtle">Turtle</button>
-						<button data-selects="jsonld">JSON-LD</button>
+						${hasJsonld ? '<button data-selects="jsonld">JSON-LD</button>' : ''}
+						${hasShaclc ? '<button data-selects="shaclc">SHACL-C</button>' : ''}
 					`
 
 					tabs.prepend(selectors);

--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -6,7 +6,7 @@
     <title>SHACL 1.2 Rules</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
-    
+
       function prepareSyntaxRules() {
         document.querySelectorAll("[data-syntax-rule]").forEach(element => {
           let ruleId = element.getAttribute("data-syntax-rule");
@@ -35,7 +35,7 @@
           element.setAttribute("id", "syntax-rule-" + ruleId);
         });
       }
-    
+
       function prepareValidators() {
         document.querySelectorAll("[data-validator]").forEach(element => {
           let validatorId = element.getAttribute("data-validator") + "ConstraintComponent";
@@ -73,13 +73,14 @@
         for (const tabs of document.querySelectorAll(".ds-selector-tabs")) {
           const selectors = document.createElement("div");
           selectors.classList.add("selectors");
-          
-          // Check if shaclc div exists in this tab group
+
+          // Check if JSON-LD or shaclc div exists in this tab group
+          const hasJsonld = tabs.querySelector(".jsonld")
           const hasShaclc = tabs.querySelector(".shaclc");
-          
+
           selectors.innerHTML = `
             <button class="selected" data-selects="turtle">Turtle</button>
-            <button data-selects="jsonld">JSON-LD</button>
+            ${hasJsonld ? '<button data-selects="jsonld">JSON-LD</button>' : ''}
             ${hasShaclc ? '<button data-selects="shaclc">SHACL-C</button>' : ''}
           `
 
@@ -97,7 +98,7 @@
           }
         }
       });
-      
+
       var respecConfig = {
         localBiblio: {},
 
@@ -117,13 +118,13 @@
           {
             name: "Robert David",
             company: "Ontotext",
-            //mailto: 
+            //mailto:
             w3cid: "97894"
           },
           {
             name: "David Habgood",
             company: "KurrawongAI",
-            // mailto: 
+            // mailto:
             w3cid: "164266"
           },
 
@@ -154,7 +155,7 @@
             publisher: "W3C",
           }
         }
-        
+
       };
     </script>
     <style>
@@ -713,7 +714,7 @@
         <p>TODO</p>
 
         <p class="ednote">RFC 2119 language should autmatically be inserted here.</p>
-        
+
       </section>
     </section>
 
@@ -766,7 +767,7 @@ RULE { ?x :descendedFrom ?y } WHERE { ?x :childOf ?z . ?z :childOf ?y }
             A <em>data block</em> is a set of triples.
             These form extra facts that are included in the inference process.
           </dd>
-          
+
           <dt><dfn>triple template</dfn></dt>
           <dd>
             A <em>triple template</em> is 3-tuple where each element is either
@@ -778,7 +779,7 @@ RULE { ?x :descendedFrom ?y } WHERE { ?x :childOf ?z . ?z :childOf ?y }
           <dd>
             A <em>triple pattern</em> is 3-tuple where each element is either a
             variable, or an RDF term  (which might be a triple term).
-            [=Triple  patterns=] appear in the [=body=] of a [=rule=]. 
+            [=Triple  patterns=] appear in the [=body=] of a [=rule=].
           </dd>
 
           <dt><dfn>condition expression</dfn></dt>
@@ -807,19 +808,19 @@ RULE { ?x :descendedFrom ?y } WHERE { ?x :childOf ?z . ?z :childOf ?y }
             A <em>rule head</em> is a sequence where each element
             of the sequence is a [=triple template=].
           </dd>
-          
+
           <dt>
             <dfn data-lt="body|rule body">rule body</dfn>
           </dt>
           <dd>
             A <em>rule body</em> is a sequence where each element
-            of the sequence is a [=triple pattern=], a 
+            of the sequence is a [=triple pattern=], a
             [=condition expression=], or an [=assignment=].
           </dd>
-          
+
           <dt><dfn>rule set</dfn></dt>
           <dd>
-            A <em>rule set</em> is a collection of zero or more [=rules=] 
+            A <em>rule set</em> is a collection of zero or more [=rules=]
             and a collection of zero or more [=data blocks=].
           </dd>
         </dl>
@@ -836,10 +837,10 @@ RULE { ?x :descendedFrom ?y } WHERE { ?x :childOf ?z . ?z :childOf ?y }
           <p>
             Well-formedness is a set of conditions on the abstract syntax of
             shapes rules.  Together, these rules ensure that a [=variable=] in the
-            [=head=] of a rule has a value defined in the [=body=] of the rule; 
-            that each variable in an condition expression or assignment 
+            [=head=] of a rule has a value defined in the [=body=] of the rule;
+            that each variable in an condition expression or assignment
             expression has a value at the point of evaluation; and that each
-            assignment in a rule introduces a new variable, 
+            assignment in a rule introduces a new variable,
             not used earlier in the rule body.
           </p>
           <p>
@@ -849,15 +850,15 @@ RULE { ?x :descendedFrom ?y } WHERE { ?x :childOf ?z . ?z :childOf ?y }
           <ul>
             <li>For every [=variable=] appearing in a [=triple template=]
               of the [=head=] of the [=rule=],
-              there is one or more occurrences of a [=variable=] 
-              of the same name in the [=triple patterns=] in the [=body=], 
+              there is one or more occurrences of a [=variable=]
+              of the same name in the [=triple patterns=] in the [=body=],
               or in an [=assignment=] in the body, or both.
             </li>
             <li>
               For every [=variable=] in an [=expression=] at position <em>i</em>
               of the [=body=], there is a corresponding [=variable=] of the same
-              name occuring in a [=triple pattern=] at a position <em>j</em>, 
-              or occurring as an [=assignment variable=] at a position <em>j</em>, 
+              name occuring in a [=triple pattern=] at a position <em>j</em>,
+              or occurring as an [=assignment variable=] at a position <em>j</em>,
               where <em>i &gt; j</em>.
             </li>
             <li>
@@ -870,9 +871,9 @@ RULE { ?x :descendedFrom ?y } WHERE { ?x :childOf ?z . ?z :childOf ?y }
             </li>
             <li>
               For every [=variable=] in an [=assignment expression=] at position <em>i</em>,
-              there is a corresponding variable in a triple pattern at position 
+              there is a corresponding variable in a triple pattern at position
               <em>j</em> where <em>i &gt; j</em>,
-              or there is an [=assignment variable=] in an [=assignment=] at position 
+              or there is an [=assignment variable=] in an [=assignment=] at position
               <em>j</em> where <em>i &gt; j</em>.
             </li>
           </ul>
@@ -905,10 +906,10 @@ PREFIX : &lt;http://example/>
 
 DATA { :x :p 1 ; :q 2 . }
 
-RULE { ?x :bothPositive true . } 
+RULE { ?x :bothPositive true . }
 WHERE { ?x :p ?v1  FILTER ( ?v1 &gt; 0 )  ?x :q ?v2  FILTER ( ?v2 &gt; 0 )  }
 
-RULE { ?x :oneIsZero true . } 
+RULE { ?x :oneIsZero true . }
 WHERE { ?x :p ?v1 ;  :q ?v2  FILTER ( ( ?v1 = 0 ) || ( ?v2 = 0 ) )  }
 </pre>
 
@@ -1022,7 +1023,7 @@ PREFIX sparql: &lt;http://www.w3.org/ns/sparql#&gt;
       <h3>Shape Rules Evaluation</h3>
 
       <p>
-        This section defines the outcome of evaluating a rule set on given data. 
+        This section defines the outcome of evaluating a rule set on given data.
         It does not prescribe the algorithm as the method of implementation.
         An implementation can use any algorithm that generates the same outcome.
       </p>
@@ -1044,7 +1045,7 @@ where arg1, arg2 are RDF terms.
 
 Let [x/row] be
     if x is an RDF term, the [x/row] is x
-    if x is a variable then [x/row] is the value of x in the row 
+    if x is a variable then [x/row] is the value of x in the row
     ## By well-formedness, it is an error if x is not in the row.
 
 eval(F(expr1, expr2), row) = F(eval(expr1, row), eval(expr2, row))
@@ -1079,14 +1080,14 @@ for each rule element rElt:
           add row1 to T1
           endfor
     T = T1
-    endif   
+    endif
 
     if rElt is a condition expression F:
         T1 = empty list
         for each row in T:
             if ( eval(F,B) )
                 add R to T1
-                endif   
+                endif
         endfor
     T = T1
     endif
@@ -1105,7 +1106,7 @@ for each rule element rElt:
 # Evaluate rule head
 let H = empty set
 for each R in T:
-    Let S = set of triples obtained by replacing variables 
+    Let S = set of triples obtained by replacing variables
             in the triple templates of the head with values from R
     define [head(R)/row]
     H = H union S

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -6,7 +6,7 @@
 		<title>SHACL 1.2 SPARQL Extensions</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
 		<script class="remove">
-		
+
 			function prepareSyntaxRules() {
 				document.querySelectorAll("[data-syntax-rule]").forEach(element => {
 					let ruleId = element.getAttribute("data-syntax-rule");
@@ -35,7 +35,7 @@
 					element.setAttribute("id", "syntax-rule-" + ruleId);
 				});
 			}
-		
+
 			function prepareValidators() {
 				document.querySelectorAll("[data-validator]").forEach(element => {
 					let validatorId = element.getAttribute("data-validator") + "ConstraintComponent";
@@ -73,9 +73,15 @@
 				for (const tabs of document.querySelectorAll(".ds-selector-tabs")) {
 					const selectors = document.createElement("div");
 					selectors.classList.add("selectors");
+
+					// Check if JSON-LD or shaclc div exists in this tab group
+					const hasJsonld = tabs.querySelector(".jsonld");
+					const hasShaclc = tabs.querySelector(".shaclc");
+
 					selectors.innerHTML = `
 						<button class="selected" data-selects="turtle">Turtle</button>
-						<button data-selects="jsonld">JSON-LD</button>
+						${hasJsonld ? '<button data-selects="jsonld">JSON-LD</button>' : ''}
+						${hasShaclc ? '<button data-selects="shaclc">SHACL-C</button>' : ''}
 					`
 
 					tabs.prepend(selectors);
@@ -149,11 +155,11 @@
 			table.rule { background-color: #EBEBE0; }
 			table.rule td { text-align: center; }
 			td.up { border-bottom:1px solid black; }
-			
+
 			td {
 				vertical-align: top;
 			}
-			
+
 			.algorithm {
 				background: #fafafc;
 				border-left-style: solid;
@@ -162,7 +168,7 @@
 				margin-bottom: 16px;
 				padding: 8px;
 			}
-			
+
 			.arg {
 				font-weight: bold;
 				color: #000080;
@@ -175,52 +181,52 @@
 				border-color: #c0c0c0;
 				margin-bottom: 16px;
 			}
-			
+
 			.def-sparql {
 			}
-			
+
 			.def-sparql-body {
 				margin-top: 0px;
 				margin-bottom: 0px;
 			}
-			
+
 			.def-text {
 			}
-			
+
 			.def-text-body {
 			}
-			
+
 			.def-header {
 				color: #a0a0a0;
 				font-size: 16px;
 				padding-bottom: 8px;
 			}
-			
+
 			.diagram-class {
-				border: 1px solid black; 
-				border-radius: 4px; 
+				border: 1px solid black;
+				border-radius: 4px;
 				width: 360px;
 			}
-			
+
 			.diagram-class-name {
-				font-size: 16px; 
-				font-weight: bold; 
+				font-size: 16px;
+				font-weight: bold;
 				text-align: center;
 			}
-			
+
 			.diagram-class-properties {
-				border-top: 1px solid black; 
+				border-top: 1px solid black;
 			}
-			
+
 			.diagram-class-properties-start {
 				padding: 8px;
 			}
-			
+
 			.diagram-class-properties-section {
 				border-top: 1px dashed #808080;
 				padding: 8px;
 			}
-			
+
 			.example {
 				overflow-y: hidden !important;
 			}
@@ -236,17 +242,17 @@
 			.focus-node-error {
 				color: red;
 			}
-			
+
 			.component-class {
 				font-weight: bold;
 				font-size: 16px;
 			}
-			
+
 			.parameter-context {
 				font-weight: bold;
 				font-size: 16px;
 			}
-			
+
 			.parameters {
 				font-weight: bold;
 				font-size: 16px;
@@ -255,7 +261,7 @@
 			.part-header {
 				font-weight: bold;
 			}
-			
+
 			.syntax {
 				border-left-style: solid;
 				border-left-width: .5em;
@@ -264,29 +270,29 @@
 				padding: .5em 1em;
 				background-color: #f6f6f6;
 			}
-			
+
 			.syntax-rule-id {
 				padding-right: 10px;
 			}
-			
+
 			.syntax-rule-id-a {
 				white-space: nowrap;
 			}
-			
+
 			.validator-id-a {
 				font-weight: bold;
 				white-space: nowrap;
 			}
-		
+
 			.term {
 				font-style: italic;
 			}
-			
+
 			.term-def-header {
 				font-style: italic;
 				font-weight: bold;
 			}
-		
+
 			.term-table {
 				border-collapse: collapse;
 				border-color: #000000;
@@ -298,7 +304,7 @@
 				border-style: solid;
 				padding: 5px;
 			}
-		
+
 			.todo {
 				color: red;
 			}
@@ -317,37 +323,37 @@
 				margin-top: -1.5em;
 				white-space: pre;
 			}
-			
-			.data-graph { 
-				background: #eeb; 
+
+			.data-graph {
+				background: #eeb;
 				border: 1px solid #cc9;
 				margin-top: 0.3em;
 			}
-			.data-graph:before { 
-				color: #996; 
-				content: "Data graph"; 
+			.data-graph:before {
+				color: #996;
+				content: "Data graph";
 				padding-left: 0.4em;
 			}
-			
-			.results-graph { 
-				background: #edb; 
+
+			.results-graph {
+				background: #edb;
 				border: 1px solid #bbb;
 				margin-top: 0.3em;
 			}
-			.results-graph:before { 
-				color: #997; 
-				content: "Validation results"; 
+			.results-graph:before {
+				color: #997;
+				content: "Validation results";
 				padding-left: 0.4em;
 			}
-			
-			.shapes-graph { 
-				background: #deb; 
+
+			.shapes-graph {
+				background: #deb;
 				border: 1px solid #bbb;
 				margin-top: 0.3em;
 			}
-			.shapes-graph:before { 
-				color: #888; 
-				content: "Shapes graph"; 
+			.shapes-graph:before {
+				color: #888;
+				content: "Shapes graph";
 				padding-left: 0.4em;
 			}
 
@@ -436,8 +442,8 @@
 				</p>
 				<p>
 					Terminology that is linked to portions of RDF 1.2 Concepts and Abstract Syntax is used in SHACL-SPARQL as defined there.
-					Terminology that is linked to portions of SPARQL 1.2 Query Language is used in SHACL-SPARQL as defined there. 
-					Terminology that is linked to portions of SHACL 1.2 Core is used in SHACL-SPARQL as defined there. 
+					Terminology that is linked to portions of SPARQL 1.2 Query Language is used in SHACL-SPARQL as defined there.
+					Terminology that is linked to portions of SHACL 1.2 Core is used in SHACL-SPARQL as defined there.
 					A single linkage is sufficient to provide a definition for all occurences of a particular term in this document.
 				</p>
 				<p>
@@ -447,7 +453,7 @@
 				<div class="def" id="rdf-terminology">
 					<div class="term-def-header">Basic RDF Terminology</div>
 					<div>
-						This document uses the terms 
+						This document uses the terms
 						<dfn data-cite="rdf12-concepts#dfn-rdf-graph" data-lt="graph|graphs|RDF graphs">RDF graph</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-rdf-triple" data-lt="triple|triples">RDF triple</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-iri" data-lt="IRI|IRIs">IRI</dfn>,
@@ -634,7 +640,7 @@
 <pre class="def-sparql-body">
 # This box contains SPARQL or textual definitions. </pre>
 				</div>
-				
+
 				<p class="syntax">
 					Grey boxes such as this include syntax rules that apply to the <a>shapes graph</a>.
 				</p>
@@ -642,7 +648,7 @@
 				<p>
 					SPARQL variables using the <code>$</code> marker represent external <a>bindings</a> that are <a>pre-bound</a> or, in the case of <code>$PATH</code>, <a>substituted</a> in the SPARQL query before execution (as explained in <a href="#constraint-components-validation"></a>).
 				</p>
-				
+
 				<p>
 					<code>true</code> denotes the RDF term <code>"true"^^xsd:boolean</code>.
 					<code>false</code> denotes the RDF term <code>"false"^^xsd:boolean</code>.
@@ -667,9 +673,9 @@
 					A <a>shapes graph</a> is ill-formed if it contains at least one ill-formed node.
 				</p>
 			</section>
-			
+
 		</section>
-		
+
 		<section id="sparql-constraints">
 			<h2>SPARQL-based Constraints</h2>
 			<p>
@@ -759,7 +765,7 @@ ex:
 						<div class="turtle">
 ex:ValidCountry a ex:Country ;
 	ex:germanLabel "Spanien"@de .
-	  
+
 <span class="focus-node-error">ex:InvalidCountry</span> a ex:Country ;
 	ex:germanLabel "Spain"@en .
 						</div>
@@ -786,7 +792,7 @@ ex:ValidCountry a ex:Country ;
 }</pre>
 						</div>
 					</div>
-	
+
 					<div class="results-graph">
 						<div class="turtle">
 [	a sh:ValidationReport ;
@@ -901,7 +907,7 @@ ex:
 					</div>
 				</aside>
 			</section>
-			
+
 			<section id="sparql-constraints-syntax">
 				<h3>Syntax of SPARQL-based Constraints</h3>
 				<p class="syntax">
@@ -1129,7 +1135,7 @@ ex:
 				</section>
 			</section>
 		</section>
-		
+
 		<section id="sparql-constraint-components">
 			<h2>SPARQL-based Constraint Components</h2>
 			<p>
@@ -1166,8 +1172,8 @@ ex:hasPattern
 	a sh:SPARQLAskValidator ;
 	sh:message "Value does not match pattern {$pattern}" ;
 	sh:ask """
-		ASK { 
-			FILTER (!isBlank($value) &amp;&amp; 
+		ASK {
+			FILTER (!isBlank($value) &amp;&amp;
 				IF(bound($flags), regex(str($value), $pattern, $flags), regex(str($value), $pattern)))
 		}""" .
 						</div>
@@ -1219,7 +1225,7 @@ ex:hasPattern
 					and a <a>validator</a> that can be used to perform validation against either <a>node shapes</a> or <a>property shapes</a>.
 				</p>
 			</section>
-			
+
 			<section id="constraint-components-syntax">
 				<h3>Syntax of SPARQL-based Constraint Components</h3>
 				<p class="syntax">
@@ -1230,7 +1236,7 @@ ex:hasPattern
 					The mechanism to declare new <a>constraint components</a> in this document is limited to those based on SPARQL.
 					However, the general syntax of declaring parameters and validators has been designed to also work for other extension languages such as JavaScript.
 				</p>
-			
+
 				<section id="constraint-components-parameters">
 					<h4>Parameter Declarations (sh:parameter)</h4>
 					<p class="syntax">
@@ -1282,7 +1288,7 @@ ex:hasPattern
 						There may be multiple label templates for the same subject, but they should not have the same language tags.
 					</p>
 				</section>
-				
+
 				<section id="constraint-components-validators">
 					<h4>Validators</h4>
 					<p>
@@ -1462,7 +1468,7 @@ ex:LanguageConstraintComponentUsingASK
 	] ;
 	sh:labelTemplate "Values are literals with language \"{$lang}\"" ;
 	sh:validator ex:hasLang .
-	
+
 ex:hasLang
 	a sh:SPARQLAskValidator ;
 	sh:message "Values are literals with language \"{$lang}\"" ;
@@ -1530,7 +1536,7 @@ ex:hasLang
 				</p>
 				<ul>
 					<li>
-						For <a>ASK-based validators</a>: 
+						For <a>ASK-based validators</a>:
 						For each <a>value node</a> <code>v</code> where the SPARQL ASK query returns <code>false</code>
 						with <code>v</code> <a>pre-bound</a> to the variable <code>value</code>,
 						create one <a>solution</a> consisting of the bindings
@@ -1559,7 +1565,7 @@ ex:hasLang
 				</p>
 			</section>
 		</section>
-				
+
 		<section id="sparql-constraints-annotations">
 			<h2>Annotation Properties</h2>
 			<p>
@@ -1617,12 +1623,12 @@ ex:hasLang
 			</p>
 			<ol>
 				<li>Use the <a>value</a> of the property <code>sh:annotationVarName</code></li>
-				<li>If no such <a>value</a> exists, use the <a>local name</a> of the <a>value</a> of <code>sh:annotationProperty</code> 
+				<li>If no such <a>value</a> exists, use the <a>local name</a> of the <a>value</a> of <code>sh:annotationProperty</code>
 				as the variable name.</li>
 			</ol>
 			<p>
 				If a variable name could be determined, then the SHACL processor copies the <a>binding</a> for the given variable
-				as a value for the property specified using <code>sh:annotationProperty</code> 
+				as a value for the property specified using <code>sh:annotationProperty</code>
 				into the validation result that is being produced for the current <a>solution</a>.
 				If the variable has no <a>binding</a> in the result set <a>solution</a>,
 				then the <a>values</a> of <code>sh:annotationValue</code> are used, if present.
@@ -1703,7 +1709,7 @@ ex:AnnotationExample
 				<p><em>The remainder of this section is informative.</em></p>
 				<aside class="example" title="A dynamically computed property using a node expression based on a SPARQL query">
 					<p>
-						Here is an example use of a <a>select expression</a>, computing the values of a property shape for the property 
+						Here is an example use of a <a>select expression</a>, computing the values of a property shape for the property
 						"full name" as the concatenation of the <code>ex:firstName</code>, a space, and the <code>ex:lastName</code>.
 					</p>
 					<div class="shapes-graph">
@@ -1888,7 +1894,7 @@ ex:Bernd
 				<p><em>The remainder of this section is informative.</em></p>
 				<aside class="example" title="A dynamically computed property using a SPARQL expr expression">
 					<p>
-						Here is an example use of an <a>SPARQL expr expression</a>, computing the values of a property shape for the property 
+						Here is an example use of an <a>SPARQL expr expression</a>, computing the values of a property shape for the property
 						"uri length" as the length of the IRI of the focus node.
 					</p>
 					<div class="shapes-graph">
@@ -1961,7 +1967,7 @@ ex:Resource-uriLength
 				</aside>
 			</section>
 		</section>
-		
+
 		<div style="padding-top: 30px">
 			<h1 id="appendix" style="font-size: 160%; font-weight: bold">Appendix</h1>
 		</div>
@@ -2001,7 +2007,7 @@ ex:Resource-uriLength
 					</p>
 					<p>
 						Define the <em>Values Insertion</em> function <code>Replace(X, μ)</code> to
-						replace each occurence <code>Y</code> of a 
+						replace each occurence <code>Y</code> of a
 						<a data-cite="sparql12-query/#sparqlTranslateBasicGraphPatterns">Basic Graph Pattern</a>,
 						<a data-cite="sparql12-query/#sparqlTranslatePathExpressions">Property Path Expression</a>,
 						<a data-cite="sparql12-query/#sparqlTranslateGraphPatterns"><code>Graph(Var, pattern)</code></a>
@@ -2022,13 +2028,13 @@ ex:Resource-uriLength
 			</div>
 
 		</section>
-		
+
 		<section id="syntax-rules" class="appendix">
 			<h2>Summary of SHACL Syntax Rules</h2>
 			<p>
 				This section enumerates all normative syntax rules of SHACL.
 				This section is automatically generated from other parts of this spec and hyperlinks are provided back
-				into the prose if the context of the rule in unclear. 
+				into the prose if the context of the rule in unclear.
 				Nodes that violate these rules in a <a>shapes graph</a> are <a>ill-formed</a>.
 			</p>
 			<table class="term-table" id="syntax-rules-table">
@@ -2038,7 +2044,7 @@ ex:Resource-uriLength
 				</tr>
 			</table>
 		</section>
-		
+
 		<section id="sparql-definitions-core" class="appendix informative">
 			<h2>Potential SPARQL Definitions of SHACL Core Constraint Validators</h2>
 			<p>
@@ -2083,7 +2089,7 @@ WHERE {
 				</div>
 			</section>
 			<section id="sparql-definition-targetObjectsOf">
-				<h3>sh:targetObjectsOf</h3>	
+				<h3>sh:targetObjectsOf</h3>
 				<p class="def-sparql">
 					The following query expresses a potential definition of <a data-cite="shacl12-core#targetObjectsOf">objects-of targets</a> in SPARQL.
 					The variable <code>targetObjectsOf</code> will be <a>pre-bound</a> to the given value of <code>sh:targetObjectsOf</code>.
@@ -2240,7 +2246,7 @@ WHERE {
 				</div>
 			</section>
 		</section>
-		
+
 		<section id="security" class="appendix informative">
 			<h2>Security and Privacy Considerations</h2>
 			<p>
@@ -2257,7 +2263,7 @@ WHERE {
 				SHACL-SPARQL includes all the <a data-cite="sparql12-query/#security">security issues of SPARQL</a>.
 			</p>
 		</section>
-		
+
 		<section id="ack" class="appendix informative">
 			<h2>Acknowledgements</h2>
 			<p>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -81,9 +81,15 @@
         for (const tabs of document.querySelectorAll(".ds-selector-tabs")) {
           const selectors = document.createElement("div");
           selectors.classList.add("selectors");
+
+          // Check if JSON-LD or shaclc div exists in this tab group
+          const hasJsonld = tabs.querySelector(".jsonld");
+          const hasShaclc = tabs.querySelector(".shaclc");
+
           selectors.innerHTML = `
 						<button class="selected" data-selects="turtle">Turtle</button>
-						<button data-selects="jsonld">JSON-LD</button>
+						${hasJsonld ? '<button data-selects="jsonld">JSON-LD</button>' : ''}
+						${hasShaclc ? '<button data-selects="shaclc">SHACL-C</button>' : ''}
 					`;
 
           tabs.prepend(selectors);


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #615 

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-615-selection-menu/shacl12-core/index.html)
