### PR TITLE
#645: [UI] added terminology

### DIFF
--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -391,7 +391,7 @@
           <div class="term-def-header">Language Resolution</div>
           <div>
             <dfn data-lt="language resolution">Language resolution</dfn> is the process of determining and ordering the
-            values associated with a given subject-predicate pair, prioritising the most relevant or preferred language
+            values associated with a given subject-predicate pair, prioritizing the preferred or most relevant language
             value for display.
           </div>
         </div>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -398,13 +398,12 @@
         <div class="def">
           <div class="term-def-header">Label Resolution</div>
           <div>
-            <dfn data-lt="label resolution">Label Resolution</dfn> is the process of determining the most appropriate
-            display value for an RDF resource, or generating a fallback value when none is explicitly available. This
-            process applies to both value nodes and <code>sh:path</code> values.
+            <dfn data-lt="label resolution">Label Resolution</dfn> is the process of selecting the most appropriate
+            display label for an RDF resource, or generating a fallback value when no suitable value exists. It
+            applies to both value nodes and properties identified by <code>sh:path</code>, the latter of which is commonly used to label form elements.
 
-            The process includes <a>language resolution</a>, taking into account annotations defined in the
-            <a>shapes graph</a>, <a>data graph</a>, application environment, and user preferences to select the most
-            suitable label for UI presentation.
+            The process includes <a>language resolution</a> and considers labeling-related annotations from the
+            <a>shapes graph</a>, <a>data graph</a>, application environment, and user preferences, to determine the best label for UI presentation.
           </div>
         </div>
         <div class="def">

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -425,32 +425,25 @@
         <div class="def">
           <div class="term-def-header">SHACL Renderer</div>
           <div>
-            A <dfn data-lt="shacl Renderer">SHACL Renderer</dfn> is a piece of software that processes SHACL
-            <a>shapes</a> and data to dynamically generate a form. A UI that represents the data is generated from one
-            or more <a>node UI components</a>. The SHACL renderer may add additional UI elements, such as a submit
-            button to save changes, a button to toggle between edit and view mode, selectors for <a>focus node</a> and
-            <a>node shape</a>, or messages from the <a>validation report</a>.
+            A <dfn data-lt="shacl Renderer">SHACL Renderer</dfn> is software that processes SHACL
+            <a>shapes</a> and data and dynamically generates a user-interface using one
+            or more <a>node UI components</a>. Implementations may add supplementary UI elements, such as a submit
+            button to save changes, controls to toggle between edit and view modes, selectors for <a>focus node</a> and
+            <a>node shape</a>, or visualizations of <a>validation report</a> messages.
 
-            Further functionality the SHACL renderer may provide:
+            They may also provide:
             <ul>
-              <li>State management for the mode (edit/view) and changes</li>
-              <li>Managing widgets and widget selection logic</li>
-              <li>The target selection logic</li>
-              <li>Communication with the persistence layer</li>
+              <li>State management for editing, viewing, and tracking data changes</li>
+              <li>Widget management, including widget selection strategies</li>
+              <li>Logic for determining the initial focus node (target) and the best suited node shape</li>
+              <li>An interface to interact with the data layer</li>
             </ul>
 
-            The inputs:
-            <ul>
-              <li><a>Focus node</a> IRI (optional, some implementations may provide a logic or UI to determine the root
-                node)</li>
-              <li><a>Node shape</a> IRI (optional, some implementations may provide a logic or UI to determine a
-                matching shape)</li>
-              <li><a>Data graph</a></li>
-              <li><a>Shapes graph</a></li>
-            </ul>
-
-            If both the focus node and node shape are provided, the SHACL renderer operates in manual mode. Otherwise,
-            when logic is applied to determine one or both values, it operates in automatic mode.
+            A SHACL Renderer operates on a <a>data graph</a> and a <a>shapes graph</a>, and may also take a
+            <a>focus node</a> and a <a>node shape</a>. When all four inputs are provided, the renderer
+            operates in <strong>manual mode</strong>. When the focus node or node shape is not provided,
+            the renderer may operate in <strong>automatic mode</strong>, in which case the application determines
+            appropriate values for the missing inputs.
           </div>
         </div>
       </section>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -390,7 +390,7 @@
         <div class="def">
           <div class="term-def-header">Language Resolution</div>
           <div>
-            <dfn data-lt="language resolution">Language resolution</dfn> is the process of determining and ordering the
+            <dfn data-lt="language resolution">Language Resolution</dfn> is the process of determining and ordering the
             values associated with a given subject-predicate pair, prioritizing the preferred or most relevant language
             value for display.
           </div>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -387,6 +387,73 @@
           </dfn>
           .
         </p>
+        <div class="def">
+          <div class="term-def-header">Language Resolution</div>
+          <div>
+            <dfn data-lt="language resolution">Language resolution</dfn> is the process of determining and ordering the
+            values associated with a given subject-predicate pair, prioritising the most relevant or preferred language
+            value for display.
+          </div>
+        </div>
+        <div class="def">
+          <div class="term-def-header">Label Resolution</div>
+          <div>
+            <dfn data-lt="label resolution">Label Resolution</dfn> is the process of determining the most appropriate
+            display value for an RDF resource, or generating a fallback value when none is explicitly available. This
+            process applies to both value nodes and <code>sh:path</code> values.
+
+            The process includes <a>language resolution</a>, taking into account annotations defined in the
+            <a>shapes graph</a>, <a>data graph</a>, application environment, and user preferences to select the most
+            suitable label for UI presentation.
+          </div>
+        </div>
+        <div class="def">
+          <div class="term-def-header">Property UI Component</div>
+          <div>
+            A <dfn data-lt="property ui component">Property UI Component</dfn> is a combination of <a>constraints</a>
+            across multiple <a>property shapes</a> that share the same <a>property path</a>, <a>focus node</a>, and
+            <a>value nodes</a>. It represents a single field (e.g., a text input, a dropdown) in a form.
+          </div>
+        </div>
+        <div class="def">
+          <div class="term-def-header">Node UI Component</div>
+          <div>
+            A <dfn data-lt="node ui component">Node UI Component</dfn> is generated from a single <a>focus node</a>,
+            typically containing one or more <a>property UI components</a>. It is often derived from one or more
+            <a>node shapes</a> that apply to the <a>focus node</a>.
+          </div>
+        </div>
+        <div class="def">
+          <div class="term-def-header">SHACL Renderer</div>
+          <div>
+            A <dfn data-lt="shacl Renderer">SHACL Renderer</dfn> is a piece of software that processes SHACL
+            <a>shapes</a> and data to dynamically generate a form. A UI that represents the data is generated from one
+            or more <a>node UI components</a>. The SHACL renderer may add additional UI elements, such as a submit
+            button to save changes, a button to toggle between edit and view mode, selectors for <a>focus node</a> and
+            <a>node shape</a>, or messages from the <a>validation report</a>.
+
+            Further functionality the SHACL renderer may provide:
+            <ul>
+              <li>State management for the mode (edit/view) and changes</li>
+              <li>Managing widgets and widget selection logic</li>
+              <li>The target selection logic</li>
+              <li>Communication with the persistence layer</li>
+            </ul>
+
+            The inputs:
+            <ul>
+              <li><a>Focus node</a> IRI (optional, some implementations may provide a logic or UI to determine the root
+                node)</li>
+              <li><a>Node shape</a> IRI (optional, some implementations may provide a logic or UI to determine a
+                matching shape)</li>
+              <li><a>Data graph</a></li>
+              <li><a>Shapes graph</a></li>
+            </ul>
+
+            If both the focus node and node shape are provided, the SHACL renderer operates in manual mode. Otherwise,
+            when logic is applied to determine one or both values, it operates in automatic mode.
+          </div>
+        </div>
       </section>
 
       <section id="conventions">


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Adds a terminology section to the UI specification.

Closes #645

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-645-ui-terms/shacl12-ui/index.html)
