### PR TITLE
#665: Added links to definition of validation result

### DIFF
--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -235,6 +235,7 @@
 						<dfn data-cite="shacl12-core#dfn-focus-graph" data-lt="focus graph">focus graph</dfn>,
 						<dfn data-cite="shacl12-core#dfn-conform" data-lt="conform|conforms">conform</dfn>,
 						<dfn data-cite="shacl12-core#dfn-failure" data-lt="failure|failures">failure</dfn>,
+						<dfn data-cite="shacl12-core#dfn-validation-result" data-lt="validation result">validation result</dfn>,
 						<dfn data-cite="shacl12-core#dfn-shacl-instance" data-lt="shacl instance">SHACL instance</dfn>,
 						<dfn data-cite="shacl12-core#dfn-shacl-subclass" data-lt="shacl subclass">SHACL subclass</dfn>,
 						<dfn data-cite="shacl12-core#dfn-shacl-type" data-lt="shacl type">SHACL type</dfn>,
@@ -582,8 +583,8 @@ ex:ValidCountry a ex:Country ;
 				</aside>
 				<p>
 					The SPARQL query returns result set <a>solutions</a> for all bindings of the variable <code>value</code> that violate the constraint.
-					There is a validation result for each <a>solution</a> in that result set, applying the <a href="#sparql-constraints-validation">mapping rules</a> explained later.
-					In this example, each validation result will have the <a>binding</a> for the variable <code>this</code> as the <code>sh:focusNode</code>,
+					There is a <a>validation result</a> for each <a>solution</a> in that result set, applying the <a href="#sparql-constraints-validation">mapping rules</a> explained later.
+					In this example, each <a>validation result</a> will have the <a>binding</a> for the variable <code>this</code> as the <code>sh:focusNode</code>,
 					<code>ex:germanLabel</code> as <code>sh:resultPath</code> and the violating value as <code>sh:value</code>.
 				</p>
 				<p>
@@ -781,7 +782,7 @@ ex:
 					<div class="def-header">TEXTUAL DEFINITION</div>
 					<div class="def-text-body">
 						Let <code>$sparql</code> be a <a>value</a> of <code>sh:sparql</code>.
-						There are no validation results if the <a>SPARQL-based constraint</a> has <code>true</code>
+						There are no <a>validation results</a> if the <a>SPARQL-based constraint</a> has <code>true</code>
 						as a <a>value</a> for the property <code>sh:deactivated</code>.
 						Otherwise, execute the SPARQL query specified by the <a>SPARQL-based constraint</a> <code>$sparql</code>
 						<a>pre-binding</a> the variable <code>this</code> as described in <a href="#sparql-constraints-prebound"></a>.
@@ -790,8 +791,8 @@ ex:
 						position of a <a data-cite="sparql12-query/#QSynTriples">triple pattern</a>
 						with a valid SPARQL surface syntax string of the <a>SHACL property path</a>
 						specified via <code>sh:path</code> at the <a>property shape</a>.
-						<span id="sparql-constraints-validation-rule">There is one validation result for each <a>solution</a> that does not have <code>true</code> as the <a>binding</a> for the variable <code>failure</code>.
-						These validation results MUST have the property values explained in <a href="#sparql-constraints-variables"></a>.
+						<span id="sparql-constraints-validation-rule">There is one <a>validation result</a> for each <a>solution</a> that does not have <code>true</code> as the <a>binding</a> for the variable <code>failure</code>.
+						These <a>validation results</a> MUST have the property values explained in <a href="#sparql-constraints-variables"></a>.
 						A <a>failure</a> MUST be produced if and only if one of the <a>solutions</a> has <code>true</code> as the <a>binding</a> for <code>failure</code>.</span>
 					</div>
 				</div>
@@ -807,7 +808,7 @@ ex:
 				<section id="sparql-constraints-variables">
 					<h4>Mapping of Solution Bindings to Result Properties</h4>
 					<p>
-						The property <a>values</a> of the validation result nodes are derived by the following rules, through a combination of result solutions and the values of the constraint itself.
+						The property <a>values</a> of the <a>validation result</a> nodes are derived by the following rules, through a combination of result solutions and the values of the constraint itself.
 						The rules are meant to be executed from top to bottom, so that the first bound value will be used.
 					</p>
 					<table class="term-table">
@@ -1301,7 +1302,7 @@ ex:hasLang
 					MUST be <a>pre-bound</a> as a variable that has the <a>parameter name</a> as its name.
 				</p>
 				<p>
-					The production rules for the validation results are identical to those for <a href="#sparql-constraints-validation-rule">SPARQL-based constraints</a>,
+					The production rules for the <a>validation results</a> are identical to those for <a href="#sparql-constraints-validation-rule">SPARQL-based constraints</a>,
 					using the <a>solutions</a> <code>QS</code> as produced above.
 				</p>
 			</section>
@@ -1311,12 +1312,12 @@ ex:hasLang
 			<h2>Annotation Properties</h2>
 			<p>
 				This section extends the general <a href="#sparql-constraints-variables">mechanism</a>
-				to produce validation results using <a href="sparql-constraints">SPARQL-based constraints</a> or
+				to produce <a>validation results</a> using <a href="sparql-constraints">SPARQL-based constraints</a> or
 				<a href="sparql-constraint-components">constraint components</a>.
 			</p>
 			<p>
 				Implementations that support this feature make it possible to inject <dfn>annotation properties</dfn>
-				into the validation result nodes created for each <a>solution</a> produced by the <code>SELECT</code> queries of a
+				into the <a>validation result</a> nodes created for each <a>solution</a> produced by the <code>SELECT</code> queries of a
 				SPARQL-based <a>constraint</a> or <a>constraint component</a>.
 				Any such annotation property needs to be declared via a <a>value</a> of <code>sh:resultAnnotation</code> at
 				the <a>subject</a> of the <code>sh:select</code> or <code>sh:ask</code> <a>triple</a>.
@@ -1370,7 +1371,7 @@ ex:hasLang
 			<p>
 				If a variable name could be determined, then the SHACL processor copies the <a>binding</a> for the given variable
 				as a value for the property specified using <code>sh:annotationProperty</code>
-				into the validation result that is being produced for the current <a>solution</a>.
+				into the <a>validation result</a> that is being produced for the current <a>solution</a>.
 				If the variable has no <a>binding</a> in the result set <a>solution</a>,
 				then the <a>values</a> of <code>sh:annotationValue</code> are used, if present.
 			</p>
@@ -1884,7 +1885,7 @@ ASK {
 					The following query expresses a potential SPARQL-based validator for <a data-cite="shacl12-core#MinExclusiveConstraintComponent">sh:minExclusive</a>.
 					The SPARQL expression produces an error if the value node cannot be compared to the specified range,
 					for example when someone compares a string with an integer.
-					If the comparison cannot be performed, then there is a validation result.
+					If the comparison cannot be performed, then there is a <a>validation result</a>.
 					This is different from, say, a plain SPARQL query, in which such errors would silently not lead to any results.
 				</p>
 				<div class="def def-sparql">


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #665

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-665/shacl12-sparql/index.html)

This is adding proper linkage to the definition of validation result to SHACL SPARQL.

The other issue that you mention @afs  - ensuring that Core consistently uses the term "violation" - is IMHO already addressed.