### PR TITLE
fix: #646 removed severity count, aligned violation naming

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -1457,7 +1457,7 @@ ex:Bob a ex:Person .
 					</p>
 					<p>
 						The values of <code>sh:severity</code> are called <dfn data-lt="severity">severities</dfn>.
-						SHACL includes the three IRIs listed in the table below to represent <a>severities</a>.
+						SHACL includes the IRIs listed in the table below to represent <a>severities</a>.
 						These are declared in the SHACL vocabulary as SHACL instances of <code>sh:Severity</code>.
 					</p>
 					<table class="term-table">
@@ -1467,11 +1467,11 @@ ex:Bob a ex:Person .
 						</tr>
 						<tr>
 							<td><code>sh:Trace</code></td>
-							<td>A trace message that is not a violation.</td>
+							<td>A trace message that is not a constraint violation.</td>
 						</tr>
 						<tr>
 							<td><code>sh:Debug</code></td>
-							<td>A debug message that is not a violation.</td>
+							<td>A debug message that is not a constraint violation.</td>
 						</tr>
 						<tr>
 							<td><code>sh:Info</code></td>


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #646

- Removes the count of severities to remove conflicts with the number of table entries.
- Consistently use the term constraint violation to align with the previously defined entries in the table.

This PR should fix the issues with the new violations introduced recently. Any additional fixes, like a missing definition, should be handled in a separate PR.

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-646-sev-dec/shacl12-core/index.html#dfn-severity)
