### PR TITLE
Fixes for shacl12-common

### DIFF
--- a/shacl12-common/specifications.html
+++ b/shacl12-common/specifications.html
@@ -11,7 +11,7 @@
 				<dt><a href="https://w3c.github.io/data-shapes/shacl12-core/">SHACL 1.2 Core</a></dt>
 				<dd>defines the Core of SHACL</dd>
 				<dt><a href="https://w3c.github.io/data-shapes/shacl12-sparql/">SHACL 1.2 SPARQL Extensions</a></dt>
-				<dd>defines SPARQL-related extensions of the SHACL</dd>
+				<dd>defines SPARQL-related extensions of SHACL</dd>
 				<dt><a href="https://w3c.github.io/data-shapes/shacl12-node-expr/">SHACL 1.2 Node Expressions</a></dt>
 				<dd>defines graph expressions used to determine focus nodes in SHACL</dd>
 				<dt><a href="https://w3c.github.io/data-shapes/shacl12-rules/">SHACL 1.2 Rules</a></dt>
@@ -31,7 +31,7 @@
         <dt data-transform="noSelfCite">[[[shacl12-core]]]</dt>
         <dd>defines the Core of SHACL</dd>
         <dt data-transform="noSelfCite">[[[shacl12-sparql]]]</dt>
-        <dd>defines SPARQL-related extensions of the SHACL</dd>
+        <dd>defines SPARQL-related extensions of SHACL</dd>
         <dt data-transform="noSelfCite">[[[shacl12-node-expr]]]</dt>
         <dd>defines graph expressions used to determine focus nodes in SHACL</dd>
         <dt data-transform="noSelfCite">[[[shacl12-rules]]]</dt>

--- a/shacl12-common/specifications.html
+++ b/shacl12-common/specifications.html
@@ -1,28 +1,28 @@
-			<h2>SHACL Specifications</h2>
-			<p>
-				This specification is part of the SHACL 1.2 family of specifications. See the <a href="https://w3c.github.io/data-shapes/shacl12-overview/">SHACL 1.2 Overview</a> for a more detailed introduction to them.
-			</p>
-			<p>
-				The specifications are as follows:
-			</p>
-			<dl>
-				<dt><a href="https://w3c.github.io/data-shapes/shacl12-overview/">SHACL 1.2 Overview</a></dt>
-				<dd>overviews the set of SHACL specifications</dd>
-				<dt><a href="https://w3c.github.io/data-shapes/shacl12-core/">SHACL 1.2 Core</a></dt>
-				<dd>defines the Core of SHACL</dd>
-				<dt><a href="https://w3c.github.io/data-shapes/shacl12-sparql/">SHACL 1.2 SPARQL Extensions</a></dt>
-				<dd>defines SPARQL-related extensions of SHACL</dd>
-				<dt><a href="https://w3c.github.io/data-shapes/shacl12-node-expr/">SHACL 1.2 Node Expressions</a></dt>
-				<dd>defines graph expressions used to determine focus nodes in SHACL</dd>
-				<dt><a href="https://w3c.github.io/data-shapes/shacl12-rules/">SHACL 1.2 Rules</a></dt>
-				<dd>defines SHACL's methods of rule-based inference</dd>
-				<dt><a href="https://w3c.github.io/data-shapes/shacl12-ui/">SHACL 1.2 UI</a></dt>
-				<dd>defines SHACL's use for User Interface generation</dd>
-				<dt><a href="https://w3c.github.io/data-shapes/shacl12-compact-syntax/">SHACL 1.2 Compact Syntax</a></dt>
-				<dd>defines an RDF syntax for expressing SHACL concepts</dd>
+      <h2>SHACL Specifications</h2>
+      <p>
+        This specification is part of the SHACL 1.2 family of specifications. See the <a href="https://w3c.github.io/data-shapes/shacl12-overview/">SHACL 1.2 Overview</a> for a more detailed introduction to them.
+      </p>
+      <p>
+        The specifications are as follows:
+      </p>
+      <dl>
+        <dt><a href="https://w3c.github.io/data-shapes/shacl12-overview/">SHACL 1.2 Overview</a></dt>
+        <dd>overviews the set of SHACL specifications</dd>
+        <dt><a href="https://w3c.github.io/data-shapes/shacl12-core/">SHACL 1.2 Core</a></dt>
+        <dd>defines the Core of SHACL</dd>
+        <dt><a href="https://w3c.github.io/data-shapes/shacl12-sparql/">SHACL 1.2 SPARQL Extensions</a></dt>
+        <dd>defines SPARQL-related extensions of SHACL</dd>
+        <dt><a href="https://w3c.github.io/data-shapes/shacl12-node-expr/">SHACL 1.2 Node Expressions</a></dt>
+        <dd>defines graph expressions used to determine focus nodes in SHACL</dd>
+        <dt><a href="https://w3c.github.io/data-shapes/shacl12-rules/">SHACL 1.2 Rules</a></dt>
+        <dd>defines SHACL's methods of rule-based inference</dd>
+        <dt><a href="https://w3c.github.io/data-shapes/shacl12-ui/">SHACL 1.2 UI</a></dt>
+        <dd>defines SHACL's use for User Interface generation</dd>
+        <dt><a href="https://w3c.github.io/data-shapes/shacl12-compact-syntax/">SHACL 1.2 Compact Syntax</a></dt>
+        <dd>defines an RDF syntax for expressing SHACL concepts</dd>
         <dt><a href="https://w3c.github.io/data-shapes/shacl12-profiling/">SHACL 1.2 Profiling</a></dt>
-				<dd>defines the use of SHACL for profiling data, including SHACL data</dd>
-			</dl>
+        <dd>defines the use of SHACL for profiling data, including SHACL data</dd>
+      </dl>
 
       <!--
       <dl>


### PR DESCRIPTION
* [Fix for description of SHACL-SPARQL](https://github.com/w3c/data-shapes/commit/cfbf6ca7258a2c261096de2b7ae561f2d8a1c7ce)

* [Replace partial use of tabs by spaces](https://github.com/w3c/data-shapes/commit/a16dc154470afdd9296901f76e6514d6c37d2795)

&nbsp;

[See this document rendered online here](https://raw.githack.com/w3c/data-shapes/typo-common/shacl12-common/specifications.html)
