### PR TITLE
Several formatting fixes and improvements

### DIFF
--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -452,7 +452,7 @@
 			</p>
 		</section>
 
-		<section id="sotd"></section>
+    	<section id="sotd" class="updateable-rec"></section>
 
 		<section id="specifications" class="introductory" data-include="../shacl12-common/specifications.html"></section>
 
@@ -606,9 +606,9 @@
 				the <code>ex:headQuarterCountry</code> is <code>ex:Estonia</code>.
 			</p>
 			
-				<aside class="example" title="A node expression used to compute the target nodes of a shape.">
-					<div class="shapes-graph">
-						<div class="turtle">
+			<aside class="example" title="A node expression used to compute the target nodes of a shape.">
+				<div class="shapes-graph">
+					<div class="turtle">
 ex:EstonianCompanyShape
 	a sh:NodeShape ;
 	sh:targetNode <b>[
@@ -622,9 +622,9 @@ ex:EstonianCompanyShape
 			]
 		]
 	]</b> .
-						</div>
 					</div>
-				</aside>
+				</div>
+			</aside>
 		
 			<p>
 				The following diagram illustrates how this node expression is interpreted, from a logical point of view.
@@ -649,9 +649,9 @@ ex:EstonianCompanyShape
 				internally convert node expressions such as the <code>shnex:filterShape</code> above to SPARQL.
 			</p>
 			
-				<aside class="example" title="A SPARQL select expression used to compute the target nodes of a shape.">
-					<div class="shapes-graph">
-						<div class="turtle">
+			<aside class="example" title="A SPARQL select expression used to compute the target nodes of a shape.">
+				<div class="shapes-graph">
+					<div class="turtle">
 ex:EstonianCompanyShape
 	a sh:NodeShape ;
 	sh:targetNode <b>[
@@ -663,18 +663,18 @@ ex:EstonianCompanyShape
 			}
 		"""
 	]</b> .
-						</div>
 					</div>
-				</aside>
+				</div>
+			</aside>
 		
 			<p>
 				The next example uses a node expression to compute the values of the property <code>ex:employeeCount</code>
 				as the number of values of the property <code>ex:employee</code> at each instance of <code>ex:Company</code>.
 			</p>
 			
-				<aside class="example" title="A node expression used to compute the values of a derived property.">
-					<div class="shapes-graph">
-						<div class="turtle">
+			<aside class="example" title="A node expression used to compute the values of a derived property.">
+				<div class="shapes-graph">
+					<div class="turtle">
 ex:Company
 	a sh:ShapeClass ;
 	sh:property ex:Company-employee ;
@@ -698,9 +698,9 @@ ex:Company-employeeCount
 			shnex:pathValues ex:employee ;
 		]
 	]</b> .
-						</div>
 					</div>
-				</aside>
+				</div>
+			</aside>
 			
 			<div>
 				<img
@@ -902,9 +902,9 @@ ex:Company-employeeCount
 						as a concatenation of <code>ex:firstName</code>, a space, and <code>ex:lastName</code>.
 					</p>
 					
-						<aside class="example" title="A complex node expression based on list parameter functions.">
-							<div class="shapes-graph">
-								<div class="turtle">
+					<aside class="example" title="A complex node expression based on list parameter functions.">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:Person-displayName
 	a sh:PropertyShape ;
 	sh:name "display name" ;
@@ -925,10 +925,9 @@ ex:Person-displayName
 			]
 		)
 	]</b> .
-								</div>
 							</div>
-						</aside>
-					
+						</div>
+					</aside>
 				</section>
 			</section>
 
@@ -1108,10 +1107,9 @@ ex:Person-loves
 						but with the constants from the list <code>( owl:Thing rdfs:Resource )</code> removed using
 						<a href="#RemoveExpression"><code>shnex:remove</code></a>.
 					</p>
-					<p>
-						<aside class="example" title="A list expression that is used to enumerate the values of a shnex:remove expression.">
-							<div class="shapes-graph">
-								<div class="turtle">
+					<aside class="example" title="A list expression that is used to enumerate the values of a shnex:remove expression.">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:ClassShape
 	a sh:NodeShape ;
 	sh:targetClass rdfs:Class ;
@@ -1129,10 +1127,9 @@ ex:ClassShape-superClassesExceptRoots
 		# This removes any superclasses that are in the list below
 		shnex:remove <b>( owl:Thing rdfs:Resource )</b> ;
 	] .
-								</div>
 							</div>
-						</aside>
-					
+						</div>
+					</aside>
 				</section>
 
 				<section id="PathValuesExpression">
@@ -1209,9 +1206,9 @@ ex:ClassShape-superClassesExceptRoots
 						number of top concepts.
 					</p>
 				
-						<aside class="example" title="A path values expression computing the number of top concepts in a scheme">
-							<div class="shapes-graph">
-								<div class="turtle">
+					<aside class="example" title="A path values expression computing the number of top concepts in a scheme">
+						<div class="shapes-graph">
+							<div class="turtle">
 skos:ConceptScheme
 	a sh:ShapeClass ;
 	sh:property skos:ConceptScheme-topConceptCount .
@@ -1228,30 +1225,29 @@ skos:ConceptScheme-topConceptCount
 			shnex:pathValues skos:hasTopConcept ;
 		]</b> ;
 	] .
-								</div>
 							</div>
-						</aside>
-						<p>
-							The next example illustrates the use of a <a>path values expression</a> together with a specific focus node
-							(instead of the default focus node provided by the evaluation context).
-							The shape targets all <a>subjects</a> that have <code>skos:Concept</code> as their <code>rdf:type</code>
-							with a dynamically computed <code>sh:targetNode</code> expression.
-							In other words, the target nodes are the direct instances of <code>skos:Concept</code> based on asserted
-							<code>rdf:type</code> triples, not including the subclasses of <code>skos:Concept</code>.
-						</p>
-						<aside class="example" title="A shape that targets the direct instances of skos:Concept, using a path values expression">
-							<div class="shapes-graph">
-								<div class="turtle">
+						</div>
+					</aside>
+					<p>
+						The next example illustrates the use of a <a>path values expression</a> together with a specific focus node
+						(instead of the default focus node provided by the evaluation context).
+						The shape targets all <a>subjects</a> that have <code>skos:Concept</code> as their <code>rdf:type</code>
+						with a dynamically computed <code>sh:targetNode</code> expression.
+						In other words, the target nodes are the direct instances of <code>skos:Concept</code> based on asserted
+						<code>rdf:type</code> triples, not including the subclasses of <code>skos:Concept</code>.
+					</p>
+					<aside class="example" title="A shape that targets the direct instances of skos:Concept, using a path values expression">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:DirectInstancesOfConceptShape
     a sh:NodeShape ;
     sh:targetNode <b>[
         shnex:pathValues [ sh:inversePath rdf:type ] ;
         shnex:focusNode skos:Concept ;
     ]</b> .
-								</div>
 							</div>
-						</aside>
-					
+						</div>
+					</aside>
 				</section>
 
 				<section id="ExistsExpression">
@@ -1366,9 +1362,9 @@ ex:DirectInstancesOfConceptShape
 						will be displayed in <code>"blue"</code>, while the others will be <code>"red"</code>.
 					</p>
 				
-						<aside class="example" title="An example &quot;if&quot; expression computing the fill color of a city">
-							<div class="shapes-graph">
-								<div class="turtle">
+					<aside class="example" title="An example &quot;if&quot; expression computing the fill color of a city">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:City
     a sh:ShapeClass ;
     sh:property ex:City-fillColor .
@@ -1387,10 +1383,9 @@ ex:City-fillColor
         shnex:then "blue" ;
         shnex:else "red" ;
     ]</b> .
-								</div>
 							</div>
-						</aside>
-				
+						</div>
+					</aside>
 				</section>
 
 			</section>
@@ -1444,9 +1439,9 @@ ex:City-fillColor
 						sure that the output nodes do not include <code>rdfs:Resource</code> twice.
 					</p>
 			
-						<aside class="example" title="Using shnex:distinct to return a list of superclasses including rdfs:Resource but not including duplicates">
-							<div class="shapes-graph">
-								<div class="turtle">
+					<aside class="example" title="Using shnex:distinct to return a list of superclasses including rdfs:Resource but not including duplicates">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:ClassShape
     a sh:NodeShape ;
     sh:targetClass rdfs:Class ;
@@ -1466,9 +1461,9 @@ ex:ClassShape-superClassesIncludingRoot
             )
         ]</b> ;
     ] .
-								</div>
 							</div>
-						</aside>
+						</div>
+					</aside>
 			
 				</section>
 
@@ -1514,9 +1509,9 @@ ex:ClassShape-superClassesIncludingRoot
 						<code>ex:German</code> at the same time.
 					</p>
 				
-						<aside class="example" title="Using shnex:intersection to compute the target nodes of a shape">
-							<div class="shapes-graph">
-								<div class="turtle">
+					<aside class="example" title="Using shnex:intersection to compute the target nodes of a shape">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:DualCitizenShape
     a sh:NodeShape ;
     sh:targetNode <b>[
@@ -1525,85 +1520,83 @@ ex:DualCitizenShape
             [ shnex:instancesOf ex:German ]
         )
     ]</b> .
-								</div>
 							</div>
-							 <div class="evaluation">
-                                        <p>
-                                            <strong>Evaluation trace:</strong>
-                                        </p>
-                                        <p>
-                                            The evaluation proceeds as follows:
-                                        </p>
-                                        <ol>
-                                            <li>
-                                                <code>shnex:instancesOf ex:Australian</code>
-                                                produces: <code>[ex:Person1, ex:Person2, ex:Person3, ex:Person4]</code>
-                                            </li>
-                                            <li>
-                                                <code>shnex:instancesOf ex:German</code>
-                                                produces: <code>[ex:Person2, ex:Person4, ex:Person5]</code>
-                                            </li>
-                                            <li>
-                                                Compute the intersection (nodes appearing in both lists):
-                                                <code>[ex:Person2, ex:Person4]</code>
-                                            </li>
-                                        </ol>
-                                        <p>
-                                            More abstractly, the intersection of <code>[1, 2, 3, 4]</code> and <code>[2, 4, 5]</code> results in <code>[2, 4]</code>,
-                                            containing only the elements that appear in both lists.
-                                        </p>
-                                    </div>
-
-						</aside>
-					
+						</div>
+						<div class="evaluation">
+							<p>
+								<strong>Evaluation trace:</strong>
+							</p>
+							<p>
+								The evaluation proceeds as follows:
+							</p>
+							<ol>
+								<li>
+									<code>shnex:instancesOf ex:Australian</code>
+									produces: <code>[ex:Person1, ex:Person2, ex:Person3, ex:Person4]</code>
+								</li>
+								<li>
+									<code>shnex:instancesOf ex:German</code>
+									produces: <code>[ex:Person2, ex:Person4, ex:Person5]</code>
+								</li>
+								<li>
+									Compute the intersection (nodes appearing in both lists):
+									<code>[ex:Person2, ex:Person4]</code>
+								</li>
+							</ol>
+							<p>
+								More abstractly, the intersection of <code>[1, 2, 3, 4]</code> and <code>[2, 4, 5]</code> results in <code>[2, 4]</code>,
+								containing only the elements that appear in both lists.
+							</p>
+						</div>
+					</aside>
 				</section>
 
-<section id="ConcatExpression">
-				<h3>Concat Expressions</h3>
-				<p class="syntax">
-					<span data-syntax-rule="ConcatExpression-syntax">
-						A <a>blank node</a> that is the <a>subject</a> of the following properties
-						is called a <dfn>concat expression</dfn>, with the <a>function name</a> <code>shnex:ConcatExpression</code>:
-						<table class="term-table">
-							<thead>
-								<th>Property</th>
-								<th>Constraints</th>
-								<th>Description</th>
-							</thead>
-							<tbody>
-								<tr>
-									<td><b><code>shnex:concat</code></b></td>
-									<td>
-										A <a>well-formed</a> <a>SHACL list</a> where each <a>member</a> is a <a>well-formed</a> <a>node expression</a>.
-									</td>
-									<td>
-										The node expressions that shall be concatenated.
-									</td>
-								</tr>
-							</tbody>
-						</table>
-					</span>
-				</p>
-				<div class="def" id="ConcatExpression-evaluation">
-					<div class="def-header">EVALUATION OF CONCAT EXPRESSIONS</div>
-					<p>
-						Let <code>members</code> be the <a>members</a> of the <a>value</a> of <code>shnex:concat</code> in the <a>concat expression</a>.
-						The <a>output nodes</a> of the <a>concat expression</a> are the concatenation of all <a>output nodes</a>
-						for each <a>node expression</a> <code>NE</code> in <code>members</code>, using <code>evalExpr(NE, focusGraph, focusNode, scope)</code>.
-						The order is preserved, evaluating the <code>members</code> from left to right and keeping the order of each list of output nodes.
+				<section id="ConcatExpression">
+					<h3>Concat Expressions</h3>
+					<p class="syntax">
+						<span data-syntax-rule="ConcatExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>concat expression</dfn>, with the <a>function name</a> <code>shnex:ConcatExpression</code>:
+							<table class="term-table">
+								<thead>
+									<th>Property</th>
+									<th>Constraints</th>
+									<th>Description</th>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>shnex:concat</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>SHACL list</a> where each <a>member</a> is a <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The node expressions that shall be concatenated.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
 					</p>
-				</div>
-				<p><em>The remainder of this section is informative.</em></p>
-				<p>
-					Note that a <a>concat expression</a> may produce duplicate <a>output nodes</a> if the individual output nodes overlap.
-					Use <a href="#DistinctExpression">shnex:distinct</a> to eliminate duplicates.
-				</p>
-				<p>
-					The following example declares a derived property <code>ex:allRelatives</code>
-					that concatenates the values of <code>ex:parent</code> and <code>ex:sibling</code>.
-					The <code>shnex:concat</code> expression takes a list of node expressions and returns
-					all nodes from each expression in sequence from left to right.
-				</p>
+					<div class="def" id="ConcatExpression-evaluation">
+						<div class="def-header">EVALUATION OF CONCAT EXPRESSIONS</div>
+						<p>
+							Let <code>members</code> be the <a>members</a> of the <a>value</a> of <code>shnex:concat</code> in the <a>concat expression</a>.
+							The <a>output nodes</a> of the <a>concat expression</a> are the concatenation of all <a>output nodes</a>
+							for each <a>node expression</a> <code>NE</code> in <code>members</code>, using <code>evalExpr(NE, focusGraph, focusNode, scope)</code>.
+							The order is preserved, evaluating the <code>members</code> from left to right and keeping the order of each list of output nodes.
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p>
+						Note that a <a>concat expression</a> may produce duplicate <a>output nodes</a> if the individual output nodes overlap.
+						Use <a href="#DistinctExpression">shnex:distinct</a> to eliminate duplicates.
+					</p>
+					<p>
+						The following example declares a derived property <code>ex:allRelatives</code>
+						that concatenates the values of <code>ex:parent</code> and <code>ex:sibling</code>.
+						The <code>shnex:concat</code> expression takes a list of node expressions and returns
+						all nodes from each expression in sequence from left to right.
+					</p>
 				
 					<aside class="example" title="Using shnex:concat to combine results from multiple node expressions">
 						<div class="shapes-graph">
@@ -1627,36 +1620,33 @@ ex:PersonShape-allRelatives
 							</div>
 						</div>
 
-    <div class="evaluation">
-                    <p>
-                        <strong>Evaluation trace:</strong>
-                    </p>
-                    <p>
-                        The evaluation proceeds as follows:
-                    </p>
-                    <ol>
-                        <li>
-                            <code>shnex:pathValues ex:parent</code> with focus node <code>ex:Person1</code>
-                            produces: <code>[ex:Parent1, ex:Parent2]</code>
-                        </li>
-                        <li>
-                            <code>shnex:pathValues ex:sibling</code> with focus node <code>ex:Person1</code>
-                            produces: <code>[ex:Sibling1, ex:Sibling2, ex:Sibling3]</code>
-                        </li>
-                        <li>
-                            Concatenate the results in order:
-                            <code>[ex:Parent1, ex:Parent2, ex:Sibling1, ex:Sibling2, ex:Sibling3]</code>
-                        </li>
-                    </ol>
-                    <p>
-                        More abstractly, concatenating <code>[1, 2]</code> and <code>[3, 4, 5]</code> results in <code>[1, 2, 3, 4, 5]</code>
-                        with all elements preserved in order from left to right.
-                    </p>
-                </div>
-
-               
+    					<div class="evaluation">
+							<p>
+								<strong>Evaluation trace:</strong>
+							</p>
+							<p>
+								The evaluation proceeds as follows:
+							</p>
+							<ol>
+								<li>
+									<code>shnex:pathValues ex:parent</code> with focus node <code>ex:Person1</code>
+									produces: <code>[ex:Parent1, ex:Parent2]</code>
+								</li>
+								<li>
+									<code>shnex:pathValues ex:sibling</code> with focus node <code>ex:Person1</code>
+									produces: <code>[ex:Sibling1, ex:Sibling2, ex:Sibling3]</code>
+								</li>
+								<li>
+									Concatenate the results in order:
+									<code>[ex:Parent1, ex:Parent2, ex:Sibling1, ex:Sibling2, ex:Sibling3]</code>
+								</li>
+							</ol>
+							<p>
+								More abstractly, concatenating <code>[1, 2]</code> and <code>[3, 4, 5]</code> results in <code>[1, 2, 3, 4, 5]</code>
+								with all elements preserved in order from left to right.
+							</p>
+						</div>
 					</aside>
-	
 				</section>
 
 				<section id="RemoveExpression">
@@ -1707,16 +1697,16 @@ ex:PersonShape-allRelatives
 						</p>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
-			<p>
-			The following example declares a derived property, <code>ex:availableAuthors</code>,
-			that returns all persons who are authors, except those who are currently on leave.
-			The <code>shnex:remove</code> expression takes the nodes from <code>shnex:nodes</code> (all authors) 
-			and removes the nodes returned by the <code>shnex:remove</code> expression (authors on leave).
-		</p>
+					<p>
+						The following example declares a derived property, <code>ex:availableAuthors</code>,
+						that returns all persons who are authors, except those who are currently on leave.
+						The <code>shnex:remove</code> expression takes the nodes from <code>shnex:nodes</code> (all authors) 
+						and removes the nodes returned by the <code>shnex:remove</code> expression (authors on leave).
+					</p>
 		
-			<aside class="example" title="Using shnex:remove to exclude unavailable authors from a list">
-				<div class="shapes-graph">
-					<div class="turtle">
+					<aside class="example" title="Using shnex:remove to exclude unavailable authors from a list">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:PublisherShape
 	a sh:NodeShape ;
 	sh:targetClass ex:Publisher ;
@@ -1731,36 +1721,36 @@ ex:PublisherShape-availableAuthors
 		shnex:nodes  [ shnex:pathValues ex:author ] ; 		  
 		shnex:remove [ shnex:pathValues ex:authorOnLeave ] ;  
 	]</b> .
-					</div>
-				</div>
-				<div class="evaluation">
-					<p>
-						<strong>Evaluation trace:</strong>
-					</p>
-					<p>
-						The evaluation proceeds as follows:
-					</p>
-					<ol>
-						<li>
-							<code>shnex:nodes [shnex:pathValues ex:author]</code> with focus node <code>ex:PublisherA</code>
-							produces: <code>[ex:Author1, ex:Author1, ex:Author1, ex:Author2, ex:Author2]</code>
-						</li>
-						<li>
-							<code>shnex:remove [shnex:pathValues ex:authorOnLeave]</code> with focus node <code>ex:PublisherA</code>
-							produces: <code>[ex:Author1, ex:Author1]</code>
-						</li>
-						<li>
-							Remove all occurrences of <code>ex:Author1</code> from the nodes list, preserving order:
-							<code>[ex:Author2, ex:Author2]</code>
-						</li>
-					</ol>
-					<p>
-						More abstractly, removing <code>[1, 1]</code> from <code>[1, 1, 1, 2, 2]</code> results in <code>[2, 2]</code>
-						because all instances of <code>1</code> are removed (not just the first occurrence).
-					</p>
-				</div>
-				</aside>
-							</section>
+							</div>
+						</div>
+						<div class="evaluation">
+							<p>
+								<strong>Evaluation trace:</strong>
+							</p>
+							<p>
+								The evaluation proceeds as follows:
+							</p>
+							<ol>
+								<li>
+									<code>shnex:nodes [shnex:pathValues ex:author]</code> with focus node <code>ex:PublisherA</code>
+									produces: <code>[ex:Author1, ex:Author1, ex:Author1, ex:Author2, ex:Author2]</code>
+								</li>
+								<li>
+									<code>shnex:remove [shnex:pathValues ex:authorOnLeave]</code> with focus node <code>ex:PublisherA</code>
+									produces: <code>[ex:Author1, ex:Author1]</code>
+								</li>
+								<li>
+									Remove all occurrences of <code>ex:Author1</code> from the nodes list, preserving order:
+									<code>[ex:Author2, ex:Author2]</code>
+								</li>
+							</ol>
+							<p>
+								More abstractly, removing <code>[1, 1]</code> from <code>[1, 1, 1, 2, 2]</code> results in <code>[2, 2]</code>
+								because all instances of <code>1</code> are removed (not just the first occurrence).
+							</p>
+						</div>
+					</aside>
+				</section>
 
 				<section id="FilterShapeExpression">
 					<h3>Filter Shape Expressions</h3>
@@ -1814,9 +1804,9 @@ ex:PublisherShape-availableAuthors
 						has the value <code>"male"</code>.
 					</p>
 				
-						<aside class="example" title="Using shnex:filterShape to compute the children that are male">
-							<div class="shapes-graph">
-								<div class="turtle">
+					<aside class="example" title="Using shnex:filterShape to compute the children that are male">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:Person
     a sh:ShapeClass ;
     sh:property ex:Person-maleChildren .
@@ -1836,10 +1826,9 @@ ex:Person-maleChildren
             ]
         ] ;
     ]</b> .
-								</div>
 							</div>
-						</aside>
-			
+						</div>
+					</aside>
 				</section>
 
 				<section id="LimitExpression">
@@ -1899,9 +1888,9 @@ ex:Person-maleChildren
 						<code>2</code> of these children at most.
 					</p>
 				
-						<aside class="example" title="Using shnex:limit to compute the oldest two children">
-							<div class="shapes-graph">
-								<div class="turtle">
+					<aside class="example" title="Using shnex:limit to compute the oldest two children">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:PersonShape
     a sh:NodeShape ;
     sh:targetClass ex:Person ;
@@ -1920,10 +1909,9 @@ ex:PersonShape-oldestTwoChildren
         ] ;
         shnex:limit 2 ;
     ]</b> .
-								</div>
 							</div>
-						</aside>
-			
+						</div>
+					</aside>
 				</section>
 
 				<section id="OffsetExpression">
@@ -1983,9 +1971,9 @@ ex:PersonShape-oldestTwoChildren
 						of these children.
 					</p>
 				
-						<aside class="example" title="Using shnex:offset to compute all but the oldest child">
-							<div class="shapes-graph">
-								<div class="turtle">
+					<aside class="example" title="Using shnex:offset to compute all but the oldest child">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:PersonShape
     a sh:NodeShape ;
     sh:targetClass ex:Person ;
@@ -2004,10 +1992,9 @@ ex:PersonShape-remainingChildren
         ] ;
         shnex:offset 1 ;
     ]</b> .
-								</div>
 							</div>
-						</aside>
-		
+						</div>
+					</aside>
 				</section>
 
 				<section id="OrderByExpression">
@@ -2019,93 +2006,94 @@ ex:PersonShape-remainingChildren
 				</section>
 
 			</section>
-		<section id="library-advanced-sequence">
-	<h2>Advanced Sequence Operations</h2>
 
-	<section id="FlatMapExpression">
-		<h3>FlatMap Expressions</h3>
-		<p class="syntax">
-			<span data-syntax-rule="FlatMapExpression-syntax">
-				A <a>blank node</a> that is the <a>subject</a> of the following properties
-				is called a <dfn>flat map expression</dfn>,
-				with the <a>function name</a> <code>shnex:FlatMapExpression</code>:
-				<table class="term-table">
-					<thead>
-						<tr>
-							<th>Property</th>
-							<th>Constraints</th>
-							<th>Description</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td><b><code>shnex:flatMap</code></b></td>
-							<td>
-								A <a>well-formed</a> <a>node expression</a>.
-							</td>
-							<td>
-								The <a>node expression</a> that is applied to each input node.
-							</td>
-						</tr>
-						<tr>
-							<td><b><code>shnex:nodes</code></b></td>
-							<td>
-								A <a>well-formed</a> <a>node expression</a>.
-							</td>
-							<td>
-								The input nodes. If omitted, defaults to the focus node.
-							</td>
-						</tr>
-					</tbody>
-				</table>
-			</span>
-		</p>
-		<div class="def" id="FlatMapExpression-evaluation">
-			<div class="def-header">EVALUATION OF FLAT MAP EXPRESSIONS</div>
-			<p>
-				Let <code>flatMap</code> be the <a>value</a> of <code>shnex:flatMap</code>
-				and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in a <a>flat map expression</a>.
-				If <code>shnex:nodes</code> is not specified, let <code>nodes</code> be the focus node.
-			</p>
-			<p>
-				Let <code>N</code> be the <a>output nodes</a> of 
-				<code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
-			</p>
-			<p>
-				For each node <code>n</code> in <code>N</code>, let <code>M<sub>n</sub></code> be the <a>output nodes</a> of 
-				<code>evalExpr(flatMap, focusGraph, <var>n</var>, scope)</code>.
-			</p>
-			<p>
-				The <a>output nodes</a> of the <a>flat map expression</a> are produced by concatenating all sequences 
-				<code>M<sub>n</sub></code> in the order of the corresponding nodes <code>n</code> in <code>N</code>.
-			</p>
-		</div>
-		<p><em>The remainder of this section is informative.</em></p>
-		<p>
-			The <code>shnex:flatMap</code> operation applies an expression to each input node and flattens the results
-			into a single sequence. This is particularly useful when combining results from multiple path traversals
-			or when working with nested structures.
-		</p>
-		<p>
-			A key aspect of <code>shnex:flatMap</code> is that the focus node changes for each iteration.
-			For each node produced by the <code>shnex:nodes</code> expression, that node becomes the focus node
-			when evaluating the <code>shnex:flatMap</code> expression. This allows relative path expressions to work correctly
-			at each level of nesting. The output sequences are then concatenated in order, preserving both the order
-			of input nodes and the order of results within each output sequence.
-		</p>
-		<p>
-			Unlike operations that remove duplicates, <code>shnex:flatMap</code> preserves all results, including duplicates.
-			If duplicate elimination is desired, use <code>shnex:distinct</code> to post-process the results.
-		</p>
-		<p id="FlatMapExpressionExample">
-			The following example illustrates the use of <code>shnex:flatMap</code> to derive a property
-			<code>ex:allSkills</code> that collects all skills from all employees of a company.
-			For each employee of the company, the flatMap operation applies a path expression to retrieve their skills,
-			and flattens the resulting skill sequences into a single comprehensive list.
-		</p>
-		<aside class="example" title="Using shnex:flatMap to collect skills from all employees">
-			<div class="shapes-graph">
-				<div class="turtle">
+			<section id="library-advanced-sequence">
+				<h2>Advanced Sequence Operations</h2>
+
+				<section id="FlatMapExpression">
+					<h3>FlatMap Expressions</h3>
+					<p class="syntax">
+						<span data-syntax-rule="FlatMapExpression-syntax">
+							A <a>blank node</a> that is the <a>subject</a> of the following properties
+							is called a <dfn>flat map expression</dfn>,
+							with the <a>function name</a> <code>shnex:FlatMapExpression</code>:
+							<table class="term-table">
+								<thead>
+									<tr>
+										<th>Property</th>
+										<th>Constraints</th>
+										<th>Description</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td><b><code>shnex:flatMap</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The <a>node expression</a> that is applied to each input node.
+										</td>
+									</tr>
+									<tr>
+										<td><b><code>shnex:nodes</code></b></td>
+										<td>
+											A <a>well-formed</a> <a>node expression</a>.
+										</td>
+										<td>
+											The input nodes. If omitted, defaults to the focus node.
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</span>
+					</p>
+					<div class="def" id="FlatMapExpression-evaluation">
+						<div class="def-header">EVALUATION OF FLAT MAP EXPRESSIONS</div>
+						<p>
+							Let <code>flatMap</code> be the <a>value</a> of <code>shnex:flatMap</code>
+							and <code>nodes</code> be the <a>value</a> of <code>shnex:nodes</code> in a <a>flat map expression</a>.
+							If <code>shnex:nodes</code> is not specified, let <code>nodes</code> be the focus node.
+						</p>
+						<p>
+							Let <code>N</code> be the <a>output nodes</a> of 
+							<code>evalExpr(nodes, focusGraph, focusNode, scope)</code>.
+						</p>
+						<p>
+							For each node <code>n</code> in <code>N</code>, let <code>M<sub>n</sub></code> be the <a>output nodes</a> of 
+							<code>evalExpr(flatMap, focusGraph, <var>n</var>, scope)</code>.
+						</p>
+						<p>
+							The <a>output nodes</a> of the <a>flat map expression</a> are produced by concatenating all sequences 
+							<code>M<sub>n</sub></code> in the order of the corresponding nodes <code>n</code> in <code>N</code>.
+						</p>
+					</div>
+					<p><em>The remainder of this section is informative.</em></p>
+					<p>
+						The <code>shnex:flatMap</code> operation applies an expression to each input node and flattens the results
+						into a single sequence. This is particularly useful when combining results from multiple path traversals
+						or when working with nested structures.
+					</p>
+					<p>
+						A key aspect of <code>shnex:flatMap</code> is that the focus node changes for each iteration.
+						For each node produced by the <code>shnex:nodes</code> expression, that node becomes the focus node
+						when evaluating the <code>shnex:flatMap</code> expression. This allows relative path expressions to work correctly
+						at each level of nesting. The output sequences are then concatenated in order, preserving both the order
+						of input nodes and the order of results within each output sequence.
+					</p>
+					<p>
+						Unlike operations that remove duplicates, <code>shnex:flatMap</code> preserves all results, including duplicates.
+						If duplicate elimination is desired, use <code>shnex:distinct</code> to post-process the results.
+					</p>
+					<p id="FlatMapExpressionExample">
+						The following example illustrates the use of <code>shnex:flatMap</code> to derive a property
+						<code>ex:allSkills</code> that collects all skills from all employees of a company.
+						For each employee of the company, the flatMap operation applies a path expression to retrieve their skills,
+						and flattens the resulting skill sequences into a single comprehensive list.
+					</p>
+					<aside class="example" title="Using shnex:flatMap to collect skills from all employees">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:CompanyShape
     a sh:NodeShape ;
     sh:targetClass ex:Company ;
@@ -2123,10 +2111,10 @@ ex:CompanyShape-allSkills
             shnex:pathValues ex:skill ;
         ] ;
     ]</b> .
-				</div>
-			</div>
-				<div class="data-graph">
-					<div class="turtle">
+							</div>
+						</div>
+						<div class="data-graph">
+							<div class="turtle">
 ex:CompanyA
     ex:employee ex:Employee1 ;
     ex:employee ex:Employee2 ;
@@ -2144,56 +2132,48 @@ ex:Employee2
 ex:Employee3
     ex:skill "Java"@en ;
     ex:skill "DevOps"@en .
-					</div>
-				</div>
-				<div class="evaluation">
-					<p>
-						<strong>Evaluation trace:</strong>
-					</p>
-					<ol>
-						<li>
-							<code>shnex:nodes [shnex:pathValues ex:employee]</code> with focus node <code>ex:CompanyA</code>
-							produces: <code>[ex:Employee1, ex:Employee2, ex:Employee3]</code>
-						</li>
-						<li>
-							For each employee <code>n</code>, evaluate <code>shnex:flatMap [shnex:pathValues ex:skill]</code>
-							with focus node <code>n</code>:
-							<ul>
-								<li><code>ex:Employee1</code> → <code>["Java", "Python", "SQL"]</code></li>
-								<li><code>ex:Employee2</code> → <code>["Python", "JavaScript"]</code></li>
-								<li><code>ex:Employee3</code> → <code>["Java", "DevOps"]</code></li>
-							</ul>
-						</li>
-						<li>
-							Combine all results in order:
-							<code>["Java", "Python", "SQL", "Python", "JavaScript", "Java", "DevOps"]</code>
-						</li>
-						<li>Optional: Refine the resulting sequence using for example:
-							<ul>
+							</div>
+						</div>
+						<div class="evaluation">
+							<p>
+								<strong>Evaluation trace:</strong>
+							</p>
+							<ol>
 								<li>
-									<code>shnex:distinct</code> to remove duplicates from the flattened result.
+									<code>shnex:nodes [shnex:pathValues ex:employee]</code> with focus node <code>ex:CompanyA</code>
+									produces: <code>[ex:Employee1, ex:Employee2, ex:Employee3]</code>
 								</li>
 								<li>
-									<code>shnex:filterShape</code> to apply an additional shape constraint to the
-									flattened nodes.
+									For each employee <code>n</code>, evaluate <code>shnex:flatMap [shnex:pathValues ex:skill]</code>
+									with focus node <code>n</code>:
+									<ul>
+										<li><code>ex:Employee1</code> → <code>["Java", "Python", "SQL"]</code></li>
+										<li><code>ex:Employee2</code> → <code>["Python", "JavaScript"]</code></li>
+										<li><code>ex:Employee3</code> → <code>["Java", "DevOps"]</code></li>
+									</ul>
 								</li>
 								<li>
-									<code>shnex:limit</code> to restrict the flattened result to the first N nodes.
+									Combine all results in order:
+									<code>["Java", "Python", "SQL", "Python", "JavaScript", "Java", "DevOps"]</code>
 								</li>
-
-							</ul>
-
-						</li>
-					</ol>
-			
-					
-				</div>
-			</div>
-		</aside>
-
-		
-	</section>
-
+								<li>Optional: Refine the resulting sequence using for example:
+									<ul>
+										<li>
+											<code>shnex:distinct</code> to remove duplicates from the flattened result.
+										</li>
+										<li>
+											<code>shnex:filterShape</code> to apply an additional shape constraint to the
+											flattened nodes.
+										</li>
+										<li>
+											<code>shnex:limit</code> to restrict the flattened result to the first N nodes.
+										</li>
+									</ul>
+								</li>
+							</ol>
+						</div>
+					</aside>
+				</section>
 
 				<section id="FindFirstExpression">
 					<h3>FindFirst Expressions</h3>
@@ -2252,10 +2232,9 @@ ex:Employee3
 						<code>ex:seniorEmployee</code> that finds the first employee with more than five years of experience.
 						The <code>shnex:findFirst</code> operation tests each employee against a shape that validates their years of service.
 					</p>
-					<p>
-						<aside class="example" title="Using shnex:findFirst to find the first senior employee">
-							<div class="shapes-graph">
-								<div class="turtle">
+					<aside class="example" title="Using shnex:findFirst to find the first senior employee">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:CompanyShape
     a sh:NodeShape ;
     sh:targetClass ex:Company ;
@@ -2281,11 +2260,9 @@ ex:SeniorEmployeeShape
         sh:datatype xsd:integer ;
         sh:minInclusive 5 ;
     ] .
-								</div>
-								
 							</div>
-						</aside>
-					</p>
+						</div>
+					</aside>
 				</section>
 
 				<section id="MatchAllExpression">
@@ -2346,10 +2323,9 @@ ex:SeniorEmployeeShape
 						<code>ex:allEmployeesActive</code> that checks whether all employees of a company are currently active.
 						The match all operation tests each employee against a shape that validates their active status.
 					</p>
-					<p>
-						<aside class="example" title="Using shnex:matchAll to verify all employees are active">
-							<div class="shapes-graph">
-								<div class="turtle">
+					<aside class="example" title="Using shnex:matchAll to verify all employees are active">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:CompanyShape
     a sh:NodeShape ;
     sh:targetClass ex:Company ;
@@ -2374,14 +2350,13 @@ ex:ActiveEmployeeShape
         sh:path ex:isActive ;
         sh:hasValue true ;
     ] .
-								</div>
-						
 							</div>
-						</aside>
-					</p>
+						</div>
+					</aside>
 				</section>
 
 			</section>
+
 			<section id="library-aggregation">
 				<h2>Aggregation Expressions</h2>
 
@@ -2426,10 +2401,9 @@ ex:ActiveEmployeeShape
 						<code>ex:topConceptCount</code> as the number of values of the <code>skos:hasTopConcept</code>
 						property in a <code>skos:ConceptScheme</code>.
 					</p>
-				
-						<aside class="example" title="Using shnex:count to compute the number of values of another property">
-							<div class="shapes-graph">
-								<div class="turtle">
+					<aside class="example" title="Using shnex:count to compute the number of values of another property">
+						<div class="shapes-graph">
+							<div class="turtle">
 skos:ConceptScheme
     a rdfs:Class, sh:NodeShape ;
     sh:property skos:ConceptScheme-topConceptCount .
@@ -2446,10 +2420,9 @@ skos:ConceptScheme-topConceptCount
             shnex:pathValues skos:hasTopConcept ;
         ] ;
     ]</b> .
-								</div>
 							</div>
-						</aside>
-				
+						</div>
+					</aside>
 				</section>
 
 				<section id="MinExpression">
@@ -2497,9 +2470,9 @@ skos:ConceptScheme-topConceptCount
 						date on which an employee started.
 					</p>
 			
-						<aside class="example" title="Using shnex:min to compute the smallest value in a property path">
-							<div class="shapes-graph">
-								<div class="turtle">
+					<aside class="example" title="Using shnex:min to compute the smallest value in a property path">
+						<div class="shapes-graph">
+							<div class="turtle">
 ex:CompanyShape
     a sh:NodeShape ;
     sh:targetClass ex:Company ;
@@ -2516,10 +2489,9 @@ ex:CompanyShape-minStartDate
             shnex:pathValues ( ex:employee ex:startDate ) ;
         ] ;
     ]</b> .
-								</div>
 							</div>
-						</aside>
-				
+						</div>
+					</aside>
 				</section>
 
 				<section id="MaxExpression">
@@ -2611,12 +2583,7 @@ ex:CompanyShape-minStartDate
 					</p>
 					<p class="todo">TODO: Find good example, or drop the feature if none makes sense</p>
 				</section>
-
 			</section>
-
-
-
-			
 
 			<section id="misc">
 				<h2>Miscellaneous Node Expressions</h2>
@@ -3082,7 +3049,7 @@ ex:Person-fullName
 				</div>
 				<p><em>The remainder of this section is informative.</em></p>
 				<p>
-					Note that the <code>scope</scope> in the evaluation of expression constraints the mapping
+					Note that the <code>scope</code> in the evaluation of expression constraints the mapping
 					<code>value</code> to be the current <a>value node</a>.
 				</p>
 				<p>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -3049,8 +3049,8 @@ ex:Person-fullName
 				</div>
 				<p><em>The remainder of this section is informative.</em></p>
 				<p>
-					Note that the <code>scope</code> in the evaluation of expression constraints the mapping
-					<code>value</code> to be the current <a>value node</a>.
+					Note that the <code>scope</code> in the evaluation of expression constraints maps
+					<code>value</code> to the current <a>value node</a>.
 				</p>
 				<p>
 					The following example uses some SPARQL-based node expressions to declare


### PR DESCRIPTION
This is an editorial follow-up to recent merges to clean up formatting (often just indentation) but also some incorrect nesting of HTML tags that caused the TOC builder to fail.

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/node-expr-formatting/shacl12-node-expr/index.html)
