### PR TITLE
[UI] Add property roles section

### DIFF
--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1536,7 +1536,7 @@ ex:part-b
       </p>
 
       <p>
-        This section introduces Property Roles for annotating SHACL property shapes along with several built-in property roles defined in the SHUI namespace.
+        This section introduces Property Roles for annotating SHACL property shapes, along with several built-in property roles defined in the SHUI namespace.
         Property Roles are defined in the SHUI namespace and define the class <code>shui:PropertyRole</code> and the property <code>shui:propertyRole</code>.
       </p>
 

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1517,7 +1517,7 @@ ex:part-b
       <h2>Property Roles</h2>
 
       <p>
-        RDF resources commonly use properties to specify labels and descriptions, which user-interface engines depend on to render structured content.
+        RDF resources commonly use properties to specify labels, descriptions, and other information needed for rendering, which user-interface engines depend on to render structured content.
         However, the vocabularies defining these properties vary across domains and communities. To ensure consistent interpretation, property shapes can
         be annotated with explicit roles for elements such as labels and descriptions.
       </p>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -530,6 +530,19 @@
       <section id="conformance">
         <p>TODO</p>
       </section>
+
+      <section id="compatibility">
+        <h2>RDF Abstract Model Compatibility</h2>
+
+        <p class="ednote">
+          At the time of writing, RDF 1.2 is a Working Draft. This section will be reviewed and updated when RDF 1.2 becomes a W3C Recommendation.
+        </p>
+
+        <p>
+          SHACL Renderers implementing this specification must support RDF 1.1 and should support RDF 1.2. When RDF 1.2 is supported, and unless
+          stated otherwise in this document, implementations should prefer RDF 1.2 syntax and data model features over their RDF 1.1 counterparts.
+        </p>
+      </section>
     </section>
 
     <section id="widgets">
@@ -1599,7 +1612,7 @@ shui:propertyRole [
         should support the triple annotation syntax in addition to the RDF 1.1-compatible qualified role annotation syntax.
       </p>
 
-      <aside class="example" title="Qualified role annotation using RDF 1.2 triple annotations">
+      <aside class="example" title="Qualified role annotation using triple annotations">
         <div class="shapes-graph">
           <div class="turtle">
 ex:PrefLabel a sh:PropertyShape ;

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1523,7 +1523,7 @@ ex:part-b
       </p>
 
       <p>
-        This section introduces Property Roles for annotating SHACL property shapes along with several core property roles defined in the SHUI namespace.
+        This section introduces Property Roles for annotating SHACL property shapes along with several built-in property roles defined in the SHUI namespace.
         Property Roles are defined in the SHUI namespace and define the class <code>shui:PropertyRole</code> and the property <code>shui:propertyRole</code>.
       </p>
 
@@ -1618,7 +1618,7 @@ ex:Name a sh:PropertyShape ;
         </p>
       </aside>
 
-      <h3>Core Property Roles</h3>
+      <h3>Built-in Property Roles</h3>
 
       <p>
         The following sections define the instances of <code>shui:PropertyRole</code> in the SHUI namespace. These property roles MUST be supported

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1513,6 +1513,142 @@ ex:part-b
         </section>
     </section>
 
+    <section id="property-roles">
+      <h2>Property Roles</h2>
+
+      <p>
+        RDF resources commonly use properties to specify labels and descriptions, which user-interface engines depend on to render structured content.
+        However, the vocabularies defining these properties vary across domains and communities. To ensure consistent interpretation, property shapes can
+        be annotated with explicit roles for elements such as labels and descriptions.
+      </p>
+
+      <p>
+        This section introduces Property Roles for annotating SHACL property shapes along with several core property roles defined in the SHUI namespace.
+        Property Roles is defined in the SHUI namespace and defines the class <code>shui:PropertyRole</code> and the property <code>shui:propertyRole</code>.
+      </p>
+
+      <h3>Direct Role Annotation</h3>
+
+      <p>
+        Property roles can be annotated on property shapes by using the <code></code>shui:propertyRole</code> predicate and linking directly to a property role instance. 
+        SHACL renderers may use this direct annotation to drive how specific user-interface elements are displayed.
+      </p>
+
+      <p>
+        It is possible but not recommended to assign the same property role to multiple property shapes that apply to the same focus node using the direct role annotation form. 
+        When this occurs, the resulting behavior is undefined.
+      </p>
+
+      <p>
+        The example below illustrates the common case where a property shape is directly annotated with shui:LabelRole. This informs user-interfaces that the shape's value nodes
+        represent human-readable labels for resources.
+      </p>
+
+      <aside class="example" title="Direct role annotation">
+        <div class="shapes-graph">
+          <div class="turtle">
+ex:Label a sh:PropertyShape ;
+    sh:path skos:prefLabel ;
+    shui:propertyRole shui:LabelRole ;
+.
+          </div>
+        </div>
+        <p>
+          This example illustrates the common case where a property shape is directly annotated with <code>shui:LabelRole</code>. 
+          This informs user-interfaces that the shape's value nodes represent human-readable labels for resources.
+        </p>
+      </aside>
+
+      <h3>Qualified Role Annotation</h3>
+
+      <p>When multiple predicates serve the same role in the data but require a defined precedence, the qualified role annotation should be used.</p>
+
+      <p>
+        For property shapes annotated with the same role, user interfaces should prefer the shape with the smallest <code>sh:order</code> value. If multiple shapes
+        share the same role, they must be sorted and processed in ascending order of their <code>sh:order</code> values. In addition, any property shape
+        using a qualified role annotation is always preferred over a shape using a direct, unqualified role annotation.
+      </p>
+
+      <aside class="example" title="Qualified role annotation">
+        <div class="shapes-graph">
+          <div class="turtle">
+ex:PrefLabel a sh:PropertyShape ;
+sh:path skos:prefLabel ;
+shui:propertyRole [
+    shui:propertyRole shui:LabelRole ;
+    sh:order 0
+]
+.
+
+ex:Name a sh:PropertyShape ;
+sh:path schema:name ;
+shui:propertyRole [
+    shui:propertyRole shui:LabelRole ;
+    sh:order 1
+]
+.
+          </div>
+        </div>
+        <p>
+          The following example demonstrates two property shapes with qualified role annotations ordered by <code>sh:order</code>.
+        </p>
+      </aside>
+
+      <p>
+        The qualified role annotation can also be expressed using triple annotations. SHACL Renderers that support RDF 1.2
+        should support the triple annotation syntax in addition to the RDF 1.1-compatible qualified role annotation syntax.
+      </p>
+
+      <aside class="example" title="Qualified role annotation using RDF 1.2 triple annotations">
+        <div class="shapes-graph">
+          <div class="turtle">
+ex:PrefLabel a sh:PropertyShape ;
+    sh:path skos:prefLabel ;
+    shui:propertyRole shui:LabelRole {| sh:order 0 |}
+.
+
+ex:Name a sh:PropertyShape ;
+    sh:path schema:name ;
+    shui:propertyRole shui:LabelRole {| sh:order 1 |}
+.
+          </div>
+        </div>
+        <p>
+          This example demonstrates two property shapes with qualified role annotations ordered by <code>sh:order</code> using RDF 1.2 triple annotations.
+        </p>
+      </aside>
+
+      <h3>Core Property Roles</h3>
+
+      <p>
+        The following sections define the instances of <code>shui:PropertyRole</code> in the SHUI namespace. These property roles MUST be supported
+        by SHACL Renderers. Additional property roles may be defined in other namespaces.
+      </p>
+
+      <h4>shui:LabelRole</h4>
+
+      <p>
+        The <code>shui:LabelRole</code> is used to identify properties whose values serve as human-readable display labels.
+        Common examples of display label predicates include <code>rdfs:label</code>, <code>skos:prefLabel</code>, and <code>schema:name</code>.
+      </p>
+
+      <h3>Definitions</h3>
+
+      <h4>shui:PropertyRole Class</h4>
+
+      <p>
+        The class of roles that a property shape may take with respect to its focus nodes. It is not required, but recommended, that roles
+        defined in other namespaces subclass <code>shui:PropertyRole</code>.
+      </p>
+
+      <h4>shui:propertyRole Property</h4>
+
+      <p>
+        The property used to annotate property shapes with roles. Its value is expected to be either an instance of <code>shui:PropertyRole</code> or a
+        resource that itself declares a <code>shui:propertyRole</code> and an associated <code>sh:order</code> value.
+      </p>
+    </section>
+
     <section id="syntax-rules" class="appendix">
       <h2>Summary of Syntax Rules from this Specification</h2>
     </section>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -539,8 +539,8 @@
         </p>
 
         <p>
-          SHACL Renderers implementing this specification must support RDF 1.1 and should support RDF 1.2. When RDF 1.2 is supported, and unless
-          stated otherwise in this document, implementations should prefer RDF 1.2 syntax and data model features over their RDF 1.1 counterparts.
+          SHACL Renderers implementing this specification MUST support RDF 1.1 and SHOULD support RDF 1.2. When RDF 1.2 is supported, and unless
+          stated otherwise in this document, implementations SHOULD prefer RDF 1.2 syntax and data model features over their RDF 1.1 counterparts.
         </p>
       </section>
     </section>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1519,7 +1519,7 @@ ex:part-b
       <p>
         RDF resources commonly use properties to specify labels, descriptions, and other information needed for rendering, which user-interface engines depend on to render structured content.
         However, the vocabularies defining these properties vary across domains and communities. To ensure consistent interpretation, property shapes can
-        be annotated with explicit roles for elements such as labels and descriptions.
+        be annotated with explicit roles for elements such as labels, descriptions, and other rendering properties.
       </p>
 
       <p>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1524,19 +1524,19 @@ ex:part-b
 
       <p>
         This section introduces Property Roles for annotating SHACL property shapes along with several core property roles defined in the SHUI namespace.
-        Property Roles is defined in the SHUI namespace and defines the class <code>shui:PropertyRole</code> and the property <code>shui:propertyRole</code>.
+        Property Roles are defined in the SHUI namespace and define the class <code>shui:PropertyRole</code> and the property <code>shui:propertyRole</code>.
       </p>
 
       <h3>Direct Role Annotation</h3>
 
       <p>
         Property roles can be annotated on property shapes by using the <code></code>shui:propertyRole</code> predicate and linking directly to a property role instance. 
-        SHACL renderers may use this direct annotation to drive how specific user-interface elements are displayed.
+        SHACL renderers may use such direct annotations to drive the way specific user-interface elements are displayed.
       </p>
 
       <p>
         It is possible but not recommended to assign the same property role to multiple property shapes that apply to the same focus node using the direct role annotation form. 
-        When this occurs, the resulting behavior is undefined.
+        When this is done, the resulting behavior is undefined.
       </p>
 
       <p>


### PR DESCRIPTION
This PR adds the Property Roles section to the UI document. It builds on the foundations established in the [DASH Property Roles and Resource Summaries](https://www.datashapes.org/propertyroles.html) document and introduces a new qualified role annotation modeling pattern that enables assigning multiple roles of the same type with support for preference ordering.

This initial PR introduces only one built-in property role: `shui:LabelRole`. It does not yet include the constraints or processing logic implied by this role as the task force still needs to decide whether roles should inherit constraints or processing behaviour. Additional label-related logic (such as defining label properties as subproperties of `rdfs:label` has been deferred to the upcoming label resolution section, which will be added in a separate PR.

Other property roles from the DASH Property Roles document will also be added later in separate PRs.

Closes https://github.com/w3c/data-shapes/issues/538

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/ui/property-roles/shacl12-ui/index.html)
