### PR TITLE
refactor: rename union/minus node expressions to join/remove in node …

### DIFF
--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1458,7 +1458,7 @@ ex:ClassShape-superClassesIncludingRoot
     sh:description "The superclasses of this, always including rdfs:Resource." ;
     sh:values <b>[
         shnex:distinct [
-            shnex:union (
+            shnex:join (
                 [
                     shnex:pathValues [ sh:zeroOrMorePath rdfs:subClassOf ] ;
                 ]
@@ -1550,7 +1550,7 @@ ex:DualCitizenShape
 											A <a>well-formed</a> <a>SHACL list</a> where each <a>member</a> is a <a>well-formed</a> <a>node expression</a>.
 										</td>
 										<td>
-											The node expressions that shall be unioned.
+											The node expressions that shall be joined.
 										</td>
 									</tr>
 								</tbody>
@@ -1558,17 +1558,17 @@ ex:DualCitizenShape
 						</span>
 					</p>
 					<div class="def" id="JoinExpression-evaluation">
-						<div class="def-header">EVALUATION OF UNION EXPRESSIONS</div>
+						<div class="def-header">EVALUATION OF JOIN EXPRESSIONS</div>
 						<p>
 							Let <code>members</code> be the <a>members</a> of the <a>value</a> of <code>shnex:join</code> in the <a>join expression</a>.
-							The <a>output nodes</a> of the <a>union expression</a> are the concatenation of all <a>output nodes</a>
+							The <a>output nodes</a> of the <a>join expression</a> are the concatenation of all <a>output nodes</a>
 							for each <a>node expression</a> <code>NE</code> in <code>members</code>, using <code>evalExpr(NE, focusGraph, focusNode, scope)</code>.
 							The order is preserved, evaluating the <code>members</code> from left to right and keeping the order of each list of output nodes.
 						</p>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
 					<p>
-						Note that a <a>union expression</a> may produce duplicate <a>output nodes</a> if the individual output nodes overlap.
+						Note that a <a>join expression</a> may produce duplicate <a>output nodes</a> if the individual output nodes overlap.
 						Use <a href="#DistinctExpression">shnex:distinct</a> to eliminate duplicates.
 					</p>
 					<p>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1527,6 +1527,33 @@ ex:DualCitizenShape
     ]</b> .
 								</div>
 							</div>
+							 <div class="evaluation">
+                                        <p>
+                                            <strong>Evaluation trace:</strong>
+                                        </p>
+                                        <p>
+                                            The evaluation proceeds as follows:
+                                        </p>
+                                        <ol>
+                                            <li>
+                                                <code>shnex:instancesOf ex:Australian</code>
+                                                produces: <code>[ex:Person1, ex:Person2, ex:Person3, ex:Person4]</code>
+                                            </li>
+                                            <li>
+                                                <code>shnex:instancesOf ex:German</code>
+                                                produces: <code>[ex:Person2, ex:Person4, ex:Person5]</code>
+                                            </li>
+                                            <li>
+                                                Compute the intersection (nodes appearing in both lists):
+                                                <code>[ex:Person2, ex:Person4]</code>
+                                            </li>
+                                        </ol>
+                                        <p>
+                                            More abstractly, the intersection of <code>[1, 2, 3, 4]</code> and <code>[2, 4, 5]</code> results in <code>[2, 4]</code>,
+                                            containing only the elements that appear in both lists.
+                                        </p>
+                                    </div>
+
 						</aside>
 					
 				</section>
@@ -1599,6 +1626,35 @@ ex:PersonShape-allRelatives
 	]</b> .
 							</div>
 						</div>
+
+    <div class="evaluation">
+                    <p>
+                        <strong>Evaluation trace:</strong>
+                    </p>
+                    <p>
+                        The evaluation proceeds as follows:
+                    </p>
+                    <ol>
+                        <li>
+                            <code>shnex:pathValues ex:parent</code> with focus node <code>ex:Person1</code>
+                            produces: <code>[ex:Parent1, ex:Parent2]</code>
+                        </li>
+                        <li>
+                            <code>shnex:pathValues ex:sibling</code> with focus node <code>ex:Person1</code>
+                            produces: <code>[ex:Sibling1, ex:Sibling2, ex:Sibling3]</code>
+                        </li>
+                        <li>
+                            Concatenate the results in order:
+                            <code>[ex:Parent1, ex:Parent2, ex:Sibling1, ex:Sibling2, ex:Sibling3]</code>
+                        </li>
+                    </ol>
+                    <p>
+                        More abstractly, concatenating <code>[1, 2]</code> and <code>[3, 4, 5]</code> results in <code>[1, 2, 3, 4, 5]</code>
+                        with all elements preserved in order from left to right.
+                    </p>
+                </div>
+
+               
 					</aside>
 	
 				</section>
@@ -1676,6 +1732,33 @@ ex:PublisherShape-availableAuthors
 		shnex:remove [ shnex:pathValues ex:authorOnLeave ] ;  
 	]</b> .
 					</div>
+				</div>
+				<div class="evaluation">
+					<p>
+						<strong>Evaluation trace:</strong>
+					</p>
+					<p>
+						The evaluation proceeds as follows:
+					</p>
+					<ol>
+						<li>
+							<code>shnex:nodes [shnex:pathValues ex:author]</code> with focus node <code>ex:PublisherA</code>
+							produces: <code>[ex:Author1, ex:Author1, ex:Author1, ex:Author2, ex:Author2]</code>
+						</li>
+						<li>
+							<code>shnex:remove [shnex:pathValues ex:authorOnLeave]</code> with focus node <code>ex:PublisherA</code>
+							produces: <code>[ex:Author1, ex:Author1]</code>
+						</li>
+						<li>
+							Remove all occurrences of <code>ex:Author1</code> from the nodes list, preserving order:
+							<code>[ex:Author2, ex:Author2]</code>
+						</li>
+					</ol>
+					<p>
+						More abstractly, removing <code>[1, 1]</code> from <code>[1, 1, 1, 2, 2]</code> results in <code>[2, 2]</code>
+						because all instances of <code>1</code> are removed (not just the first occurrence).
+					</p>
+				</div>
 				</aside>
 							</section>
 
@@ -1936,74 +2019,94 @@ ex:PersonShape-remainingChildren
 				</section>
 
 			</section>
-			<section id="library-advanced-sequence">
-				<h2>Advanced Sequence Operations</h2>
+		<section id="library-advanced-sequence">
+	<h2>Advanced Sequence Operations</h2>
 
-				<section id="FlatMapExpression">
-					<h3>FlatMap Expressions</h3>
-					<p class="syntax">
-						<span data-syntax-rule="FlatMapExpression-syntax">
-							A <a>blank node</a> that is the <a>subject</a> of the following properties
-							is called a <dfn>flatMap expression</dfn>,
-							with the <a>function name</a> <code>shnex:FlatMapExpression</code>:
-							<table class="term-table">
-								<thead>
-									<th>Property</th>
-									<th>Constraints</th>
-									<th>Description</th>
-								</thead>
-								<tbody>
-									<tr>
-										<td><b><code>shnex:flatMap</code></b></td>
-										<td>
-											A <a>well-formed</a> <a>node expression</a>.
-										</td>
-										<td>
-											The node expression that is applied to each input node.
-										</td>
-									</tr>
-									<tr>
-										<td><b><code>shnex:nodes</code></b></td>
-										<td>
-											A <a>well-formed</a> <a>node expression</a>.
-										</td>
-										<td>
-											The input nodes. If omitted, defaults to the focus node.
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</span>
-					</p>
-					<div class="def" id="FlatMapExpression-evaluation">
-						<div class="def-header">EVALUATION OF FLATMAP EXPRESSIONS</div>
-						<p>
-							Let <code>flatMap</code> be the <a>value</a> of <code>shnex:flatMap</code>
-							and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in a <a>flatMap expression</a>.
-							If <code>shnex:nodes</code> is not specified, let <code>nodes</code> be the focus node.
-							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
-							For each node <code>n</code> in <code>N</code>, let <code>M</code> be the <a>output nodes</a> of 
-							<code>evalExpr(flatMap, focusGraph, n, scope)</code>.
-							The <a>output nodes</a> of the <a>flatMap expression</a> are produced by concatenating all sequences 
-							<code>M_n</code> in the order of the corresponding nodes <code>n</code> in <code>N</code>.
-						</p>
-					</div>
-					<p><em>The remainder of this section is informative.</em></p>
-					<p>
-						The <code>shnex:flatMap</code> operation applies an expression to each input node and flattens the results
-						into a single sequence. This is particularly useful when combining results from multiple path traversals
-						or when working with nested structures.
-					</p>
-					<p id="FlatMapExpressionExample">
-						The following example illustrates the use of <code>shnex:flatMap</code> to derive a property
-						<code>ex:allSkills</code> that collects all skills from all employees of a company.
-						The flatMap operation applies a path expression to each employee and flattens the resulting
-						skill sequences into a single comprehensive list.
-					</p>
-					<p>
-						<aside class="example" title="Using shnex:flatMap to collect skills from all employees">
-							<div class="shapes-graph">
-								<div class="turtle">
+	<section id="FlatMapExpression">
+		<h3>FlatMap Expressions</h3>
+		<p class="syntax">
+			<span data-syntax-rule="FlatMapExpression-syntax">
+				A <a>blank node</a> that is the <a>subject</a> of the following properties
+				is called a <dfn>flatMap expression</dfn>,
+				with the <a>function name</a> <code>shnex:FlatMapExpression</code>:
+				<table class="term-table">
+					<thead>
+						<tr>
+							<th>Property</th>
+							<th>Constraints</th>
+							<th>Description</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td><b><code>shnex:flatMap</code></b></td>
+							<td>
+								A <a>well-formed</a> <a>node expression</a>.
+							</td>
+							<td>
+								The <a>node expression</a> that is applied to each input node.
+								The <a>node expression</a> that is applied to each input node.
+							</td>
+						</tr>
+						<tr>
+							<td><b><code>shnex:nodes</code></b></td>
+							<td>
+								A <a>well-formed</a> <a>node expression</a>.
+							</td>
+							<td>
+								The input nodes. If omitted, defaults to the focus node.
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</span>
+		</p>
+		<div class="def" id="FlatMapExpression-evaluation">
+			<div class="def-header">EVALUATION OF FLATMAP EXPRESSIONS</div>
+			<p>
+				Let <code>flatMap</code> be the <a>value</a> of <code>shnex:flatMap</code>
+				and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in a <a>flatMap expression</a>.
+				If <code>shnex:nodes</code> is not specified, let <code>nodes</code> be the focus node.
+			</p>
+			<p>
+				Let <code>N</code> be the <a>output nodes</a> of 
+				<code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
+			</p>
+			<p>
+				For each node <code>n</code> in <code>N</code>, let <code>M<sub>n</sub></code> be the <a>output nodes</a> of 
+				<code>evalExpr(flatMap, focusGraph, <var>n</var>, scope)</code>.
+			</p>
+			<p>
+				The <a>output nodes</a> of the <a>flatMap expression</a> are produced by concatenating all sequences 
+				<code>M<sub>n</sub></code> in the order of the corresponding nodes <code>n</code> in <code>N</code>.
+			</p>
+		</div>
+		<p><em>The remainder of this section is informative.</em></p>
+		<p>
+			The <code>shnex:flatMap</code> operation applies an expression to each input node and flattens the results
+			into a single sequence. This is particularly useful when combining results from multiple path traversals
+			or when working with nested structures.
+		</p>
+		<p>
+			A key aspect of <code>shnex:flatMap</code> is that the focus node changes for each iteration.
+			For each node produced by the <code>shnex:nodes</code> expression, that node becomes the focus node
+			when evaluating the <code>shnex:flatMap</code> expression. This allows relative path expressions to work correctly
+			at each level of nesting. The output sequences are then concatenated in order, preserving both the order
+			of input nodes and the order of results within each output sequence.
+		</p>
+		<p>
+			Unlike operations that remove duplicates, <code>shnex:flatMap</code> preserves all results, including duplicates.
+			If duplicate elimination is desired, use <code>shnex:distinct</code> to post-process the results.
+		</p>
+		<p id="FlatMapExpressionExample">
+			The following example illustrates the use of <code>shnex:flatMap</code> to derive a property
+			<code>ex:allSkills</code> that collects all skills from all employees of a company.
+			For each employee of the company, the flatMap operation applies a path expression to retrieve their skills,
+			and flattens the resulting skill sequences into a single comprehensive list.
+		</p>
+		<aside class="example" title="Using shnex:flatMap to collect skills from all employees">
+			<div class="shapes-graph">
+				<div class="turtle">
 ex:CompanyShape
     a sh:NodeShape ;
     sh:targetClass ex:Company ;
@@ -2013,22 +2116,85 @@ ex:CompanyShape-allSkills
     a sh:PropertyShape ;
     sh:path ex:allSkills ;
     sh:name "all skills" ;
-    sh:values [
-		shnex:nodes [
-			shnex:pathValues ex:employee ;
-		] ;
-		shnex:flatMap [
-			shnex:pathValues ex:skill ;
-		] ;
-    ] .
-								</div>
-								<div class="jsonld">
-									<equivalent jsonld>
-								</div>
-							</div>
-						</aside>
+    sh:values <b>[
+        shnex:nodes [
+            shnex:pathValues ex:employee ;
+        ] ;
+        shnex:flatMap [
+            shnex:pathValues ex:skill ;
+        ] ;
+    ]</b> .
+				</div>
+			</div>
+				<div class="data-graph">
+					<div class="turtle">
+ex:CompanyA
+    ex:employee ex:Employee1 ;
+    ex:employee ex:Employee2 ;
+    ex:employee ex:Employee3 .
+
+ex:Employee1
+    ex:skill "Java"@en ;
+    ex:skill "Python"@en ;
+    ex:skill "SQL"@en .
+
+ex:Employee2
+    ex:skill "Python"@en ;
+    ex:skill "JavaScript"@en .
+
+ex:Employee3
+    ex:skill "Java"@en ;
+    ex:skill "DevOps"@en .
+					</div>
+				</div>
+				<div class="evaluation">
+					<p>
+						<strong>Evaluation trace:</strong>
 					</p>
-				</section>
+					<ol>
+						<li>
+							<code>shnex:nodes [shnex:pathValues ex:employee]</code> with focus node <code>ex:CompanyA</code>
+							produces: <code>[ex:Employee1, ex:Employee2, ex:Employee3]</code>
+						</li>
+						<li>
+							For each employee <code>n</code>, evaluate <code>shnex:flatMap [shnex:pathValues ex:skill]</code>
+							with focus node <code>n</code>:
+							<ul>
+								<li><code>ex:Employee1</code> → <code>["Java", "Python", "SQL"]</code></li>
+								<li><code>ex:Employee2</code> → <code>["Python", "JavaScript"]</code></li>
+								<li><code>ex:Employee3</code> → <code>["Java", "DevOps"]</code></li>
+							</ul>
+						</li>
+						<li>
+							Combine all results in order:
+							<code>["Java", "Python", "SQL", "Python", "JavaScript", "Java", "DevOps"]</code>
+						</li>
+						<li>Optional: Refine the resulting sequence using for example:
+							<ul>
+								<li>
+									<code>shnex:distinct</code> to remove duplicates from the flattened result.
+								</li>
+								<li>
+									<code>shnex:filterShape</code> to apply an additional shape constraint to the
+									flattened nodes.
+								</li>
+								<li>
+									<code>shnex:limit</code> to restrict the flattened result to the first N nodes.
+								</li>
+
+							</ul>
+
+						</li>
+					</ol>
+			
+					
+				</div>
+			</div>
+		</aside>
+
+		
+	</section>
+
 
 				<section id="FindFirstExpression">
 					<h3>FindFirst Expressions</h3>
@@ -2102,12 +2268,12 @@ ex:CompanyShape-seniorEmployee
     sh:class ex:Employee ;
     sh:maxCount 1 ;
     sh:name "senior employee" ;
-    sh:values [
+    sh:values <b>[
 		shnex:nodes [
 			shnex:pathValues ex:employee ;
 		] ;
 		shnex:findFirst ex:SeniorEmployeeShape ;
-    ] .
+    ]</b> .
 
 ex:SeniorEmployeeShape
     a sh:NodeShape ;
@@ -2117,9 +2283,7 @@ ex:SeniorEmployeeShape
         sh:minInclusive 5 ;
     ] .
 								</div>
-								<div class="jsonld">
-									<equivalent jsonld>
-								</div>
+								
 							</div>
 						</aside>
 					</p>
@@ -2198,12 +2362,12 @@ ex:CompanyShape-allEmployeesActive
     sh:datatype xsd:boolean ;
     sh:maxCount 1 ;
     sh:name "all employees active" ;
-    sh:values [
+    sh:values <b> [
 		shnex:nodes [
 			shnex:pathValues ex:employee ;
 		] ;
 		shnex:matchAll ex:ActiveEmployeeShape ;
-    ] .
+    ]</b> .
 
 ex:ActiveEmployeeShape
     a sh:NodeShape ;
@@ -2212,9 +2376,7 @@ ex:ActiveEmployeeShape
         sh:hasValue true ;
     ] .
 								</div>
-								<div class="jsonld">
-									<equivalent jsonld>
-								</div>
+						
 							</div>
 						</aside>
 					</p>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -2101,6 +2101,10 @@ ex:CompanyShape-minStartDate
 
 			</section>
 
+
+
+			
+
 			<section id="misc">
 				<h2>Miscellaneous Node Expressions</h2>
 				<p>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -891,6 +891,15 @@ ex:ClassShape-superClassesExceptRoots
 							for the (only) member of <code>N</code>.
 						</p>
 					</div>
+					
+					<div class="note">
+						<p><strong>Important:</strong> Note the distinction between <code>sh:path</code> and <code>shnex:pathValues</code>:</p>
+						<ul>
+							<li><code>sh:path</code> is used in <strong>property shapes</strong> to specify the property path that will be constrained during validation. It defines the property or path to which the shape's constraints apply.</li>
+							<li><code>shnex:pathValues</code> is used in <strong>node expressions</strong> to specify the property path that will be traversed to generate a sequence of values. It produces the actual values found by following the path.</li>
+						</ul>
+						<p>For example, <code>sh:path ex:name</code> in a property shape constrains the values of the <code>ex:name</code> property, while <code>shnex:pathValues ex:name</code> in a node expression generates a sequence containing all values of the <code>ex:name</code> property.</p>
+					</div>
 					<p><em>The remainder of this section is informative.</em></p>
 					<p>
 						Note that by definition, the <a>value nodes</a> of a property shape may be derived properties,

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1242,7 +1242,7 @@ ex:DualCitizenShape
 					<p class="syntax">
 						<span data-syntax-rule="JoinExpression-syntax">
 							A <a>blank node</a> that is the <a>subject</a> of the following properties
-							is called a <dfn>join expression</dfn> with the <a>function name</a> <code>shnex:JoinExpression</code>:
+							is called a <dfn>join expression</dfn>, with the <a>function name</a> <code>shnex:JoinExpression</code>:
 							<table class="term-table">
 								<thead>
 									<th>Property</th>
@@ -1287,7 +1287,7 @@ ex:DualCitizenShape
 					<p class="syntax">
 						<span data-syntax-rule="RemoveExpression-syntax">
 							A <a>blank node</a> that is the <a>subject</a> of the following properties
-							is called a <dfn>remove expression</dfn> with the <a>function name</a> <code>shnex:RemoveExpression</code>:
+							is called a <dfn>remove expression</dfn>, with the <a>function name</a> <code>shnex:RemoveExpression</code>:
 							<table class="term-table">
 								<thead>
 									<th>Property</th>
@@ -1600,7 +1600,8 @@ ex:PersonShape-remainingChildren
 					<p class="syntax">
 						<span data-syntax-rule="FlatMapExpression-syntax">
 							A <a>blank node</a> that is the <a>subject</a> of the following properties
-							is called a <dfn>flatMap expression</dfn> with the <a>function name</a> <code>shnex:FlatMapExpression</code>:
+							is called a <dfn>flatMap expression</dfn>,
+							with the <a>function name</a> <code>shnex:FlatMapExpression</code>:
 							<table class="term-table">
 								<thead>
 									<th>Property</th>
@@ -1690,7 +1691,8 @@ ex:CompanyShape-allSkills
 					<p class="syntax">
 						<span data-syntax-rule="FindFirstExpression-syntax">
 							A <a>blank node</a> that is the <a>subject</a> of the following properties
-							is called a <dfn>findFirst expression</dfn> with the <a>function name</a> <code>shnex:FindFirstExpression</code>:
+							is called a <dfn>findFirst expression</dfn>,
+							with the <a>function name</a> <code>shnex:FindFirstExpression</code>:
 							<table class="term-table">
 								<thead>
 									<th>Property</th>
@@ -1738,7 +1740,7 @@ ex:CompanyShape-allSkills
 					</p>
 					<p id="FindFirstExpressionExample">
 						The following example illustrates the use of <code>shnex:findFirst</code> to derive a property
-						<code>ex:seniorEmployee</code> that finds the first employee with more than 5 years of experience.
+						<code>ex:seniorEmployee</code> that finds the first employee with more than five years of experience.
 						The findFirst operation tests each employee against a shape that validates their years of service.
 					</p>
 					<p>
@@ -1784,7 +1786,8 @@ ex:SeniorEmployeeShape
 					<p class="syntax">
 						<span data-syntax-rule="MatchAllExpression-syntax">
 							A <a>blank node</a> that is the <a>subject</a> of the following properties
-							is called a <dfn>matchAll expression</dfn> with the <a>function name</a> <code>shnex:MatchAllExpression</code>:
+							is called a <dfn>matchAll expression</dfn>,
+							with the <a>function name</a> <code>shnex:MatchAllExpression</code>:
 							<table class="term-table">
 								<thead>
 									<th>Property</th>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1583,7 +1583,292 @@ ex:PersonShape-remainingChildren
 				</section>
 
 			</section>
+			<section id="library-advanced-sequence">
+				<h2>Advanced Sequence Operations</h2>
+				<p>
+					This section describes advanced node expression functions for sequence manipulation,
+					providing enhanced operations for complex sequence processing scenarios.
+				</p>
 
+				<section id="FlatMapExpression">
+					<h3>FlatMap Expressions</h3>
+					<p class="syntax">
+						<span data-syntax-rule="FlatMapExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>flatMap expression</dfn> with the <a>function name</a> <code>shnex:FlatMapExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>shnex:flatMap</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The node expression that is applied to each input node.
+										</td>
+									</tr>
+									<tr>
+										<td><b><code>shnex:nodes</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The input nodes. If omitted, defaults to the focus node.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="FlatMapExpression-evaluation">
+						<div class="def-header">EVALUATION OF FLATMAP EXPRESSIONS</div>
+						<p>
+							Let <code>mapper</code> be the <a>value</a> of <code>shnex:flatMap</code>
+							and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in a <a>flatMap expression</a>.
+							If <code>shnex:nodes</code> is not specified, let <code>nodes</code> be the focus node.
+							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
+							For each node <code>n</code> in <code>N</code>, let <code>M_n</code> be the <a>output nodes</a> of 
+							<code>evalExpr(mapper, focusGraph, n, scope)</code>.
+							The <a>output nodes</a> of the <a>flatMap expression</a> are produced by concatenating all sequences 
+							<code>M_n</code> in the order of the corresponding nodes <code>n</code> in <code>N</code>.
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p>
+						The <code>shnex:flatMap</code> operation applies an expression to each input node and flattens the results
+						into a single sequence. This is particularly useful when combining results from multiple path traversals
+						or when working with nested structures.
+					</p>
+					<p id="FlatMapExpressionExample">
+						The following example illustrates the use of <code>shnex:flatMap</code> to derive a property
+						<code>ex:allSkills</code> that collects all skills from all employees of a company.
+						The flatMap operation applies a path expression to each employee and flattens the resulting
+						skill sequences into a single comprehensive list.
+					</p>
+					<p>
+						<aside class="example" title="Using shnex:flatMap to collect skills from all employees">
+							<div class="shapes-graph">
+								<div class="turtle">
+ex:CompanyShape
+    a sh:NodeShape ;
+    sh:targetClass ex:Company ;
+    sh:property ex:CompanyShape-allSkills .
+
+ex:CompanyShape-allSkills
+    a sh:PropertyShape ;
+    sh:path ex:allSkills ;
+    sh:name "all skills" ;
+    sh:values [
+		shnex:nodes [
+			shnex:pathValues ex:employee ;
+		] ;
+		shnex:flatMap [
+			shnex:pathValues ex:skill ;
+		] ;
+    ] .
+								</div>
+								<div class="jsonld">
+									<equivalent jsonld>
+								</div>
+							</div>
+						</aside>
+					</p>
+				</section>
+
+				<section id="FindFirstExpression">
+					<h3>FindFirst Expressions</h3>
+					<p class="syntax">
+						<span data-syntax-rule="FindFirstExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>findFirst expression</dfn> with the <a>function name</a> <code>shnex:FindFirstExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>shnex:findFirst</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>shape</a>.
+										</td>
+										<td>
+											The shape that the matching node must conform to.
+										</td>
+									</tr>
+									<tr>
+										<td><b><code>shnex:nodes</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The input nodes. If omitted, defaults to the focus node.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="FindFirstExpression-evaluation">
+						<div class="def-header">EVALUATION OF FINDFIRST EXPRESSIONS</div>
+						<p>
+							Let <code>shape</code> be the <a>value</a> of <code>shnex:findFirst</code>
+							and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in a <a>findFirst expression</a>.
+							If <code>shnex:nodes</code> is not specified, let <code>nodes</code> be the focus node.
+							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
+							The <a>output nodes</a> of the <a>findFirst expression</a> contain exactly the first node <code>n</code> 
+							in <code>N</code> that <a>conforms</a> to the <a>shape</a> <code>shape</code>, 
+							or an empty sequence if no such node exists.
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p>
+						The <code>shnex:findFirst</code> operation finds the first node in a sequence that conforms to a given shape.
+					</p>
+					<p id="FindFirstExpressionExample">
+						The following example illustrates the use of <code>shnex:findFirst</code> to derive a property
+						<code>ex:seniorEmployee</code> that finds the first employee with more than 5 years of experience.
+						The findFirst operation tests each employee against a shape that validates their years of service.
+					</p>
+					<p>
+						<aside class="example" title="Using shnex:findFirst to find the first senior employee">
+							<div class="shapes-graph">
+								<div class="turtle">
+ex:CompanyShape
+    a sh:NodeShape ;
+    sh:targetClass ex:Company ;
+    sh:property ex:CompanyShape-seniorEmployee .
+
+ex:CompanyShape-seniorEmployee
+    a sh:PropertyShape ;
+    sh:path ex:seniorEmployee ;
+    sh:class ex:Employee ;
+    sh:maxCount 1 ;
+    sh:name "senior employee" ;
+    sh:values [
+		shnex:nodes [
+			shnex:pathValues ex:employee ;
+		] ;
+		shnex:findFirst ex:SeniorEmployeeShape ;
+    ] .
+
+ex:SeniorEmployeeShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path ex:yearsOfService ;
+        sh:datatype xsd:integer ;
+        sh:minInclusive 5 ;
+    ] .
+								</div>
+								<div class="jsonld">
+									<equivalent jsonld>
+								</div>
+							</div>
+						</aside>
+					</p>
+				</section>
+
+				<section id="MatchAllExpression">
+					<h3>MatchAll Expressions</h3>
+					<p class="syntax">
+						<span data-syntax-rule="MatchAllExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>matchAll expression</dfn> with the <a>function name</a> <code>shnex:MatchAllExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>shnex:matchAll</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>shape</a>.
+										</td>
+										<td>
+											The shape that all input nodes must conform to.
+										</td>
+									</tr>
+									<tr>
+										<td><b><code>shnex:nodes</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The input nodes. If omitted, defaults to the focus node.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="MatchAllExpression-evaluation">
+						<div class="def-header">EVALUATION OF MATCHALL EXPRESSIONS</div>
+						<p>
+							Let <code>shape</code> be the <a>value</a> of <code>shnex:matchAll</code>
+							and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in the <a>matchAll expression</a>.
+							If <code>shnex:nodes</code> is not specified, let <code>nodes</code> be the focus node.
+							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
+							The <a>output nodes</a> of the <a>matchAll expression</a> contain the boolean <code>true</code> if
+							every node <code>n</code> in <code>N</code> <a>conforms</a> to the <a>shape</a> <code>shape</code>;
+							otherwise the output contains the boolean <code>false</code>.
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p>
+						The <code>shnex:matchAll</code> operation returns <code>true</code> if all nodes in a sequence conform to a given shape,
+						<code>false</code> otherwise.
+					</p>
+					<p id="MatchAllExpressionExample">
+						The following example illustrates the use of <code>shnex:matchAll</code> to derive a property
+						<code>ex:allEmployeesActive</code> that checks whether all employees of a company are currently active.
+						The matchAll operation tests each employee against a shape that validates their active status.
+					</p>
+					<p>
+						<aside class="example" title="Using shnex:matchAll to verify all employees are active">
+							<div class="shapes-graph">
+								<div class="turtle">
+ex:CompanyShape
+    a sh:NodeShape ;
+    sh:targetClass ex:Company ;
+    sh:property ex:CompanyShape-allEmployeesActive .
+
+ex:CompanyShape-allEmployeesActive
+    a sh:PropertyShape ;
+    sh:path ex:allEmployeesActive ;
+    sh:datatype xsd:boolean ;
+    sh:maxCount 1 ;
+    sh:name "all employees active" ;
+    sh:values [
+		shnex:nodes [
+			shnex:pathValues ex:employee ;
+		] ;
+		shnex:matchAll ex:ActiveEmployeeShape ;
+    ] .
+
+ex:ActiveEmployeeShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path ex:isActive ;
+        sh:hasValue true ;
+    ] .
+								</div>
+								<div class="jsonld">
+									<equivalent jsonld>
+								</div>
+							</div>
+						</aside>
+					</p>
+				</section>
+
+			</section>
 			<section id="library-aggregation">
 				<h2>Aggregation Expressions</h2>
 

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1572,8 +1572,35 @@ ex:DualCitizenShape
 					Use <a href="#DistinctExpression">shnex:distinct</a> to eliminate duplicates.
 				</p>
 				<p>
-					The <a href="#DistinctExpressionExample">Example for <code>shnex:distinct</code></a> uses <code>shnex:concat</code>.
-					</p>
+					The following example declares a derived property <code>ex:allRelatives</code>
+					that concatenates the values of <code>ex:parent</code> and <code>ex:sibling</code>.
+					The <code>shnex:concat</code> expression takes a list of node expressions and returns
+					all nodes from each expression in sequence from left to right.
+				</p>
+				
+					<aside class="example" title="Using shnex:concat to combine results from multiple node expressions">
+						<div class="shapes-graph">
+							<div class="turtle">
+ex:PersonShape
+	a sh:NodeShape ;
+	sh:targetClass ex:Person ;
+	sh:property ex:PersonShape-allRelatives .
+
+ex:PersonShape-allRelatives
+	a sh:PropertyShape ;
+	sh:path ex:allRelatives ;
+	sh:class ex:Person ;
+	sh:name "all relatives" ;
+	sh:values <b>[
+		shnex:concat (
+			[ shnex:pathValues ex:parent ]
+			[ shnex:pathValues ex:sibling ]
+		)
+	]</b> .
+							</div>
+						</div>
+					</aside>
+	
 				</section>
 
 				<section id="RemoveExpression">
@@ -1614,9 +1641,9 @@ ex:DualCitizenShape
 					<div class="def" id="RemoveExpression-evaluation">
 						<div class="def-header">EVALUATION OF REMOVE EXPRESSIONS</div>
 						<p>
-							Let <code>toRemove</code> be the <a>value</a> of <code>shnex:remove</code>
+							Let <code>remove</code> be the <a>value</a> of <code>shnex:remove</code>
 							and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in the <a>remove expression</a>.
-							Let <code>M</code> be the <a>output nodes</a> of <code>evalExpr(toRemove, focusGraph, focusNode, scope)</code>.
+							Let <code>M</code> be the <a>output nodes</a> of <code>evalExpr(remove, focusGraph, focusNode, scope)</code>.
 							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
 							The <a>output nodes</a> of the <a>remove expression</a> are the <a>nodes</a> in <code>N</code>
 							except those that are also in <code>M</code>, preserving the order of <code>N</code>.
@@ -1624,10 +1651,33 @@ ex:DualCitizenShape
 						</p>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
-					<p>
-						The <a href="#ListExpressionExample">List Expression example</a> uses <code>shnex:remove</code>.
-					</p>
-				</section>
+			<p>
+			The following example declares a derived property <code>ex:availableAuthors</code>
+			that returns all persons who are authors, except those who are currently on leave.
+			The <code>shnex:remove</code> expression takes the nodes from <code>shnex:nodes</code> (all authors) 
+			and removes the nodes returned by the <code>shnex:remove</code> expression (authors on leave).
+		</p>
+		
+			<aside class="example" title="Using shnex:remove to exclude unavailable authors from a list">
+				<div class="shapes-graph">
+					<div class="turtle">
+ex:PublisherShape
+	a sh:NodeShape ;
+	sh:targetClass ex:Publisher ;
+	sh:property ex:PublisherShape-availableAuthors .
+
+ex:PublisherShape-availableAuthors
+	a sh:PropertyShape ;
+	sh:path ex:availableAuthors ;
+	sh:class ex:Person ;
+	sh:description "Authors who are currently available (not on leave)." ;
+	sh:values <b>[
+		shnex:nodes  [ shnex:pathValues ex:author ] ; 		  
+		shnex:remove [ shnex:pathValues ex:authorOnLeave ] ;  
+	]</b> .
+					</div>
+				</aside>
+							</section>
 
 				<section id="FilterShapeExpression">
 					<h3>Filter Shape Expressions</h3>
@@ -1928,12 +1978,12 @@ ex:PersonShape-remainingChildren
 					<div class="def" id="FlatMapExpression-evaluation">
 						<div class="def-header">EVALUATION OF FLATMAP EXPRESSIONS</div>
 						<p>
-							Let <code>mapper</code> be the <a>value</a> of <code>shnex:flatMap</code>
+							Let <code>flatMap</code> be the <a>value</a> of <code>shnex:flatMap</code>
 							and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in a <a>flatMap expression</a>.
 							If <code>shnex:nodes</code> is not specified, let <code>nodes</code> be the focus node.
 							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
-							For each node <code>n</code> in <code>N</code>, let <code>M_n</code> be the <a>output nodes</a> of 
-							<code>evalExpr(mapper, focusGraph, n, scope)</code>.
+							For each node <code>n</code> in <code>N</code>, let <code>M</code> be the <a>output nodes</a> of 
+							<code>evalExpr(flatMap, focusGraph, n, scope)</code>.
 							The <a>output nodes</a> of the <a>flatMap expression</a> are produced by concatenating all sequences 
 							<code>M_n</code> in the order of the corresponding nodes <code>n</code> in <code>N</code>.
 						</p>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1594,10 +1594,6 @@ ex:PersonShape-remainingChildren
 			</section>
 			<section id="library-advanced-sequence">
 				<h2>Advanced Sequence Operations</h2>
-				<p>
-					This section describes advanced node expression functions for sequence manipulation,
-					providing enhanced operations for complex sequence processing scenarios.
-				</p>
 
 				<section id="FlatMapExpression">
 					<h3>FlatMap Expressions</h3>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1128,7 +1128,7 @@ ex:ClassShape-superClassesExceptRoots
 		] ;
 		# This removes any superclasses that are in the list below
 		shnex:remove <b>( owl:Thing rdfs:Resource )</b> ;
-	] .</b>
+	] .
 								</div>
 							</div>
 						</aside>
@@ -1708,7 +1708,7 @@ ex:PersonShape-allRelatives
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
 			<p>
-			The following example declares a derived property <code>ex:availableAuthors</code>
+			The following example declares a derived property, <code>ex:availableAuthors</code>,
 			that returns all persons who are authors, except those who are currently on leave.
 			The <code>shnex:remove</code> expression takes the nodes from <code>shnex:nodes</code> (all authors) 
 			and removes the nodes returned by the <code>shnex:remove</code> expression (authors on leave).
@@ -2027,7 +2027,7 @@ ex:PersonShape-remainingChildren
 		<p class="syntax">
 			<span data-syntax-rule="FlatMapExpression-syntax">
 				A <a>blank node</a> that is the <a>subject</a> of the following properties
-				is called a <dfn>flatMap expression</dfn>,
+				is called a <dfn>flat map expression</dfn>,
 				with the <a>function name</a> <code>shnex:FlatMapExpression</code>:
 				<table class="term-table">
 					<thead>
@@ -2045,7 +2045,6 @@ ex:PersonShape-remainingChildren
 							</td>
 							<td>
 								The <a>node expression</a> that is applied to each input node.
-								The <a>node expression</a> that is applied to each input node.
 							</td>
 						</tr>
 						<tr>
@@ -2062,10 +2061,10 @@ ex:PersonShape-remainingChildren
 			</span>
 		</p>
 		<div class="def" id="FlatMapExpression-evaluation">
-			<div class="def-header">EVALUATION OF FLATMAP EXPRESSIONS</div>
+			<div class="def-header">EVALUATION OF FLAT MAP EXPRESSIONS</div>
 			<p>
 				Let <code>flatMap</code> be the <a>value</a> of <code>shnex:flatMap</code>
-				and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in a <a>flatMap expression</a>.
+				and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in a <a>flat map expression</a>.
 				If <code>shnex:nodes</code> is not specified, let <code>nodes</code> be the focus node.
 			</p>
 			<p>
@@ -2077,7 +2076,7 @@ ex:PersonShape-remainingChildren
 				<code>evalExpr(flatMap, focusGraph, <var>n</var>, scope)</code>.
 			</p>
 			<p>
-				The <a>output nodes</a> of the <a>flatMap expression</a> are produced by concatenating all sequences 
+				The <a>output nodes</a> of the <a>flat map expression</a> are produced by concatenating all sequences 
 				<code>M<sub>n</sub></code> in the order of the corresponding nodes <code>n</code> in <code>N</code>.
 			</p>
 		</div>
@@ -2201,7 +2200,7 @@ ex:Employee3
 					<p class="syntax">
 						<span data-syntax-rule="FindFirstExpression-syntax">
 							A <a>blank node</a> that is the <a>subject</a> of the following properties
-							is called a <dfn>findFirst expression</dfn>,
+							is called a <dfn>find first expression</dfn>,
 							with the <a>function name</a> <code>shnex:FindFirstExpression</code>:
 							<table class="term-table">
 								<thead>
@@ -2233,13 +2232,13 @@ ex:Employee3
 						</span>
 					</p>
 					<div class="def" id="FindFirstExpression-evaluation">
-						<div class="def-header">EVALUATION OF FINDFIRST EXPRESSIONS</div>
+						<div class="def-header">EVALUATION OF FIND FIRST EXPRESSIONS</div>
 						<p>
 							Let <code>shape</code> be the <a>value</a> of <code>shnex:findFirst</code>
-							and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in a <a>findFirst expression</a>.
+							and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in a <a>find first expression</a>.
 							If <code>shnex:nodes</code> is not specified, let <code>nodes</code> be the focus node.
 							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
-							The <a>output nodes</a> of the <a>findFirst expression</a> contain exactly the first node <code>n</code> 
+							The <a>output nodes</a> of the <a>find first expression</a> contain exactly the first node <code>n</code> 
 							in <code>N</code> that <a>conforms</a> to the <a>shape</a> <code>shape</code>, 
 							or an empty sequence if no such node exists.
 						</p>
@@ -2251,7 +2250,7 @@ ex:Employee3
 					<p id="FindFirstExpressionExample">
 						The following example illustrates the use of <code>shnex:findFirst</code> to derive a property
 						<code>ex:seniorEmployee</code> that finds the first employee with more than five years of experience.
-						The <code>findFirst</code> operation tests each employee against a shape that validates their years of service.
+						The <code>shnex:findFirst</code> operation tests each employee against a shape that validates their years of service.
 					</p>
 					<p>
 						<aside class="example" title="Using shnex:findFirst to find the first senior employee">
@@ -2294,7 +2293,7 @@ ex:SeniorEmployeeShape
 					<p class="syntax">
 						<span data-syntax-rule="MatchAllExpression-syntax">
 							A <a>blank node</a> that is the <a>subject</a> of the following properties
-							is called a <dfn>matchAll expression</dfn>,
+							is called a <dfn>match all expression</dfn>,
 							with the <a>function name</a> <code>shnex:MatchAllExpression</code>:
 							<table class="term-table">
 								<thead>
@@ -2326,13 +2325,13 @@ ex:SeniorEmployeeShape
 						</span>
 					</p>
 					<div class="def" id="MatchAllExpression-evaluation">
-						<div class="def-header">EVALUATION OF MATCHALL EXPRESSIONS</div>
+						<div class="def-header">EVALUATION OF MATCH ALL EXPRESSIONS</div>
 						<p>
 							Let <code>shape</code> be the <a>value</a> of <code>shnex:matchAll</code>
-							and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in the <a>matchAll expression</a>.
+							and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in the <a>match all expression</a>.
 							If <code>shnex:nodes</code> is not specified, let <code>nodes</code> be the focus node.
 							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
-							The <a>output nodes</a> of the <a>matchAll expression</a> contain the boolean <code>true</code> if
+							The <a>output nodes</a> of the <a>match all expression</a> contain the boolean <code>true</code> if
 							every node <code>n</code> in <code>N</code> <a>conforms</a> to the <a>shape</a> <code>shape</code>;
 							otherwise the output contains the boolean <code>false</code>.
 						</p>
@@ -2345,7 +2344,7 @@ ex:SeniorEmployeeShape
 					<p id="MatchAllExpressionExample">
 						The following example illustrates the use of <code>shnex:matchAll</code> to derive a property
 						<code>ex:allEmployeesActive</code> that checks whether all employees of a company are currently active.
-						The matchAll operation tests each employee against a shape that validates their active status.
+						The match all operation tests each employee against a shape that validates their active status.
 					</p>
 					<p>
 						<aside class="example" title="Using shnex:matchAll to verify all employees are active">

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1437,7 +1437,7 @@ ex:City-fillColor
 					<p><em>The remainder of this section is informative.</em></p>
 					<p id="DistinctExpressionExample">
 						The following example declares a derived property <code>ex:superClassesIncludingRoot</code>
-						that is computed as the <a href="#JoinExpression">join</a> of the (transitive) values of <code>rdfs:subClassOf</code>
+						that is computed as the <a href="#ConcatExpression">concat</a> of the (transitive) values of <code>rdfs:subClassOf</code>
 						and the <a href="#ListExpression">list expression</a> <code>( rdfs:Resource )</code>.
 						Since the asserted values of <code>rdfs:subClassOf</code> may already include <code>rdfs:Resource</code>
 						(for example, due to an active inference engine on the data graph), <code>shnex:distinct</code> will make
@@ -1458,7 +1458,7 @@ ex:ClassShape-superClassesIncludingRoot
     sh:description "The superclasses of this, always including rdfs:Resource." ;
     sh:values <b>[
         shnex:distinct [
-            shnex:join (
+            shnex:concat (
                 [
                     shnex:pathValues [ sh:zeroOrMorePath rdfs:subClassOf ] ;
                 ]
@@ -1531,48 +1531,48 @@ ex:DualCitizenShape
 					
 				</section>
 
-				<section id="JoinExpression">
-					<h3>Join Expressions</h3>
-					<p class="syntax">
-						<span data-syntax-rule="JoinExpression-syntax">
-							A <a>blank node</a> that is the <a>subject</a> of the following properties
-							is called a <dfn>join expression</dfn>, with the <a>function name</a> <code>shnex:JoinExpression</code>:
-							<table class="term-table">
-								<thead>
-									<th>Property</th>
-									<th>Constraints</th>
-									<th>Description</th>
-								</thead>
-								<tbody>
-									<tr>
-										<td><b><code>shnex:join</code></b></td>
-										<td>
-											A <a>well-formed</a> <a>SHACL list</a> where each <a>member</a> is a <a>well-formed</a> <a>node expression</a>.
-										</td>
-										<td>
-											The node expressions that shall be joined.
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</span>
-					</p>
-					<div class="def" id="JoinExpression-evaluation">
-						<div class="def-header">EVALUATION OF JOIN EXPRESSIONS</div>
-						<p>
-							Let <code>members</code> be the <a>members</a> of the <a>value</a> of <code>shnex:join</code> in the <a>join expression</a>.
-							The <a>output nodes</a> of the <a>join expression</a> are the concatenation of all <a>output nodes</a>
-							for each <a>node expression</a> <code>NE</code> in <code>members</code>, using <code>evalExpr(NE, focusGraph, focusNode, scope)</code>.
-							The order is preserved, evaluating the <code>members</code> from left to right and keeping the order of each list of output nodes.
-						</p>
-					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+<section id="ConcatExpression">
+				<h3>Concat Expressions</h3>
+				<p class="syntax">
+					<span data-syntax-rule="ConcatExpression-syntax">
+						A <a>blank node</a> that is the <a>subject</a> of the following properties
+						is called a <dfn>concat expression</dfn>, with the <a>function name</a> <code>shnex:ConcatExpression</code>:
+						<table class="term-table">
+							<thead>
+								<th>Property</th>
+								<th>Constraints</th>
+								<th>Description</th>
+							</thead>
+							<tbody>
+								<tr>
+									<td><b><code>shnex:concat</code></b></td>
+									<td>
+										A <a>well-formed</a> <a>SHACL list</a> where each <a>member</a> is a <a>well-formed</a> <a>node expression</a>.
+									</td>
+									<td>
+										The node expressions that shall be concatenated.
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</span>
+				</p>
+				<div class="def" id="ConcatExpression-evaluation">
+					<div class="def-header">EVALUATION OF CONCAT EXPRESSIONS</div>
 					<p>
-						Note that a <a>join expression</a> may produce duplicate <a>output nodes</a> if the individual output nodes overlap.
-						Use <a href="#DistinctExpression">shnex:distinct</a> to eliminate duplicates.
+						Let <code>members</code> be the <a>members</a> of the <a>value</a> of <code>shnex:concat</code> in the <a>concat expression</a>.
+						The <a>output nodes</a> of the <a>concat expression</a> are the concatenation of all <a>output nodes</a>
+						for each <a>node expression</a> <code>NE</code> in <code>members</code>, using <code>evalExpr(NE, focusGraph, focusNode, scope)</code>.
+						The order is preserved, evaluating the <code>members</code> from left to right and keeping the order of each list of output nodes.
 					</p>
-					<p>
-						The <a href="#DistinctExpressionExample">Example for <code>shnex:distinct</code></a> uses <code>shnex:join</code>.
+				</div>
+				<p><em>The remainder of this section is informative.</em></p>
+				<p>
+					Note that a <a>concat expression</a> may produce duplicate <a>output nodes</a> if the individual output nodes overlap.
+					Use <a href="#DistinctExpression">shnex:distinct</a> to eliminate duplicates.
+				</p>
+				<p>
+					The <a href="#DistinctExpressionExample">Example for <code>shnex:distinct</code></a> uses <code>shnex:concat</code>.
 					</p>
 				</section>
 

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1741,7 +1741,7 @@ ex:CompanyShape-allSkills
 					<p id="FindFirstExpressionExample">
 						The following example illustrates the use of <code>shnex:findFirst</code> to derive a property
 						<code>ex:seniorEmployee</code> that finds the first employee with more than five years of experience.
-						The findFirst operation tests each employee against a shape that validates their years of service.
+						The <code>findFirst</code> operation tests each employee against a shape that validates their years of service.
 					</p>
 					<p>
 						<aside class="example" title="Using shnex:findFirst to find the first senior employee">

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -812,10 +812,10 @@ ex:Person-loves
 						The following example declares a property for instances of <code>rdfs:Class</code>
 						where the values are derived from the values of the path <code>rdfs:subClassOf*</code>
 						but with the constants from the list <code>( owl:Thing rdfs:Resource )</code> removed using
-						<a href="#MinusExpression"><code>shnex:minus</code></a>.
+						<a href="#RemoveExpression"><code>shnex:remove</code></a>.
 					</p>
 					<p>
-						<aside class="example" title="A list expression that is used to enumerate the values of a shnex:minus expression.">
+						<aside class="example" title="A list expression that is used to enumerate the values of a shnex:remove expression.">
 							<div class="shapes-graph">
 								<div class="turtle">
 ex:ClassShape
@@ -833,7 +833,7 @@ ex:ClassShape-superClassesExceptRoots
 			shnex:pathValues [ sh:zeroOrMorePath rdfs:subClassOf ] ;
 		] ;
 		# This removes any superclasses that are in the list below
-		shnex:minus <b>( owl:Thing rdfs:Resource )</b> ;
+		shnex:remove <b>( owl:Thing rdfs:Resource )</b> ;
 	] .</b>
 								</div>
 							</div>
@@ -1134,7 +1134,7 @@ ex:City-fillColor
 					<p><em>The remainder of this section is informative.</em></p>
 					<p id="DistinctExpressionExample">
 						The following example declares a derived property <code>ex:superClassesIncludingRoot</code>
-						that is computed as the <a href="#UnionExpression">union</a> of the (transitive) values of <code>rdfs:subClassOf</code>
+						that is computed as the <a href="#JoinExpression">join</a> of the (transitive) values of <code>rdfs:subClassOf</code>
 						and the <a href="#ListExpression">list expression</a> <code>( rdfs:Resource )</code>.
 						Since the asserted values of <code>rdfs:subClassOf</code> may already include <code>rdfs:Resource</code>
 						(for example, due to an active inference engine on the data graph), <code>shnex:distinct</code> will make
@@ -1228,12 +1228,12 @@ ex:DualCitizenShape
 					</p>
 				</section>
 
-				<section id="UnionExpression">
-					<h3>Union Expressions</h3>
+				<section id="JoinExpression">
+					<h3>Join Expressions</h3>
 					<p class="syntax">
-						<span data-syntax-rule="UnionExpression-syntax">
+						<span data-syntax-rule="JoinExpression-syntax">
 							A <a>blank node</a> that is the <a>subject</a> of the following properties
-							is called a <dfn>union expression</dfn> with the <a>function name</a> <code>shnex:UnionExpression</code>:
+							is called a <dfn>join expression</dfn> with the <a>function name</a> <code>shnex:JoinExpression</code>:
 							<table class="term-table">
 								<thead>
 									<th>Property</th>
@@ -1242,7 +1242,7 @@ ex:DualCitizenShape
 								</thead>
 								<tbody>
 									<tr>
-										<td><b><code>shnex:union</code></b></td>
+										<td><b><code>shnex:join</code></b></td>
 										<td>
 											A <a>well-formed</a> <a>SHACL list</a> where each <a>member</a> is a <a>well-formed</a> <a>node expression</a>.
 										</td>
@@ -1254,10 +1254,10 @@ ex:DualCitizenShape
 							</table>
 						</span>
 					</p>
-					<div class="def" id="UnionExpression-evaluation">
+					<div class="def" id="JoinExpression-evaluation">
 						<div class="def-header">EVALUATION OF UNION EXPRESSIONS</div>
 						<p>
-							Let <code>members</code> be the <a>members</a> of the <a>value</a> of <code>shnex:union</code> in the <a>union expression</a>.
+							Let <code>members</code> be the <a>members</a> of the <a>value</a> of <code>shnex:join</code> in the <a>join expression</a>.
 							The <a>output nodes</a> of the <a>union expression</a> are the concatenation of all <a>output nodes</a>
 							for each <a>node expression</a> <code>NE</code> in <code>members</code>, using <code>evalExpr(NE, focusGraph, focusNode, scope)</code>.
 							The order is preserved, evaluating the <code>members</code> from left to right and keeping the order of each list of output nodes.
@@ -1269,16 +1269,16 @@ ex:DualCitizenShape
 						Use <a href="#DistinctExpression">shnex:distinct</a> to eliminate duplicates.
 					</p>
 					<p>
-						The <a href="#DistinctExpressionExample">Example for <code>shnex:distinct</code></a> uses <code>shnex:union</code>.
+						The <a href="#DistinctExpressionExample">Example for <code>shnex:distinct</code></a> uses <code>shnex:join</code>.
 					</p>
 				</section>
 
-				<section id="MinusExpression">
-					<h3>Minus Expressions</h3>
+				<section id="RemoveExpression">
+					<h3>Remove Expressions</h3>
 					<p class="syntax">
-						<span data-syntax-rule="MinusExpression-syntax">
+						<span data-syntax-rule="RemoveExpression-syntax">
 							A <a>blank node</a> that is the <a>subject</a> of the following properties
-							is called a <dfn>minus expression</dfn> with the <a>function name</a> <code>shnex:MinusExpression</code>:
+							is called a <dfn>remove expression</dfn> with the <a>function name</a> <code>shnex:RemoveExpression</code>:
 							<table class="term-table">
 								<thead>
 									<th>Property</th>
@@ -1287,7 +1287,7 @@ ex:DualCitizenShape
 								</thead>
 								<tbody>
 									<tr>
-										<td><b><code>shnex:minus</code></b></td>
+										<td><b><code>shnex:remove</code></b></td>
 										<td>
 											A <a>well-formed</a> <a>node expression</a>.
 										</td>
@@ -1308,21 +1308,21 @@ ex:DualCitizenShape
 							</table>
 						</span>
 					</p>
-					<div class="def" id="MinusExpression-evaluation">
-						<div class="def-header">EVALUATION OF MINUS EXPRESSIONS</div>
+					<div class="def" id="RemoveExpression-evaluation">
+						<div class="def-header">EVALUATION OF REMOVE EXPRESSIONS</div>
 						<p>
-							Let <code>minus</code> be the <a>value</a> of <code>shnex:minus</code>
-							and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in the <a>minus expression</a>.
-							Let <code>M</code> be the <a>output nodes</a> of <code>evalExpr(minus, focusGraph, focusNode, scope)</code>.
+							Let <code>toRemove</code> be the <a>value</a> of <code>shnex:remove</code>
+							and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in the <a>remove expression</a>.
+							Let <code>M</code> be the <a>output nodes</a> of <code>evalExpr(toRemove, focusGraph, focusNode, scope)</code>.
 							Let <code>N</code> be the <a>output nodes</a> of <code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
-							The <a>output nodes</a> of the <a>minus expression</a> are the <a>nodes</a> in <code>N</code>
+							The <a>output nodes</a> of the <a>remove expression</a> are the <a>nodes</a> in <code>N</code>
 							except those that are also in <code>M</code>, preserving the order of <code>N</code>.
-							Nodes must be equal using <a>term equality</a>, i.e. <code>"01"^^xsd:integer</code> is distinct from <code>"1"^^xsd:integer</code>.
+							Nodes must be equal using <a>term equality</a>, i.e., <code>"01"^^xsd:integer</code> is distinct from <code>"1"^^xsd:integer</code>.
 						</p>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
 					<p>
-						The <a href="#ListExpressionExample">List Expression example</a> uses <code>shnex:minus</code>.
+						The <a href="#ListExpressionExample">List Expression example</a> uses <code>shnex:remove</code>.
 					</p>
 				</section>
 

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1848,7 +1848,7 @@ sh:intersection
 	rdfs:comment "Deprecated with SHACL 1.2: replaced by shnex:intersection."@en .
 
 sh:union
-	rdfs:comment "Deprecated with SHACL 1.2: replaced by shnex:join."@en .
+	rdfs:comment "Deprecated with SHACL 1.2: replaced by shnex:concat."@en .
 
 sh:minus
 	rdfs:comment "Deprecated with SHACL 1.2: replaced by shnex:remove."@en .

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1848,7 +1848,10 @@ sh:intersection
 	rdfs:comment "Deprecated with SHACL 1.2: replaced by shnex:intersection."@en .
 
 sh:union
-	rdfs:comment "Deprecated with SHACL 1.2: replaced by shnex:union."@en .
+	rdfs:comment "Deprecated with SHACL 1.2: replaced by shnex:join."@en .
+
+sh:minus
+	rdfs:comment "Deprecated with SHACL 1.2: replaced by shnex:remove."@en .
 
 
 # Rules -----------------------------------------------------------------------

--- a/shacl12-vocabularies/shnex.ttl
+++ b/shacl12-vocabularies/shnex.ttl
@@ -544,3 +544,107 @@ shnex:var
 	rdfs:domain shnex:VarExpression ;
 	rdfs:range xsd:string ;
 .
+
+
+# FlatMap Expressions ---------------------------------------------------------
+
+shnex:FlatMapExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "FlatMap expression"@en ;
+	rdfs:comment "A SHACL node expression that applies an expression to each input node and flattens the results into a single sequence."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:FlatMapExpression-flatMap ;
+	sh:parameter shnex:FlatMapExpression-nodes ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:FlatMapExpression-flatMap
+	a sh:Parameter ;
+	sh:path shnex:flatMap ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:FlatMapExpression-nodes
+	a sh:Parameter ;
+	sh:path shnex:nodes ;
+	sh:name "nodes"@en ;
+	sh:description "A node expression that produces the input nodes."@en ;
+	sh:optional true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:flatMap
+	a rdf:Property ;
+	rdfs:label "flatMap"@en ;
+	rdfs:comment "In FlatMap Expressions, this property specifies the node expression that is applied to each input node."@en ;
+	rdfs:domain shnex:FlatMapExpression ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# FindFirst Expressions -------------------------------------------------------
+
+shnex:FindFirstExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "FindFirst expression"@en ;
+	rdfs:comment "A SHACL node expression that returns the first node from a sequence that satisfies a given predicate."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:FindFirstExpression-findFirst ;
+	sh:parameter shnex:FindFirstExpression-nodes ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:FindFirstExpression-findFirst
+	a sh:Parameter ;
+	sh:path shnex:findFirst ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:FindFirstExpression-nodes
+	a sh:Parameter ;
+	sh:path shnex:nodes ;
+	sh:name "nodes"@en ;
+	sh:description "A node expression that produces the input nodes."@en ;
+	sh:optional true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:findFirst
+	a rdf:Property ;
+	rdfs:label "findFirst"@en ;
+	rdfs:comment "In FindFirst Expressions, this property specifies the shape that the matching node must conform to."@en ;
+	rdfs:domain shnex:FindFirstExpression ;
+	rdfs:range sh:Shape ;
+	rdfs:isDefinedBy shnex: ;
+.
+
+
+# MatchAll Expressions --------------------------------------------------------
+
+shnex:MatchAllExpression
+	a sh:NamedParameterExpressionFunction ;
+	rdfs:label "MatchAll expression"@en ;
+	rdfs:comment "A SHACL node expression that returns true if all nodes in a sequence satisfy a given predicate, false otherwise."@en ;
+	rdfs:subClassOf sh:NamedParameterExpression ;
+	sh:parameter shnex:MatchAllExpression-matchAll ;
+	sh:parameter shnex:MatchAllExpression-nodes ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:MatchAllExpression-matchAll
+	a sh:Parameter ;
+	sh:path shnex:matchAll ;
+	sh:keyParameter true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:MatchAllExpression-nodes
+	a sh:Parameter ;
+	sh:path shnex:nodes ;
+	sh:name "nodes"@en ;
+	sh:description "A node expression that produces the input nodes."@en ;
+	sh:optional true ;
+	rdfs:isDefinedBy shnex: ;
+.
+shnex:matchAll
+	a rdf:Property ;
+	rdfs:label "matchAll"@en ;
+	rdfs:comment "In MatchAll Expressions, this property specifies the shape that all input nodes must conform to."@en ;
+	rdfs:domain shnex:MatchAllExpression ;
+	rdfs:range sh:Shape ;
+	rdfs:isDefinedBy shnex: ;
+.

--- a/shacl12-vocabularies/shnex.ttl
+++ b/shacl12-vocabularies/shnex.ttl
@@ -367,35 +367,35 @@ shnex:min
 .
 
 
-# Minus Expressions -----------------------------------------------------------
+# Remove Expressions -----------------------------------------------------------
 
-shnex:MinusExpression
+shnex:RemoveExpression
 	a sh:NamedParameterExpressionFunction ;
-	rdfs:label "Minus expression"@en ;
-	rdfs:comment "A SHACL node expression that returns the values of a given node expression (sh:nodes) except for those returned by another node expression (sh:minus)."@en ;
+	rdfs:label "Remove expression"@en ;
+	rdfs:comment "A SHACL node expression that returns the values of a given node expression (sh:nodes) except for those returned by another node expression (sh:remove)."@en ;
 	rdfs:subClassOf sh:NamedParameterExpression ;
-	sh:parameter shnex:MinusExpression-minus ;
-	sh:parameter shnex:MinusExpression-nodes ;
+	sh:parameter shnex:RemoveExpression-remove ;
+	sh:parameter shnex:RemoveExpression-nodes ;
 	rdfs:isDefinedBy shnex: ;
 .
-shnex:MinusExpression-minus
+shnex:RemoveExpression-remove
 	a sh:Parameter ;
-	sh:path shnex:minus ;
+	sh:path shnex:remove ;
 	sh:keyParameter true ;
 	rdfs:isDefinedBy shnex: ;
 .
-shnex:MinusExpression-nodes
+shnex:RemoveExpression-nodes
 	a sh:Parameter ;
 	sh:path shnex:nodes ;
 	sh:name "nodes"@en ;
 	sh:description "A node expression that produces the input nodes."@en ;
 	rdfs:isDefinedBy shnex: ;
 .
-shnex:minus
+shnex:remove
 	a rdf:Property ;
-	rdfs:label "minus"@en ;
-	rdfs:comment "In Minus Expressions, this property specifies the node expression that produces the values that shall be removed from the input nodes (sh:nodes)."@en ;
-	rdfs:domain shnex:MinusExpression ;
+	rdfs:label "remove"@en ;
+	rdfs:comment "In Remove Expressions, this property specifies the node expression that produces the values that shall be removed from the input nodes (sh:nodes)."@en ;
+	rdfs:domain shnex:RemoveExpression ;
 	rdfs:isDefinedBy shnex: ;
 .
 
@@ -493,27 +493,27 @@ shnex:sum
 .
 
 
-# Union Expressions -----------------------------------------------------------
+# Join Expressions -----------------------------------------------------------
 
-shnex:UnionExpression
+shnex:JoinExpression
 	a sh:NamedParameterExpressionFunction ;
-	rdfs:label "Union expression"@en ;
+	rdfs:label "Join expression"@en ;
 	rdfs:comment "A SHACL node expression that can be used to returns the nodes that are found in either of the results of the listed node expression."@en ;
 	rdfs:subClassOf sh:NamedParameterExpression ;
-	sh:parameter shnex:UnionExpression-union ;
+	sh:parameter shnex:JoinExpression-join ;
 	rdfs:isDefinedBy shnex: ;
 .
-shnex:UnionExpression-union
+shnex:JoinExpression-join
 	a sh:Parameter ;
-	sh:path shnex:union ;
+	sh:path shnex:join ;
 	sh:keyParameter true ;
 	rdfs:isDefinedBy shnex: ;
 .
-shnex:union
+shnex:join
 	a rdf:Property ;
-	rdfs:label "union"@en ;
-	rdfs:comment "In Union Expressions, this property specifies the list of node expressions that shall be unioned."@en ;
-	rdfs:domain shnex:UnionExpression ;
+	rdfs:label "join"@en ;
+	rdfs:comment "In Join Expressions, this property specifies the list of node expressions that shall be joined."@en ;
+	rdfs:domain shnex:JoinExpression ;
 	rdfs:range rdf:List ;
 	rdfs:isDefinedBy shnex: ;
 .

--- a/shacl12-vocabularies/shnex.ttl
+++ b/shacl12-vocabularies/shnex.ttl
@@ -519,27 +519,27 @@ shnex:sum
 .
 
 
-# Join Expressions -----------------------------------------------------------
+# Concat Expressions ----------------------------------------------------------
 
-shnex:JoinExpression
+shnex:ConcatExpression
 	a sh:NamedParameterExpressionFunction ;
-	rdfs:label "Join expression"@en ;
+	rdfs:label "Concat expression"@en ;
 	rdfs:comment "A SHACL node expression that can be used to returns the nodes that are found in either of the results of the listed node expression."@en ;
 	rdfs:subClassOf sh:NamedParameterExpression ;
-	sh:parameter shnex:JoinExpression-join ;
+	sh:parameter shnex:ConcatExpression-concat ;
 	rdfs:isDefinedBy shnex: ;
 .
-shnex:JoinExpression-join
+shnex:ConcatExpression-concat
 	a sh:Parameter ;
-	sh:path shnex:join ;
+	sh:path shnex:concat ;
 	sh:keyParameter true ;
 	rdfs:isDefinedBy shnex: ;
 .
-shnex:join
+shnex:concat
 	a rdf:Property ;
-	rdfs:label "join"@en ;
-	rdfs:comment "In Join Expressions, this property specifies the list of node expressions that shall be joined."@en ;
-	rdfs:domain shnex:JoinExpression ;
+	rdfs:label "concat"@en ;
+	rdfs:comment "In Concat Expressions, this property specifies the list of node expressions that shall be concatenated."@en ;
+	rdfs:domain shnex:ConcatExpression ;
 	rdfs:range rdf:List ;
 	rdfs:isDefinedBy shnex: ;
 .


### PR DESCRIPTION
This is a revision of the now closed PR here: https://github.com/w3c/data-shapes/pull/526#issue-3351151169

Closes #484 

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/new-issue-484-sequence-shnex/shacl12-node-expr/index.html)

----------

This pull request implements comprehensive changes to address [Issue #484](https://github.com/w3c/data-shapes/issues/484) regarding sequence processing naming inconsistencies in SHACL Node Expressions. The changes align the vocabulary and documentation with the sequence-based nature of node expression processing while maintaining backward compatibility through deprecation notices.

## Problem Statement

SHACL Node Expressions are fundamentally sequence-based but were using set-style operation names, creating confusion:
- Operations like `union` and `minus` suggested set semantics despite working on ordered sequences
- The generic `path` property conflicted conceptually with constraint `sh:path` 
- Missing advanced sequence operations limited processing capabilities

## Solution

### 1. Vocabulary Renaming for Sequence Semantics

**Renamed Operations:**
- `shnex:union` → `shnex:join` - Emphasizes sequence concatenation with order preservation
- `shnex:minus` → `shnex:remove` - Clearer operation name for sequence subtraction
- `shnex:path` → `shnex:pathValues` - Distinguishes from constraint `sh:path` (needs to align with #514 )

**Deprecation Strategy:**
- Updated `shacl.ttl` with deprecation notices for `sh:union` and `sh:minus`
- Maintained backward compatibility while guiding migration to new terms

### 2. Advanced Sequence Operations

**New Operations Added:**
- `shnex:flatMap` - Applies expression to each input node and flattens results
- `shnex:findFirst` - Returns first node conforming to a given shape
- `shnex:matchAll` - Returns true if all nodes conform to a given shape

## Files Modified

### Vocabulary Files
- **`shacl12-vocabularies/shnex.ttl`**
  - Added complete RDF definitions for FlatMap, FindFirst, and MatchAll expressions
  - Updated existing definitions with sequence-appropriate naming
  - Enhanced property comments for clarity

- **`shacl12-vocabularies/shacl.ttl`**
  - Added deprecation notices for `sh:union` and `sh:minus`
  - Clear migration guidance to new sequence-based terms

### Documentation
- **`shacl12-node-expr/index.html`**
  - Renamed sections: UnionExpression → JoinExpression, MinusExpression → RemoveExpression


### New Advanced Operations:
```turtle
# Find first senior employee
sh:values [
    shnex:findFirst [
        shnex:nodes [ shnex:pathValues ex:employee ] ;
        shnex:findFirst ex:SeniorEmployeeShape ;
    ] ;
] .

# Check if all employees are active
sh:values [
    shnex:matchAll [
        shnex:nodes [ shnex:pathValues ex:employee ] ;
        shnex:matchAll ex:ActiveEmployeeShape ;
    ] ;
] .
```
---


