### PR TITLE
Some SRL tests

### DIFF
--- a/shacl12-test-suite/tests/rules/eval/data-01.ttl
+++ b/shacl12-test-suite/tests/rules/eval/data-01.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:s :p :o .

--- a/shacl12-test-suite/tests/rules/eval/data-02.ttl
+++ b/shacl12-test-suite/tests/rules/eval/data-02.ttl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+:s :p :z .
+:z :q :o .

--- a/shacl12-test-suite/tests/rules/eval/data-empty.ttl
+++ b/shacl12-test-suite/tests/rules/eval/data-empty.ttl
@@ -1,0 +1,1 @@
+# Empty graph

--- a/shacl12-test-suite/tests/rules/eval/eval-basic-01.srl
+++ b/shacl12-test-suite/tests/rules/eval/eval-basic-01.srl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+RULE { :x :q ?o } WHERE { :s :p ?o }

--- a/shacl12-test-suite/tests/rules/eval/eval-basic-02.srl
+++ b/shacl12-test-suite/tests/rules/eval/eval-basic-02.srl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+RULE { :x :q ?o } WHERE { :s :p ?z . ?z :q ?o }
+

--- a/shacl12-test-suite/tests/rules/eval/eval-results-basic-01.ttl
+++ b/shacl12-test-suite/tests/rules/eval/eval-results-basic-01.ttl
@@ -1,0 +1,13 @@
+PREFIX : <http://example/>
+
+## ## Data graph
+## :s :p :o
+## 
+## ## Inferred
+## :x :q :o
+## 
+## ## Output graph
+## :s :p :o
+## :x :q :o
+
+:x :q :o .

--- a/shacl12-test-suite/tests/rules/eval/eval-results-basic-02.ttl
+++ b/shacl12-test-suite/tests/rules/eval/eval-results-basic-02.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:x :q :o

--- a/shacl12-test-suite/tests/rules/eval/manifest.ttl
+++ b/shacl12-test-suite/tests/rules/eval/manifest.ttl
@@ -1,0 +1,50 @@
+## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
+
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#> 
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> 
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#> 
+
+PREFIX :       <https://w3c.github.io/rdf-tests/shacl/shacl12/>
+
+PREFIX srt:    <http://www.w3.org/ns/shacl-rules-test#>
+
+PREFIX dct:    <http://purl.org/dc/terms/> 
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#> 
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/> 
+PREFIX skos:   <http://www.w3.org/2004/02/skos/core#>
+
+
+
+<#>  rdf:type mf:Manifest ;
+   rdfs:label "SHACL 1.2 Rules Evaluation Tests"@en ;
+   mf:assumedTestBase <https://w3c.github.io/rdf-tests/shacl/shacl12/> ;
+#   dct:issued "2023-07-20"^^xsd:date ; 
+#   dct:modified "2023-07-20"^^xsd:date ; 
+#   dct:licence 
+#   dct:creator [ foaf:homepage <https://w3c.github.io/rdf-star-wg/> ; foaf:name "W3C Data Shapes Working Group" ] ;
+
+    mf:entries
+    (
+        :eval-01
+        :eval-02
+    ) .
+
+## Good Evaluation
+
+:eval-01 rdf:type srt:RulesEvalTest ;
+    mf:name "Eval-basic-1";
+    mf:action
+         [ srt:ruleset  <eval-basic-01.srl> ;
+           srt:data   <data-01.ttl> ] ;
+    mf:result  <eval-results-basic-01.ttl> ;
+    .
+    
+:eval-02 rdf:type srt:RulesEvalTest ;
+    mf:name "Eval-basic-2";
+    mf:action
+         [ srt:ruleset  <eval-basic-02.srl> ;
+           srt:data   <data-02.ttl> ] ;
+    mf:result  <eval-results-basic-02.ttl> ;
+    .

--- a/shacl12-test-suite/tests/rules/manifest-rules.ttl
+++ b/shacl12-test-suite/tests/rules/manifest-rules.ttl
@@ -1,0 +1,30 @@
+## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
+
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+<>  rdf:type mf:Manifest ;
+  rdfs:label "SHACL Rules tests"@en ;
+  mf:assumedTestBase <https://w3c.github.io/rdf-tests/shacl/shacl-1.2/> ;
+  #dct:issued ""^^xsd:date ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
+  #dct:modified "2023-10-28"^^xsd:date ;
+  #dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  #dct:creator [ foaf:homepage <https://w3c.github.io/data-shapes-wg/> ; foaf:name "W3C Data Shapes Working Group" ] ;
+  
+  rdfs:comment """
+    These test suites are a product of the [W3C Data Shapes Working Group]()
+    and have been maintained by the
+    [RDF Test Curation Community Group](https://www.w3.org/community/rdf-tests/)
+    at [https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11](https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/).
+  """;
+  mf:include (
+    <syntax/manifest.ttl>
+    <eval/manifest.ttl>
+  ) .

--- a/shacl12-test-suite/tests/rules/syntax/manifest.ttl
+++ b/shacl12-test-suite/tests/rules/syntax/manifest.ttl
@@ -1,0 +1,104 @@
+## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
+
+PREFIX :       <manifest#>
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX srl:    <http://www.w3.org/ns/shacl-rules#>
+PREFIX srt:    <http://www.w3.org/ns/shacl-rules-test#>
+
+<>  rdf:type mf:Manifest ;
+    rdfs:comment "Syntax tests SHACL Rules - Syntax" ;
+    mf:entries (
+        :test_1
+        :test_2
+        :test_3
+        :test_4
+        :test_5
+        :test_6
+        :test_7
+        :test_8
+        :test_9
+        :test_10
+        :test_11
+        :test_12
+        :test_13
+        :test_14
+        :test_15
+    ) .
+
+:test_1 rdf:type   srt:RulesPositiveSyntaxTest ;
+   mf:name    "syntax-rule-empty-01.srl" ;
+   mf:action  <syntax-rule-empty-01.srl> ;
+   .
+
+:test_2 rdf:type   srt:RulesPositiveSyntaxTest ;
+   mf:name    "syntax-rule-empty-02.srl" ;
+   mf:action  <syntax-rule-empty-02.srl> ;
+   .
+
+:test_3 rdf:type   srt:RulesPositiveSyntaxTest ;
+   mf:name    "syntax-rule-01.srl" ;
+   mf:action  <syntax-rule-01.srl> ;
+   .
+
+:test_4 rdf:type   srt:RulesPositiveSyntaxTest ;
+   mf:name    "syntax-rule-02.srl" ;
+   mf:action  <syntax-rule-02.srl> ;
+   .
+
+:test_5 rdf:type   srt:RulesPositiveSyntaxTest ;
+   mf:name    "syntax-rule-03.srl" ;
+   mf:action  <syntax-rule-03.srl> ;
+   .
+
+:test_6 rdf:type   srt:RulesPositiveSyntaxTest ;
+   mf:name    "syntax-rule-04.srl" ;
+   mf:action  <syntax-rule-04.srl> ;
+   .
+
+:test_7 rdf:type   srt:RulesPositiveSyntaxTest ;
+   mf:name    "syntax-rule-05.srl" ;
+   mf:action  <syntax-rule-05.srl> ;
+   .
+
+:test_8 rdf:type   srt:RulesPositiveSyntaxTest ;
+   mf:name    "syntax-rule-06.srl" ;
+   mf:action  <syntax-rule-06.srl> ;
+   .
+
+:test_9 rdf:type   srt:RulesPositiveSyntaxTest ;
+   mf:name    "syntax-rule-07.srl" ;
+   mf:action  <syntax-rule-07.srl> ;
+   .
+
+:test_10 rdf:type   srt:RulesPositiveSyntaxTest ;
+   mf:name    "syntax-rule-08.srl" ;
+   mf:action  <syntax-rule-08.srl> ;
+   .
+
+:test_11 rdf:type   srt:RulesPositiveSyntaxTest ;
+   mf:name    "syntax-rule-09.srl" ;
+   mf:action  <syntax-rule-09.srl> ;
+   .
+
+:test_12 rdf:type   srt:RulesNegativeSyntaxTest ;
+   mf:name    "syntax-rule-bad-01.srl" ;
+   mf:action  <syntax-rule-bad-01.srl> ;
+   .
+
+:test_13 rdf:type   srt:RulesNegativeSyntaxTest ;
+   mf:name    "syntax-rule-bad-02.srl" ;
+   mf:action  <syntax-rule-bad-02.srl> ;
+   .
+
+:test_14 rdf:type   srt:RulesNegativeSyntaxTest ;
+   mf:name    "syntax-rule-bad-03.srl" ;
+   mf:action  <syntax-rule-bad-03.srl> ;
+   .
+
+:test_15 rdf:type   srt:RulesNegativeSyntaxTest ;
+   mf:name    "syntax-rule-bad-04.srl" ;
+   mf:action  <syntax-rule-bad-04.srl> ;
+   .

--- a/shacl12-test-suite/tests/rules/syntax/syntax-rule-01.srl
+++ b/shacl12-test-suite/tests/rules/syntax/syntax-rule-01.srl
@@ -1,0 +1,1 @@
+RULE {} WHERE {}

--- a/shacl12-test-suite/tests/rules/syntax/syntax-rule-02.srl
+++ b/shacl12-test-suite/tests/rules/syntax/syntax-rule-02.srl
@@ -1,0 +1,2 @@
+PREFIX : <http://example>
+RULE {} WHERE { :s :p :o }

--- a/shacl12-test-suite/tests/rules/syntax/syntax-rule-03.srl
+++ b/shacl12-test-suite/tests/rules/syntax/syntax-rule-03.srl
@@ -1,0 +1,2 @@
+PREFIX : <http://example>
+RULE { ?s :q :z } WHERE { ?s :p :o }

--- a/shacl12-test-suite/tests/rules/syntax/syntax-rule-04.srl
+++ b/shacl12-test-suite/tests/rules/syntax/syntax-rule-04.srl
@@ -1,0 +1,4 @@
+PREFIX :    <http://example>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+RULE { ?s :q :z } WHERE { ?s :p "123"^^xsd:xsd:nonNegativeInteger }

--- a/shacl12-test-suite/tests/rules/syntax/syntax-rule-05.srl
+++ b/shacl12-test-suite/tests/rules/syntax/syntax-rule-05.srl
@@ -1,0 +1,2 @@
+PREFIX : <http://example>
+RULE { ?s :q :z ; :q ?r } WHERE { ?s :p :o ; :q ?r }

--- a/shacl12-test-suite/tests/rules/syntax/syntax-rule-06.srl
+++ b/shacl12-test-suite/tests/rules/syntax/syntax-rule-06.srl
@@ -1,0 +1,5 @@
+PREFIX : <http://example>
+RULE { ?s :q :z ; :q ?r }
+WHERE {
+    ?s :p1 [ :q1 123 ] ;
+}

--- a/shacl12-test-suite/tests/rules/syntax/syntax-rule-07.srl
+++ b/shacl12-test-suite/tests/rules/syntax/syntax-rule-07.srl
@@ -1,0 +1,5 @@
+PREFIX : <http://example>
+RULE { ?s :q :z ; :q ?r }
+WHERE {
+    ?s :p2 ( 1 2 ?x 3 ) ;
+}

--- a/shacl12-test-suite/tests/rules/syntax/syntax-rule-08.srl
+++ b/shacl12-test-suite/tests/rules/syntax/syntax-rule-08.srl
@@ -1,0 +1,5 @@
+PREFIX : <http://example>
+RULE { ?s :q :z ; :q ?r }
+WHERE {
+    ?s :p3 <<( :s :p :o )>> ;
+}

--- a/shacl12-test-suite/tests/rules/syntax/syntax-rule-09.srl
+++ b/shacl12-test-suite/tests/rules/syntax/syntax-rule-09.srl
@@ -1,0 +1,5 @@
+PREFIX : <http://example>
+RULE { ?s :q :z ; :q ?r }
+WHERE {
+    ?s :p4 << :s :p :o >> ;
+}

--- a/shacl12-test-suite/tests/rules/syntax/syntax-rule-bad-01.srl
+++ b/shacl12-test-suite/tests/rules/syntax/syntax-rule-bad-01.srl
@@ -1,0 +1,2 @@
+PREFIX : <http://example>
+RULE

--- a/shacl12-test-suite/tests/rules/syntax/syntax-rule-bad-02.srl
+++ b/shacl12-test-suite/tests/rules/syntax/syntax-rule-bad-02.srl
@@ -1,0 +1,2 @@
+PREFIX : <http://example>
+RULE {}

--- a/shacl12-test-suite/tests/rules/syntax/syntax-rule-bad-03.srl
+++ b/shacl12-test-suite/tests/rules/syntax/syntax-rule-bad-03.srl
@@ -1,0 +1,2 @@
+PREFIX : <http://example>
+RULE {} WHERE

--- a/shacl12-test-suite/tests/rules/syntax/syntax-rule-bad-04.srl
+++ b/shacl12-test-suite/tests/rules/syntax/syntax-rule-bad-04.srl
@@ -1,0 +1,2 @@
+## PREFIX : <http://example>
+RULE {} WHERE {:s :p :o }

--- a/shacl12-test-suite/tests/rules/syntax/syntax-rule-empty-02.srl
+++ b/shacl12-test-suite/tests/rules/syntax/syntax-rule-empty-02.srl
@@ -1,0 +1,1 @@
+PREFIX : <http://example>


### PR DESCRIPTION
This PR is no more than an illustrative starting point for the SHACL Rules tests for `syntax` and `eval`.

The names and organisation of tests is subject to change.

There are likely to be other categories of test.

Eventually, syntax tests will have two representations, SRL and RDF.
