### PR TITLE
Use Respec dfn syntax for links to other specs

### DIFF
--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -644,7 +644,7 @@ ex:EstonianCompanyShape
 				>
 			</div>
 			<p>
-				The scenario above can also be expressed using SPARQL <a href="shacl12-sparql#SelectExpression">select expressions</a>.
+				The scenario above can also be expressed using SPARQL <dfn data-cite="shacl12-sparq#SelectExpression">select expressions</dfn>.
 				For performance reasons, for example, specific implementations of SHACL node expressions might
 				internally convert node expressions such as the <code>shnex:filterShape</code> above to SPARQL.
 			</p>
@@ -3159,7 +3159,7 @@ ex:Germany
 					a referenced <a>node expression</a> is used to dynamically compute the set of <a>node shapes</a> to which each <a>value node</a> must conform.
 				</p>
 				
-					There are three key differences between <code>sh:nodeByExpression</code> and <a href="shacl12-core#NodeConstraintComponent"><code>sh:node</code></a>:
+					There are three key differences between <code>sh:nodeByExpression</code> and <dfn data-cite="shacl12-core#NodeConstraintComponent"><code>sh:node</code></dfn>:
 					<ol>
 						<li>
 							<code>sh:nodeByExpression</code> references a <a>node expression</a> instead of a fixed <a>node shape</a> as <code>sh:node</code> does.


### PR DESCRIPTION
Relative links to point to other specs does not work in a simple <a> element, Respec has the dfn element to refer to concepts from other specs.
