### PR TITLE
#648: Moved table of severities below syntax rules, added fallback for sh:message in SPARQL

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -1456,37 +1456,6 @@ ex:Bob a ex:Person .
 						<span data-syntax-rule="severity-nodeKind">Each value of <code>sh:severity</code> is an <a>IRI</a>.</span>
 					</p>
 					<p>
-						The values of <code>sh:severity</code> are called <dfn data-lt="severity">severities</dfn>.
-						SHACL includes the IRIs listed in the table below to represent <a>severities</a>.
-						These are declared in the SHACL vocabulary as SHACL instances of <code>sh:Severity</code>.
-					</p>
-					<table class="term-table">
-						<tbody><tr>
-							<th>Severity</th>
-							<th>Description</th>
-						</tr>
-						<tr>
-							<td><code>sh:Trace</code></td>
-							<td>A trace message that is not a constraint violation.</td>
-						</tr>
-						<tr>
-							<td><code>sh:Debug</code></td>
-							<td>A debug message that is not a constraint violation.</td>
-						</tr>
-						<tr>
-							<td><code>sh:Info</code></td>
-							<td>A non-critical constraint violation indicating an informative message.</td>
-						</tr>
-						<tr>
-							<td><code>sh:Warning</code></td>
-							<td>A non-critical constraint violation indicating a warning.</td>
-						</tr>
-						<tr>
-							<td><code>sh:Violation</code></td>
-							<td>A constraint violation.</td>
-						</tr>
-					</tbody></table>
-					<p>
 						In addition to declaring severities per shape, the property <code>sh:severity</code> can also be used
 						on a <a>reifier</a> for a triple where the <a>shape</a> is the <a>subject</a> and one of the <a>parameters</a>
 						of the <a>constraint</a> is the <a>predicate</a>.
@@ -1497,6 +1466,39 @@ ex:Bob a ex:Person .
 						A <a>shapes graph</a> can specify at most one <a>value</a> for the property <code>sh:severity</code>
 						in the <a>reifiers</a> of the <a>triples</a> in <code>T</code>.
 					</span></p>
+					<p>
+						The values of <code>sh:severity</code> are called <dfn data-lt="severity">severities</dfn>.
+						SHACL includes the IRIs listed in the table below to represent <a>severities</a>.
+						These are declared in the SHACL vocabulary as SHACL instances of <code>sh:Severity</code>.
+					</p>
+					<table class="term-table">
+						<tbody>
+							<tr>
+								<th>Severity</th>
+								<th>Description</th>
+							</tr>
+							<tr>
+								<td><code>sh:Trace</code></td>
+								<td>A trace message that is not a constraint violation.</td>
+							</tr>
+							<tr>
+								<td><code>sh:Debug</code></td>
+								<td>A debug message that is not a constraint violation.</td>
+							</tr>
+							<tr>
+								<td><code>sh:Info</code></td>
+								<td>A non-critical constraint violation indicating an informative message.</td>
+							</tr>
+							<tr>
+								<td><code>sh:Warning</code></td>
+								<td>A non-critical constraint violation indicating a warning.</td>
+							</tr>
+							<tr>
+								<td><code>sh:Violation</code></td>
+								<td>A constraint violation.</td>
+							</tr>
+						</tbody>
+					</table>
 					<p><em>The remainder of this section is informative.</em></p>
 					<p>
 						The validation process handles the values of <code>sh:severity</code> according to <a>conformance checking</a>.

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -1467,8 +1467,8 @@ ex:Bob a ex:Person .
 						in the <a>reifiers</a> of the <a>triples</a> in <code>T</code>.
 					</span></p>
 					<p>
-						The values of <code>sh:severity</code> are called <dfn data-lt="severity">severities</dfn>.
-						SHACL includes the IRIs listed in the table below to represent <a>severities</a>.
+						A value of <code>sh:severity</code> is called a <dfn>severity</dfn>.
+						SHACL includes the IRIs listed in the table below to represent [=severities=].
 						These are declared in the SHACL vocabulary as SHACL instances of <code>sh:Severity</code>.
 					</p>
 					<table class="term-table">

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -854,7 +854,7 @@ ex:
 										For SPARQL-based constraint components: The values of <code>sh:message</code> of the <a>SPARQL-based constraint component</a>.
 									</li>
 									<li>
-										The default mechanism for <a data-cite="shacl12-core/#message">declaring messages</a> at the shape or constraint apply otherwise.
+										The default mechanisms for <a data-cite="shacl12-core/#message">declaring messages</a> at the shape or constraint apply otherwise.
 									</li>
 								</ol>
 								<div>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -853,6 +853,9 @@ ex:
 									<li>
 										For SPARQL-based constraint components: The values of <code>sh:message</code> of the <a>SPARQL-based constraint component</a>.
 									</li>
+									<li>
+										The default mechanism for <a data-cite="shacl12-core/#message">declaring messages</a> at the shape or constraint apply otherwise.
+									</li>
 								</ol>
 								<div>
 									These message literals may include the names of any SELECT result variables via <code>{?varName}</code> or <code>{$varName}</code>.


### PR DESCRIPTION


<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #648

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-648/shacl12-core/index.html)
