### PR TITLE
Set spec locations to www.w3.org/TR/

### DIFF
--- a/shacl12-common/specifications.html
+++ b/shacl12-common/specifications.html
@@ -8,14 +8,16 @@
       <dl>
         <dt><a href="https://w3c.github.io/data-shapes/shacl12-overview/">SHACL 1.2 Overview</a></dt>
         <dd>overviews the set of SHACL specifications</dd>
-        <dt><a href="https://w3c.github.io/data-shapes/shacl12-core/">SHACL 1.2 Core</a></dt>
+
+        <dt><a href="https://www.w3.org/TR/shacl12-core/">SHACL 1.2 Core</a></dt>
         <dd>defines the Core of SHACL</dd>
-        <dt><a href="https://w3c.github.io/data-shapes/shacl12-sparql/">SHACL 1.2 SPARQL Extensions</a></dt>
+        <dt><a href="https://www.w3.org/TR/shacl12-sparql/">SHACL 1.2 SPARQL Extensions</a></dt>
         <dd>defines SPARQL-related extensions of SHACL</dd>
-        <dt><a href="https://w3c.github.io/data-shapes/shacl12-node-expr/">SHACL 1.2 Node Expressions</a></dt>
+        <dt><a href="https://www.w3.org/TR/shacl12-node-expr/">SHACL 1.2 Node Expressions</a></dt>
         <dd>defines graph expressions used to determine focus nodes in SHACL</dd>
-        <dt><a href="https://w3c.github.io/data-shapes/shacl12-rules/">SHACL 1.2 Rules</a></dt>
+        <dt><a href="https://www.w3.org/TR/shacl12-rules/">SHACL 1.2 Rules</a></dt>
         <dd>defines SHACL's methods of rule-based inference</dd>
+
         <dt><a href="https://w3c.github.io/data-shapes/shacl12-ui/">SHACL 1.2 UI</a></dt>
         <dd>defines SHACL's use for User Interface generation</dd>
         <dt><a href="https://w3c.github.io/data-shapes/shacl12-cs/">SHACL 1.2 Compact Syntax</a></dt>


### PR DESCRIPTION
Some of the specs are available on /TR/.

This PR changes the URLs in the common inclusion HTML fragment for those documents.

Given search engines, web caching and other effects, changing the URLs now gives it longer to flush though the system.

See also #697.
