### PR TITLE
#649: Fixed definitions to singular, added uniqueness

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -297,15 +297,7 @@
 					</div>
 				</div>
 				<div class="def">
-					<div class="term-def-header">Binding, Solution</div>
-					<div>
-						A <dfn data-lt="bindings">binding</dfn> is a pair (<a data-cite="sparql12-query/#defn_QueryVariable">variable</a>, <a>RDF term</a>), consistent with the term's use in [[!sparql12-query]].
-					    A <dfn data-lt="solutions">solution</dfn> is a set of bindings, informally often understood as one row in the body of the result table of a SPARQL query.
-					    Variables are not required to be bound in a solution.
-					</div>
-				</div>
-				<div class="def">
-				<div class="term-def-header">SHACL Subclass, SHACL superclass</div>
+					<div class="term-def-header">SHACL Subclass, SHACL superclass</div>
 					<div>
 						A <a>node</a> <code>Sub</code> in an <a>RDF graph</a> is a <dfn data-lt="SHACL subclass|subclass|subclasses">SHACL subclass</dfn> of another <a>node</a> <code>Super</code>
 						in the <a>graph</a> if there is a sequence of <a>triples</a> in the <a>graph</a> each with predicate <code>rdfs:subClassOf</code> such that the <a>subject</a> of the first <a>triple</a> is <code>Sub</code>,

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -247,7 +247,6 @@
 						A <dfn>binding</dfn> is a pair (<a data-cite="sparql12-query/#defn_QueryVariable">variable</a>, <a>RDF term</a>), consistent with the term's use in [[!sparql12-query]].
 					    A <dfn>solution</dfn> is a set of bindings where each variable must be unique.
 						Informally, a solution is often understood as one row in the body of the result table of a SPARQL query.
-					    Variables are not required to be bound in a solution.
 					</div>
 				</div>
 

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -154,16 +154,12 @@
 				by means of SPARQL.
 				In particular, this document defines how constraints and constraint components can be defined using SPARQL.
 			</p>
-			<p class="todo">
-				TODO: More will be added on Node Expressions/targets once that part is ready.
-				Other features from SHACL-AF such as user-defined functions may get added.
-			</p>
 		</section>
 
 		<section id="sotd">
 		</section>
 
-    <section id="specifications" class="introductory" data-include="../shacl12-common/specifications.html"></section>
+    	<section id="specifications" class="introductory" data-include="../shacl12-common/specifications.html"></section>
 
 		<section id="introduction">
 			<h2>Introduction</h2>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -244,8 +244,9 @@
 				<div class="def">
 					<div class="term-def-header">Binding, Solution</div>
 					<div>
-						A <dfn data-lt="bindings">binding</dfn> is a pair (<a data-cite="sparql12-query/#defn_QueryVariable">variable</a>, <a>RDF term</a>), consistent with the term's use in [[!sparql12-query]].
-					    A <dfn data-lt="solutions">solution</dfn> is a set of bindings, informally often understood as one row in the body of the result table of a SPARQL query.
+						A <dfn>binding</dfn> is a pair (<a data-cite="sparql12-query/#defn_QueryVariable">variable</a>, <a>RDF term</a>), consistent with the term's use in [[!sparql12-query]].
+					    A <dfn>solution</dfn> is a set of bindings where each variable must be unique.
+						Informally, a solution is often understood as one row in the body of the result table of a SPARQL query.
 					    Variables are not required to be bound in a solution.
 					</div>
 				</div>


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #649

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-649/shacl12-sparql/index.html)

@afs here is a PR that hopefully addresses the uniqueness constraints (thanks for pointing that out). I am not sure if the language around unbound mappings is good enough now, and I would appreciate if you could add a suggestion in GitHub with a better wording.
