### PR TITLE
chore: #663 moved built-in widget to separate section

### DIFF
--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -559,7 +559,7 @@
           However, some viewers need to take more complete control over how multiple values of a property at a focus node are rendered.
           The only example of such a viewer in SHACL UI is <a href="#ValueTableViewer"><code>shui:ValueTableViewer</code></a>, which displays
           all values of a property as an HTML table.
-          In those cases, the notions of generic add and delete buttons do not apply.
+          In such cases, the notions of generic add and delete buttons do not apply.
           Such viewers are called <em>Multi Viewers</em> and are declared instances of <code>shui:MultiViewer</code> instead of <code>shui:SingleViewer</code>.
           The equivalent classes for editors are <code>shui:MultiEditor</code> and <code>shui:SingleEditor</code>.
         </p>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -543,6 +543,375 @@
           If no such value has been specified, the system should pick a suitable default viewer based on the
           <a href="#score">scoring system</a> outlined for each widget.
         </p>
+      </section>
+
+      <section id="viewers">
+        <h3>Viewers</h3>
+        <p>
+          The following sub-sections enumerate the currently defined instances of <code>shui:Viewer</code> from the SHACL UI namespace.
+          A property shape can have an explicitly specified preferred viewer for its values in <code>shui:viewer</code>.
+          If no such value has been specified, the system should pick a suitable default viewer based on the
+          <a href="#score">scoring system</a> outlined for each widget.
+        </p>
+        <p id="multi">
+          Most viewers render a single RDF value on the screen, typically as a single widget.
+          Form editors offer buttons to edit individual values and to add or delete values.
+          However, some viewers need to take more complete control over how multiple values of a property at a focus node are rendered.
+          The only example of such a viewer in SHACL UI is <a href="#ValueTableViewer"><code>shui:ValueTableViewer</code></a>, which displays
+          all values of a property as an HTML table.
+          In those cases, the notions of generic add and delete buttons do not apply.
+          Such viewers are called <em>Multi Viewers</em> and are declared instances of <code>shui:MultiViewer</code> instead of <code>shui:SingleViewer</code>.
+          The equivalent classes for editors are <code>shui:MultiEditor</code> and <code>shui:SingleEditor</code>.
+        </p>
+      </section>
+    </section>
+
+    <section id="core-constraints">
+      <h2>Core Constraints</h2>
+      <p>Content.</p>
+    </section>
+
+    <section id="property-paths">
+        <h2>Property Paths</h2>
+        <p>
+            <a href="../shacl12-core/#property-paths">SHACL Property Paths</a> can be used to render a SHACL shape as a
+            user interface.
+            Property paths define how data values are accessed or modified relative to a focus node.
+        </p>
+        <p>
+            The following subsections outline the scenarios in which SHACL UI implementations are expected to
+            support different kinds of property paths for viewing and editing operations.
+        </p>
+
+        <section id="property-paths-view">
+            <h3>View Mode</h3>
+            <p>
+                In view mode, property paths are used to retrieve and display data values associated with a shape.
+                A SHACL UI implementation must provide mechanisms to resolve these paths for visualization.
+            </p>
+
+            <section id="view-predicate-paths">
+                <h4>Predicate and Inverse Paths</h4>
+                <p>
+                    SHACL UI implementations MUST support both
+                    <a href="../shacl12-core/#property-path-predicate">predicate paths</a> and
+                    <a href="../shacl12-core/#property-path-inverse">inverse paths</a> in view mode.
+                    This ensures that values reachable via simple forward or inverse relationships can be displayed to
+                    the user.
+                </p>
+
+                <p>
+                    The following example illustrates how predicate and inverse paths are used in view mode to access
+                    and display values, either directly from the focus node or through incoming relationships from other
+                    nodes.
+                </p>
+
+                <aside class="example" title="Predicate and inverse paths in view mode">
+                    <div class="shapes-graph">
+                        <div class="turtle">
+ex:PersonShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path foaf:name ;
+        sh:name "Name" ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path [ sh:inversePath ex:member ] ;
+        sh:name "Department" ;
+    ] .
+                        </div>
+                    </div>
+
+                    <div class="data-graph">
+                        <div class="turtle">
+ex:alice a ex:Person ;
+    foaf:name "Alice" .
+
+ex:researchDept a ex:Department ;
+    ex:member ex:alice ;
+    rdfs:label "Research Department" .
+                        </div>
+                    </div>
+
+                    <p>
+                        A SHACL UI could display the person’s <code>foaf:name</code> as text and list departments that
+                        reference the person via <code>ex:member</code>.
+                    </p>
+                </aside>
+            </section>
+
+            <section id="view-complex-paths">
+                <h4>Complex Paths</h4>
+                <p>
+                    SHACL UI implementations SHOULD support complex property paths in view mode. Complex paths include
+                    <a href="../shacl12-core/#property-path-sequence">sequence paths</a>,
+                    <a href="../shacl12-core/#property-path-alternative">alternative paths</a>,
+                    <a href="../shacl12-core/#property-path-zero-or-more">zero-or-more paths</a>,
+                    <a href="../shacl12-core/#property-path-one-or-more">one-or-more paths</a>,
+                    and
+                    <a href="../shacl12-core/#property-path-zero-or-one">zero-or-one paths</a> as defined in SHACL
+                    Core.
+                </p>
+                <p>
+                    Support for complex paths is recommended, but can be left out in cases where the implementation aims
+                    to provide symmetry between view and edit modes, and complex paths are not supported in edit mode.
+                </p>
+
+                <p>
+                    The following examples illustrate a sequence path and an alternative path, both of which may be used
+                    for richer data traversal in view mode.
+                </p>
+
+                <aside class="example" title="Complex paths in view mode">
+                    <div class="shapes-graph">
+                        <div class="turtle">
+ex:PersonShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path ( ex:address ex:cityName ) ;
+        sh:name "City" ;
+        sh:datatype xsd:string ;
+    ] .
+
+ex:BookShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path [
+            sh:alternativePath ( dct:title rdfs:label )
+        ] ;
+        sh:name "Title" ;
+        sh:datatype xsd:string ;
+    ] .
+                        </div>
+                    </div>
+
+                    <div class="data-graph">
+                        <div class="turtle">
+ex:alice a ex:Person ;
+    ex:address ex:aliceAddress .
+
+ex:aliceAddress ex:cityName "Ghent" .
+
+ex:book1 a ex:Book ;
+    dct:title "Linked Data Design" .
+                        </div>
+                    </div>
+
+                    <p>
+                        A SHACL UI could display Alice’s city as "Ghent" by traversing the <code>ex:address</code> node,
+                        and display the title of <code>ex:book1</code> as “Linked Data Design”.
+                    </p>
+                </aside>
+            </section>
+        </section>
+
+        <section id="property-paths-edit">
+            <h3>Edit Mode</h3>
+            <p>
+                In edit mode, property paths determine how changes to data and the creation of new data are applied
+                through the user interface.
+            </p>
+
+            <section id="edit-predicate-paths">
+                <h4>Predicate and Inverse Paths</h4>
+                <p>
+                    SHACL UI implementations MUST support
+                    <a href="../shacl12-core/#property-path-predicate">predicate paths</a> and
+                    <a href="../shacl12-core/#property-path-inverse">inverse paths</a> in edit mode.
+                    This allows users to modify data linked by simple properties or inverse properties.
+                </p>
+
+                <p>
+                    The following example illustrates how predicate and inverse paths can be used in edit mode to modify
+                    a person’s name and manage their membership in departments.
+                </p>
+
+                <aside class="example" title="Predicate and inverse paths in edit mode">
+                    <div class="shapes-graph">
+                        <div class="turtle">
+ex:PersonShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path foaf:name ;
+        sh:name "Name" ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path [ sh:inversePath ex:member ] ;
+        sh:name "Department" ;
+        sh:class ex:Department ;
+    ] .
+                        </div>
+                    </div>
+
+                    <div class="data-graph">
+                        <div class="turtle">
+ex:bob a ex:Person ;
+    foaf:name "Bob" .
+
+ex:engDept a ex:Department ;
+    ex:member ex:bob ;
+    rdfs:label "Engineering Department" .
+                        </div>
+                    </div>
+
+                    <p>
+                        A SHACL UI might render a text input for <code>foaf:name</code> and a selector for the
+                        departments.
+                        Editing inverse paths requires the UI to ensure consistent updates on the related nodes.
+                    </p>
+                </aside>
+            </section>
+
+            <section id="edit-alternative-paths">
+                <h4>Alternative Paths</h4>
+                <p>
+                    SHACL UI implementations SHOULD support
+                    <a href="../shacl12-core/#property-path-alternative">alternative paths</a> in edit mode.
+                    This enables editing where a shape can constrain multiple potential properties, and the UI can allow
+                    users to choose which alternative to use when entering or modifying data.
+                </p>
+
+                <p>
+                    When editing existing or newly created statements, the UI SHOULD provide a mechanism to update the
+                    predicate to one of the enumerated paths in the <code>sh:alternativePath</code> list, but only if
+                    those paths are either <a
+                        href="../shacl12-core/#property-path-predicate">predicate paths</a> or <a
+                        href="../shacl12-core/#property-path-inverse">inverse paths</a>. This restriction is necessary
+                    because the object of <code>sh:alternativePath</code> is a SHACL list that may contain any valid
+                    property path expression, including complex path types that are not generally feasible to edit
+                    directly through a user interface.
+                </p>
+
+                <p class="note">
+                    Although redundant, SHACL permits nesting of <code>sh:alternativePath</code> expressions.
+                    Such nesting simply flattens to a single list of predicate or inverse paths and does not alter the
+                    effective set of alternatives available for editing.
+                </p>
+
+                <p>
+                    The following example illustrates how an alternative path can be used in edit mode to allow a book's
+                    title to be provided through either <code>dct:title</code> or <code>rdfs:label</code>.
+                </p>
+
+                <aside class="example" title="Alternative paths in edit mode">
+                    <div class="shapes-graph">
+                        <div class="turtle">
+ex:BookShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path [
+            sh:alternativePath ( dct:title rdfs:label )
+        ] ;
+        sh:name "Title" ;
+        sh:datatype xsd:string ;
+    ] .
+                        </div>
+                    </div>
+
+                    <div class="data-graph">
+                        <div class="turtle">
+ex:book2 a ex:Book ;
+    rdfs:label "Semantic Web Foundations" .
+                        </div>
+                    </div>
+
+                    <p>
+                        A SHACL UI could show the existing title “Semantic Web Foundations” and allow the user to choose
+                        whether
+                        to edit it via <code>dct:title</code> or <code>rdfs:label</code>.
+                    </p>
+                </aside>
+            </section>
+
+            <section id="edit-other-complex-paths">
+                <h4>Other Complex Paths</h4>
+                <p>
+                    SHACL UI implementations MAY support the other complex paths (i.e.,
+                    <a href="../shacl12-core/#property-path-sequence">sequence paths</a>,
+                    <a href="../shacl12-core/#property-path-zero-or-more">zero-or-more paths</a>,
+                    <a href="../shacl12-core/#property-path-one-or-more">one-or-more paths</a>, and
+                    <a href="../shacl12-core/#property-path-zero-or-one">zero-or-one paths</a>)
+                    in edit mode.
+                </p>
+
+                <p>
+                    Implementers are encouraged to support these when their use cases require advanced
+                    data navigation or editing patterns, but such support is not mandatory as the complexity of editing
+                    through these paths may not be feasible in all user interface contexts.
+                </p>
+
+                <p class="note">
+                    Supporting complex property paths in edit mode introduces challenges related to ambiguity and the
+                    generation of intermediate data structures. Even when a path is used for view-only purposes,
+                    implementations must ensure that restrictions are in place to prevent ambiguous traversal results.
+                    SHACL property paths allow navigation across multiple steps in a graph, which can lead to
+                    situations where a single value is reachable through multiple distinct paths.
+                </p>
+
+                <aside class="example" title="Ambiguous complex paths in edit mode">
+                    <p>
+                        The following shape and data graph illustrate how a node can be reachable via a complex path
+                        expression, making editing operations ambiguous.
+                    </p>
+
+                    <div class="shapes-graph">
+                        <div class="turtle">
+ex:CompoundThingShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path [
+            sh:zeroOrMorePath ex:hasPart
+        ] ;
+        sh:name "All Descendant Parts" ;
+        sh:description "Traverses all parts and sub-parts using a zero-or-more path of hasPart relationships." ;
+    ] .
+                        </div>
+                    </div>
+
+                    <div class="data-graph">
+                        <div class="turtle">
+ex:compounded-thing
+    ex:hasPart ex:part-a ;
+    ex:hasPart ex:part-b .
+
+ex:part-a
+    ex:hasPart ex:screw .
+
+ex:part-b
+    ex:hasPart ex:screw .
+                        </div>
+                    </div>
+
+                    <p>
+                        In this example, the node <code>ex:screw</code> can be reached from
+                        <code>ex:compounded-thing</code> through two distinct paths:
+                    </p>
+
+                    <ul>
+                        <li><code>ex:compounded-thing → ex:hasPart → ex:part-a → ex:hasPart → ex:screw</code></li>
+                        <li><code>ex:compounded-thing → ex:hasPart → ex:part-b → ex:hasPart → ex:screw</code></li>
+                    </ul>
+
+                    <p>
+                        This illustrates why editing along complex property paths is non-trivial: it can be unclear
+                        which intermediate nodes or triples correspond to a user’s intended modification.
+                    </p>
+                </aside>
+            </section>
+        </section>
+    </section>
+
+    <section id="builtin-widgets">
+      <h2>Built-in Widgets</h2>
+
+      <section id="builtin-editors">
+        <h3>Editors</h3>
+        <p>
+          The following sub-sections enumerate the currently built-in instances of <code>shui:Editor</code> from the
+          SHACL UI namespace.
+        </p>
         <section id="AutoCompleteEditor">
           <h4>shui:AutoCompleteEditor</h4>
           <p>
@@ -947,23 +1316,10 @@ ex:Thing-seeAlso
         </section>
       </section>
 
-      <section id="viewers">
+      <section id="builtin-viewers">
         <h3>Viewers</h3>
         <p>
-          The following sub-sections enumerate the currently defined instances of <code>shui:Viewer</code> from the SHACL UI namespace.
-          A property shape can have an explicitly specified preferred viewer for its values in <code>shui:viewer</code>.
-          If no such value has been specified, the system should pick a suitable default viewer based on the
-          <a href="#score">scoring system</a> outlined for each widget.
-        </p>
-        <p id="multi">
-          Most viewers render a single RDF value on the screen, typically as a single widget.
-          Form editors offer buttons to edit individual values and to add or delete values.
-          However, some viewers need to take more complete control over how multiple values of a property at a focus node are rendered.
-          The only example of such a viewer in SHACL UI is <a href="#ValueTableViewer"><code>shui:ValueTableViewer</code></a>, which displays
-          all values of a property as an HTML table.
-          In those cases, the notions of generic add and delete buttons do not apply.
-          Such viewers are called <em>Multi Viewers</em> and are declared instances of <code>shui:MultiViewer</code> instead of <code>shui:SingleViewer</code>.
-          The equivalent classes for editors are <code>shui:MultiEditor</code> and <code>shui:SingleEditor</code>.
+          The following sub-sections enumerate the currently built-in instances of <code>shui:Viewer</code> from the SHACL UI namespace.
         </p>
         <section id="BlankNodeViewer">
           <h4>shui:BlankNodeViewer</h4>
@@ -1174,343 +1530,6 @@ ex:ConceptTableShape-altLabel
     sh:order "2"^^xsd:decimal .</pre>
         </section>
       </section>
-    </section>
-
-    <section id="core-constraints">
-      <h2>Core Constraints</h2>
-      <p>Content.</p>
-    </section>
-
-    <section id="property-paths">
-        <h2>Property Paths</h2>
-        <p>
-            <a href="../shacl12-core/#property-paths">SHACL Property Paths</a> can be used to render a SHACL shape as a
-            user interface.
-            Property paths define how data values are accessed or modified relative to a focus node.
-        </p>
-        <p>
-            The following subsections outline the scenarios in which SHACL UI implementations are expected to
-            support different kinds of property paths for viewing and editing operations.
-        </p>
-
-        <section id="property-paths-view">
-            <h3>View Mode</h3>
-            <p>
-                In view mode, property paths are used to retrieve and display data values associated with a shape.
-                A SHACL UI implementation must provide mechanisms to resolve these paths for visualization.
-            </p>
-
-            <section id="view-predicate-paths">
-                <h4>Predicate and Inverse Paths</h4>
-                <p>
-                    SHACL UI implementations MUST support both
-                    <a href="../shacl12-core/#property-path-predicate">predicate paths</a> and
-                    <a href="../shacl12-core/#property-path-inverse">inverse paths</a> in view mode.
-                    This ensures that values reachable via simple forward or inverse relationships can be displayed to
-                    the user.
-                </p>
-
-                <p>
-                    The following example illustrates how predicate and inverse paths are used in view mode to access
-                    and display values, either directly from the focus node or through incoming relationships from other
-                    nodes.
-                </p>
-
-                <aside class="example" title="Predicate and inverse paths in view mode">
-                    <div class="shapes-graph">
-                        <div class="turtle">
-ex:PersonShape
-    a sh:NodeShape ;
-    sh:property [
-        sh:path foaf:name ;
-        sh:name "Name" ;
-        sh:datatype xsd:string ;
-    ] ;
-    sh:property [
-        sh:path [ sh:inversePath ex:member ] ;
-        sh:name "Department" ;
-    ] .
-                        </div>
-                    </div>
-
-                    <div class="data-graph">
-                        <div class="turtle">
-ex:alice a ex:Person ;
-    foaf:name "Alice" .
-
-ex:researchDept a ex:Department ;
-    ex:member ex:alice ;
-    rdfs:label "Research Department" .
-                        </div>
-                    </div>
-
-                    <p>
-                        A SHACL UI could display the person’s <code>foaf:name</code> as text and list departments that
-                        reference the person via <code>ex:member</code>.
-                    </p>
-                </aside>
-            </section>
-
-            <section id="view-complex-paths">
-                <h4>Complex Paths</h4>
-                <p>
-                    SHACL UI implementations SHOULD support complex property paths in view mode. Complex paths include
-                    <a href="../shacl12-core/#property-path-sequence">sequence paths</a>,
-                    <a href="../shacl12-core/#property-path-alternative">alternative paths</a>,
-                    <a href="../shacl12-core/#property-path-zero-or-more">zero-or-more paths</a>,
-                    <a href="../shacl12-core/#property-path-one-or-more">one-or-more paths</a>,
-                    and
-                    <a href="../shacl12-core/#property-path-zero-or-one">zero-or-one paths</a> as defined in SHACL
-                    Core.
-                </p>
-                <p>
-                    Support for complex paths is recommended, but can be left out in cases where the implementation aims
-                    to provide symmetry between view and edit modes, and complex paths are not supported in edit mode.
-                </p>
-
-                <p>
-                    The following examples illustrate a sequence path and an alternative path, both of which may be used
-                    for richer data traversal in view mode.
-                </p>
-
-                <aside class="example" title="Complex paths in view mode">
-                    <div class="shapes-graph">
-                        <div class="turtle">
-ex:PersonShape
-    a sh:NodeShape ;
-    sh:property [
-        sh:path ( ex:address ex:cityName ) ;
-        sh:name "City" ;
-        sh:datatype xsd:string ;
-    ] .
-
-ex:BookShape
-    a sh:NodeShape ;
-    sh:property [
-        sh:path [
-            sh:alternativePath ( dct:title rdfs:label )
-        ] ;
-        sh:name "Title" ;
-        sh:datatype xsd:string ;
-    ] .
-                        </div>
-                    </div>
-
-                    <div class="data-graph">
-                        <div class="turtle">
-ex:alice a ex:Person ;
-    ex:address ex:aliceAddress .
-
-ex:aliceAddress ex:cityName "Ghent" .
-
-ex:book1 a ex:Book ;
-    dct:title "Linked Data Design" .
-                        </div>
-                    </div>
-
-                    <p>
-                        A SHACL UI could display Alice’s city as "Ghent" by traversing the <code>ex:address</code> node,
-                        and display the title of <code>ex:book1</code> as “Linked Data Design”.
-                    </p>
-                </aside>
-            </section>
-        </section>
-
-        <section id="property-paths-edit">
-            <h3>Edit Mode</h3>
-            <p>
-                In edit mode, property paths determine how changes to data and the creation of new data are applied
-                through the user interface.
-            </p>
-
-            <section id="edit-predicate-paths">
-                <h4>Predicate and Inverse Paths</h4>
-                <p>
-                    SHACL UI implementations MUST support
-                    <a href="../shacl12-core/#property-path-predicate">predicate paths</a> and
-                    <a href="../shacl12-core/#property-path-inverse">inverse paths</a> in edit mode.
-                    This allows users to modify data linked by simple properties or inverse properties.
-                </p>
-
-                <p>
-                    The following example illustrates how predicate and inverse paths can be used in edit mode to modify
-                    a person’s name and manage their membership in departments.
-                </p>
-
-                <aside class="example" title="Predicate and inverse paths in edit mode">
-                    <div class="shapes-graph">
-                        <div class="turtle">
-ex:PersonShape
-    a sh:NodeShape ;
-    sh:property [
-        sh:path foaf:name ;
-        sh:name "Name" ;
-        sh:datatype xsd:string ;
-    ] ;
-    sh:property [
-        sh:path [ sh:inversePath ex:member ] ;
-        sh:name "Department" ;
-        sh:class ex:Department ;
-    ] .
-                        </div>
-                    </div>
-
-                    <div class="data-graph">
-                        <div class="turtle">
-ex:bob a ex:Person ;
-    foaf:name "Bob" .
-
-ex:engDept a ex:Department ;
-    ex:member ex:bob ;
-    rdfs:label "Engineering Department" .
-                        </div>
-                    </div>
-
-                    <p>
-                        A SHACL UI might render a text input for <code>foaf:name</code> and a selector for the
-                        departments.
-                        Editing inverse paths requires the UI to ensure consistent updates on the related nodes.
-                    </p>
-                </aside>
-            </section>
-
-            <section id="edit-alternative-paths">
-                <h4>Alternative Paths</h4>
-                <p>
-                    SHACL UI implementations SHOULD support
-                    <a href="../shacl12-core/#property-path-alternative">alternative paths</a> in edit mode.
-                    This enables editing where a shape can constrain multiple potential properties, and the UI can allow
-                    users to choose which alternative to use when entering or modifying data.
-                </p>
-
-                <p>
-                    When editing existing or newly created statements, the UI SHOULD provide a mechanism to update the
-                    predicate to one of the enumerated paths in the <code>sh:alternativePath</code> list, but only if
-                    those paths are either <a
-                        href="../shacl12-core/#property-path-predicate">predicate paths</a> or <a
-                        href="../shacl12-core/#property-path-inverse">inverse paths</a>. This restriction is necessary
-                    because the object of <code>sh:alternativePath</code> is a SHACL list that may contain any valid
-                    property path expression, including complex path types that are not generally feasible to edit
-                    directly through a user interface.
-                </p>
-
-                <p class="note">
-                    Although redundant, SHACL permits nesting of <code>sh:alternativePath</code> expressions.
-                    Such nesting simply flattens to a single list of predicate or inverse paths and does not alter the
-                    effective set of alternatives available for editing.
-                </p>
-
-                <p>
-                    The following example illustrates how an alternative path can be used in edit mode to allow a book's
-                    title to be provided through either <code>dct:title</code> or <code>rdfs:label</code>.
-                </p>
-
-                <aside class="example" title="Alternative paths in edit mode">
-                    <div class="shapes-graph">
-                        <div class="turtle">
-ex:BookShape
-    a sh:NodeShape ;
-    sh:property [
-        sh:path [
-            sh:alternativePath ( dct:title rdfs:label )
-        ] ;
-        sh:name "Title" ;
-        sh:datatype xsd:string ;
-    ] .
-                        </div>
-                    </div>
-
-                    <div class="data-graph">
-                        <div class="turtle">
-ex:book2 a ex:Book ;
-    rdfs:label "Semantic Web Foundations" .
-                        </div>
-                    </div>
-
-                    <p>
-                        A SHACL UI could show the existing title “Semantic Web Foundations” and allow the user to choose
-                        whether
-                        to edit it via <code>dct:title</code> or <code>rdfs:label</code>.
-                    </p>
-                </aside>
-            </section>
-
-            <section id="edit-other-complex-paths">
-                <h4>Other Complex Paths</h4>
-                <p>
-                    SHACL UI implementations MAY support the other complex paths (i.e.,
-                    <a href="../shacl12-core/#property-path-sequence">sequence paths</a>,
-                    <a href="../shacl12-core/#property-path-zero-or-more">zero-or-more paths</a>,
-                    <a href="../shacl12-core/#property-path-one-or-more">one-or-more paths</a>, and
-                    <a href="../shacl12-core/#property-path-zero-or-one">zero-or-one paths</a>)
-                    in edit mode.
-                </p>
-
-                <p>
-                    Implementers are encouraged to support these when their use cases require advanced
-                    data navigation or editing patterns, but such support is not mandatory as the complexity of editing
-                    through these paths may not be feasible in all user interface contexts.
-                </p>
-
-                <p class="note">
-                    Supporting complex property paths in edit mode introduces challenges related to ambiguity and the
-                    generation of intermediate data structures. Even when a path is used for view-only purposes,
-                    implementations must ensure that restrictions are in place to prevent ambiguous traversal results.
-                    SHACL property paths allow navigation across multiple steps in a graph, which can lead to
-                    situations where a single value is reachable through multiple distinct paths.
-                </p>
-
-                <aside class="example" title="Ambiguous complex paths in edit mode">
-                    <p>
-                        The following shape and data graph illustrate how a node can be reachable via a complex path
-                        expression, making editing operations ambiguous.
-                    </p>
-
-                    <div class="shapes-graph">
-                        <div class="turtle">
-ex:CompoundThingShape
-    a sh:NodeShape ;
-    sh:property [
-        sh:path [
-            sh:zeroOrMorePath ex:hasPart
-        ] ;
-        sh:name "All Descendant Parts" ;
-        sh:description "Traverses all parts and sub-parts using a zero-or-more path of hasPart relationships." ;
-    ] .
-                        </div>
-                    </div>
-
-                    <div class="data-graph">
-                        <div class="turtle">
-ex:compounded-thing
-    ex:hasPart ex:part-a ;
-    ex:hasPart ex:part-b .
-
-ex:part-a
-    ex:hasPart ex:screw .
-
-ex:part-b
-    ex:hasPart ex:screw .
-                        </div>
-                    </div>
-
-                    <p>
-                        In this example, the node <code>ex:screw</code> can be reached from
-                        <code>ex:compounded-thing</code> through two distinct paths:
-                    </p>
-
-                    <ul>
-                        <li><code>ex:compounded-thing → ex:hasPart → ex:part-a → ex:hasPart → ex:screw</code></li>
-                        <li><code>ex:compounded-thing → ex:hasPart → ex:part-b → ex:hasPart → ex:screw</code></li>
-                    </ul>
-
-                    <p>
-                        This illustrates why editing along complex property paths is non-trivial: it can be unclear
-                        which intermediate nodes or triples correspond to a user’s intended modification.
-                    </p>
-                </aside>
-            </section>
-        </section>
     </section>
 
     <section id="syntax-rules" class="appendix">


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #663

- Adds a built-in widget section.
- Moves the built-in widget to that section.
- Keeps the widget and the editors/viewers section.

This PR doesn't touch the text of Editors and Viewers. Those sections should be updated once the terminology is added.


* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-663-builtin-widget/shacl12-ui/index.html)
