### PR TITLE
#496: Replaced shnex and shui namespaces

### DIFF
--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -33,9 +33,9 @@
 				const RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label";
 				const RDFS_COMMENT = "http://www.w3.org/2000/01/rdf-schema#comment";
 				const RDFS_ISDEFINEDBY = "http://www.w3.org/2000/01/rdf-schema#isDefinedBy";
-				const SHNEX_SPECREF = "http://www.w3.org/ns/shnex#specRef";
-				const SHNEX_CATEGORY = "http://www.w3.org/ns/shnex-sparql#category";
-				const SHNEX_EXAMPLE = "http://www.w3.org/ns/shnex-sparql#example";
+				const SHNEX_SPECREF = "http://www.w3.org/ns/shacl-node-expr#specRef";
+				const SHNEX_CATEGORY = "http://www.w3.org/ns/shacl-node-expr-sparql#category";
+				const SHNEX_EXAMPLE = "http://www.w3.org/ns/shacl-node-expr-sparql#example";
 				const DC_DESCRIPTION = "http://purl.org/dc/terms/description";
 				const OWL_SEEALSO = "http://www.w3.org/2002/07/owl#seeAlso";
 	
@@ -552,7 +552,7 @@
 					</tr>
 					<tr>
 						<td><code>shnex:</code></td>
-						<td><code>http://www.w3.org/ns/shnex#</code></td>
+						<td><code>http://www.w3.org/ns/shacl-node-expr#</code></td>
 					</tr>
 					<tr>
 						<td><code>skos:</code></td>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -421,7 +421,7 @@
           </tr>
           <tr>
             <td><code>shui:</code></td>
-            <td><code>http://www.w3.org/ns/shui#</code></td>
+            <td><code>http://www.w3.org/ns/shacl-ui#</code></td>
           </tr>
           <tr>
             <td><code>xsd:</code></td>
@@ -444,7 +444,7 @@
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "sh": "http://www.w3.org/ns/shacl#",
-    "shui": "http://www.w3.org/ns/shui#",
+    "shui": "http://www.w3.org/ns/shacl-ui#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "ex": "http://example.com/ns#",
     "dct": "http://purl.org/dc/terms/"

--- a/shacl12-vocabularies/shnex-sparql.ttl
+++ b/shacl12-vocabularies/shnex-sparql.ttl
@@ -11,8 +11,8 @@
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh:    <http://www.w3.org/ns/shacl#> .
-@prefix shnex: <http://www.w3.org/ns/shnex#> .
-@prefix shnex-sparql: <http://www.w3.org/ns/shnex-sparql#> .
+@prefix shnex: <http://www.w3.org/ns/shacl-node-expr#> .
+@prefix shnex-sparql: <http://www.w3.org/ns/shacl-node-expr-sparql#> .
 @prefix sparql:  <http://www.w3.org/ns/sparql#> .
 
 shnex-sparql:
@@ -23,7 +23,7 @@ shnex-sparql:
 		sh:prefix "sparql" ;
 		sh:namespace "http://www.w3.org/ns/sparql#"^^xsd:anyURI ;
 	] ;
-	owl:imports <http://www.w3.org/ns/shnex#>  .
+	owl:imports <http://www.w3.org/ns/shacl-node-expr#>  .
 
 
 shnex-sparql:category

--- a/shacl12-vocabularies/shnex.ttl
+++ b/shacl12-vocabularies/shnex.ttl
@@ -12,7 +12,7 @@
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 
 @prefix sh:    <http://www.w3.org/ns/shacl#> .
-@prefix shnex: <http://www.w3.org/ns/shnex#> .
+@prefix shnex: <http://www.w3.org/ns/shacl-node-expr#> .
 
 shnex:
 	a owl:Ontology ;
@@ -20,7 +20,7 @@ shnex:
 	rdfs:comment "This vocabulary defines Node Expression functions built into compliant SHACL engines."@en ;
 	sh:declare [
 		sh:prefix "shnex" ;
-		sh:namespace "http://www.w3.org/ns/shnex#"^^xsd:anyURI ;
+		sh:namespace "http://www.w3.org/ns/shacl-node-expr#"^^xsd:anyURI ;
 	] ;
 	owl:imports <http://www.w3.org/ns/shacl#> .
 


### PR DESCRIPTION
As discussed in https://github.com/w3c/data-shapes/issues/496#issuecomment-3586054793

This includes changes to shacl-ui, which I usually don't edit, thus the review requests.