### PR TITLE
Adds `sh:reifierShape` to the list of shape-expecting constraint parameters (for #629)

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2238,6 +2238,7 @@ ex:SomeClass-alternativePathExample
 						<li><a href="#QualifiedValueShapeConstraintComponent">sh:qualifiedValueShape</a></li>
 						<li><a href="#NodeConstraintComponent">sh:node</a></li>
 						<li><a href="#MemberShapeConstraintComponent">sh:memberShape</a></li>
+						<li><a href="#ReifierShapeConstraintComponent">sh:reifierShape</a></li>
 						<li><a href="#SomeValueConstraintComponent">sh:someValue</a></li>
 						<li><a href="#XoneConstraintComponent">sh:xone</a></li>
 					</ul>
@@ -4923,7 +4924,7 @@ ex:HandShape
 					</aside>
 				</section>
 
-				<section id="ReifierShapeShapeConstraintComponent">
+				<section id="ReifierShapeConstraintComponent">
 					<h4>sh:reifierShape, sh:reificationRequired</h4>
 					<p>
 						<code>sh:reifierShape</code> can be used to link a <a>property shape</a> with one or more <a>node shapes</a>.
@@ -5613,7 +5614,7 @@ ex:NameGroup
 				<li>Added the new value <code>sh:ByTypes</code> for <a href="#ClosedConstraintComponent"><code>sh:closed</code></a>; see <a href="https://github.com/w3c/data-shapes/issues/172">Issue 172</a></li>
 				<li>The values of <a href="#ClassConstraintComponent"><code>sh:class</code></a> and <a href="#DatatypeConstraintComponent"><code>sh:datatype</code></a> can now also be lists, indicating a union of choices; see <a href="https://github.com/w3c/data-shapes/issues/160">Issue 160</a></li>
 				<li>The values of <a href="#NodeKindConstraintComponent"><code>sh:nodeKind</code></a> can now also be lists, indicating a union of choices; see <a href="https://github.com/w3c/data-shapes/issues/407">Issue 407</a></li>
-				<li>Added the new constraint component <a href="#ReifierShapeShapeConstraintComponent"><code>sh:ReifierShape</code></a>; see <a href="https://github.com/w3c/data-shapes/issues/300">Issue 300</a></li>
+				<li>Added the new constraint component <a href="#ReifierShapeConstraintComponent"><code>sh:ReifierShape</code></a>; see <a href="https://github.com/w3c/data-shapes/issues/300">Issue 300</a></li>
 				<li>Added parameter <a href="#subClassOfInShapesGraph"></a> to look up rdfs:subClassOf triples in the union of the shapes graph and the data graph; see <a href="https://github.com/w3c/data-shapes/issues/185">Issue 185</a></li>
 				<li>Generalized <a href="#order"></a> to also allow xsd:integers; see <a href="https://github.com/w3c/data-shapes/issues/479">Issue 479</a></li>
 				<li>Added annotation property <a href="#codeIdentifier"></a>; see <a href="https://github.com/w3c/data-shapes/issues/559">Issue 559</a></li>


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #629

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-629/shacl12-core/index.html)
