### PR TITLE
Correct link to "solution"

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -313,7 +313,7 @@ RULE { ?x :name ?FN } WHERE {
         <p>The Shape Rules Abstract Syntax</p>
 
         <dl>
-          <dt><dfn data-cite="SPARQL12-QUERY#defn_QueryVariable">variable</dfn></dt>
+          <dt><dfn data-cite="sparql12-query#defn_QueryVariable">variable</dfn></dt>
           <dd>
             A [=variable=] represents a possible [=RDF term=] in a triple pattern.
             Variables are also used in <a>expressions</a>.
@@ -691,13 +691,6 @@ Output: an RDF graph GI of inferred triples
       <h4>Evaluation Definitions</h4>
 
         <dl>
-          <dt><dfn data-cite="shacl12-core#dfn-binding">binding</dfn></dt>
-          <dd>
-            A [=binding=] is a pair 
-            (<a>variable</a>, [=RDF term=]), consistent with the 
-            <a data-cite="sparql12-query#defn_QueryVariable">definition</a> used in [[!sparql12-query]].
-          </dd>
-
           <dt><dfn data-lt="solution|sparql12-query#defn_sparqlSolutionMapping">solution mapping</dfn></dt>
           <dd> 
             A <a data-lt="sparql12-query#defn_sparqlSolutionMapping">solution mapping</a>, 
@@ -738,7 +731,7 @@ Output: an RDF graph GI of inferred triples
               <p>
                 Let <var>G</var> be an [=RDF graph=] and <var>TP</var> be a <a>triple pattern</a>.
                 The function `graphMatch(G, TP)` returns a set of all possible 
-                <a data-cite="shacl12-core#solutions">solutions</a> that, 
+                <a data-cite="sparql12-query#defn_sparqlSolutionMapping">solutions</a> that,
                 when applied to the triple pattern, produce a triple that is in the 
                 [=evaluation graph=]
               </p>


### PR DESCRIPTION
Correct link to "solution", remove "binding".

(SHACL Core uses "binding" for prefixes)
