### PR TITLE
#209: Added clarifying paragraph that node shapes should use rdfs:label/comment

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5310,6 +5310,11 @@ ex:RainbowPony ex:color ex:Pink .
 					Both <code>sh:name</code> and <code>sh:description</code> may have
 					multiple <a>values</a>, but should only have one <a>value</a> per language tag.
 				</p>
+				<p>
+					Note that <code>sh:name</code> and <code>sh:description</code> SHOULD NOT be used for <a>node shapes</a>.
+					For those, the properties <code>rdfs:label</code> and <code>rdfs:comment</code> are well-established
+					and already used for class definitions.
+				</p>
 			</section>
 			<section id="codeIdentifier">
 				<h3>sh:codeIdentifier</h3>


### PR DESCRIPTION

<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #209

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-209/shacl12-core/index.html#name)
