### PR TITLE
#657: Clarified that members of list must be literals/IRIs and the same order is kept

### DIFF
--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -893,13 +893,13 @@ ex:Company-employeeCount
 					<p>
 						Note that some <a>named parameter functions</a> &mdash; such as <code>shnex:IntersectionExpression</code> &mdash;
 						also use a <a>SHACL list</a> as an object of the <a>key parameter</a>, similar to <a>list parameter functions</a> which always have a <a>SHACL list</a> as the object of their <a>list parameter property</a>.
-						However, these may produce more than one <a>output nodes</a>, and also accept lists as input nodes.
+						However, these may produce more than one <a>output node</a>, and also accept lists as input nodes.
 					</p>
 					<p>
 						The following example uses two <a>list parameter functions</a> &mdash;
-						the (hypothetical)<code>ex:coalesce</code> and the SPARQL-based <code>sparql:concat</code> &mdash;
+						the (hypothetical) <code>ex:coalesce</code> and the SPARQL-based <code>sparql:concat</code> &mdash;
 						to compute the <code>ex:displayName</code>
-						of a person as either the value of <code>ex:fullName</code> or (if that doesn't exist)
+						of a person either as the value of <code>ex:fullName</code> or (if that doesn't exist)
 						as a concatenation of <code>ex:firstName</code>, a space, and <code>ex:lastName</code>.
 					</p>
 					
@@ -920,7 +920,7 @@ ex:Person-displayName
 			[
 				sparql:concat (
 					[ shnex:pathValues ex:firstName ]    # Path values expression with at most one value
-					" "                         # A constant literal expression
+					" "                                  # A constant literal expression
 					[ shnex:pathValues ex:lastName ]     # Path values expression with at most one value
 				)
 			]

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1072,7 +1072,7 @@ ex:Person-loves
 									<tr>
 										<td><b><code>rdf:first</code></b></td>
 										<td>
-											MUST be <a>literal</a> or an <a>IRI</a>.
+											MUST be a <a>literal</a> or an <a>IRI</a>.
 										</td>
 										<td>
 											The first member of the list.

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1073,7 +1073,7 @@ ex:Person-loves
 										<td>
 										</td>
 										<td>
-											The first member of the list, must be a <a>literal</a> or <a>IRI</a>.
+											The first member of the list.
 										</td>
 									</tr>
 									<tr>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1081,8 +1081,8 @@ ex:Person-loves
 									<tr>
 										<td><b><code>rdf:rest</code></b></td>
 										<td>
-											Must be a <a>well-formed</a> <a>SHACL list</a> where all <a>members</a>
-											are <a>literals</a> or <a>IRIs</a>.
+											Must be a <a>well-formed</a> <a>SHACL list</a>, where each <a>member</a>
+											is either a <a>literal</a> or an <a>IRI</a>.
 										</td>
 										<td>
 											The rest of the list, e.g., <code>rdf:nil</code>.

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1073,13 +1073,14 @@ ex:Person-loves
 										<td>
 										</td>
 										<td>
-											The first member of the list.
+											The first member of the list, must be a <a>literal</a> or <a>IRI</a>.
 										</td>
 									</tr>
 									<tr>
 										<td><b><code>rdf:rest</code></b></td>
 										<td>
-											Must be a <a>well-formed</a> <a>SHACL list</a>.
+											Must be a <a>well-formed</a> <a>SHACL list</a> where all <a>members</a>
+											are <a>literals</a> or <a>IRIs</a>.
 										</td>
 										<td>
 											The rest of the list, e.g. <code>rdf:nil</code>.
@@ -1092,7 +1093,8 @@ ex:Person-loves
 					<div class="def" id="ListExpression-evaluation">
 						<div class="def-header">EVALUATION OF LIST EXPRESSIONS</div>
 						<p>
-							The <a>output nodes</a> of a <a>list expression</a> are the <a>members</a> of the <a>SHACL list</a>.
+							The <a>output nodes</a> of a <a>list expression</a> are the <a>members</a> of the <a>list expression</a>,
+							in the same order as in the list.
 						</p>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -896,8 +896,9 @@ ex:Company-employeeCount
 						However, these may produce more than one <a>output nodes</a>, and also accept lists as input nodes.
 					</p>
 					<p>
-						The following example uses multiple (imaginary) <a>list parameter functions</a> &mdash;
-						<code>ex:coalesce</code> and <code>ex:concat</code> &mdash; to compute the <code>ex:displayName</code>
+						The following example uses two <a>list parameter functions</a> &mdash;
+						the (hypothetical)<code>ex:coalesce</code> and the SPARQL-based <code>sparql:concat</code> &mdash;
+						to compute the <code>ex:displayName</code>
 						of a person as either the value of <code>ex:fullName</code> or (if that doesn't exist)
 						as a concatenation of <code>ex:firstName</code>, a space, and <code>ex:lastName</code>.
 					</p>
@@ -917,7 +918,7 @@ ex:Person-displayName
 				shnex:pathValues ex:fullName ;
 			]
 			[
-				ex:concat (
+				sparql:concat (
 					[ shnex:pathValues ex:firstName ]    # Path values expression with at most one value
 					" "                         # A constant literal expression
 					[ shnex:pathValues ex:lastName ]     # Path values expression with at most one value

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1071,6 +1071,7 @@ ex:Person-loves
 									<tr>
 										<td><b><code>rdf:first</code></b></td>
 										<td>
+											MUST be <a>literal</a> or an <a>IRI</a>.
 										</td>
 										<td>
 											The first member of the list.

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -1085,7 +1085,7 @@ ex:Person-loves
 											are <a>literals</a> or <a>IRIs</a>.
 										</td>
 										<td>
-											The rest of the list, e.g. <code>rdf:nil</code>.
+											The rest of the list, e.g., <code>rdf:nil</code>.
 										</td>
 									</tr>
 								</tbody>


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #657

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-657/shacl12-node-expr/index.html)
