### PR TITLE
Update rule grammar

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -245,7 +245,7 @@
 
         <p>TODO</p>
 
-        <p class="ednote">RFC 2119 language should automatically be inserted here.</p>
+        <p class="ednote">RFC 2119 language should be automatically inserted here.</p>
 
       </section>
     </section>

--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -245,7 +245,7 @@
 
         <p>TODO</p>
 
-        <p class="ednote">RFC 2119 language should autmatically be inserted here.</p>
+        <p class="ednote">RFC 2119 language should automatically be inserted here.</p>
 
       </section>
     </section>
@@ -952,707 +952,721 @@ the result is GI
                 <td><code>[1]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rRuleSet">RuleSet</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">( <a href="#rPrologue">Prologue</a> ( <a href="#rRule">Rule</a> | <a href="#rData">Data</a> ) )* <span class="token"></span></code></td>
+                <td><code class="gRuleBody"><a href="#rRuleOrDataBlock">RuleOrDataBlock</a> <span class="token"></span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
                 <td><code>[2]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPrologue">Prologue</span></code></td>
+                <td><code><span class="doc-ref" id="rRuleOrDataBlock">RuleOrDataBlock</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">( <a href="#rBaseDecl">BaseDecl</a> | <a href="#rPrefixDecl">PrefixDecl</a> | <a href="#rVersionDecl">VersionDecl</a> | <a href="#rImportsDecl">ImportsDecl</a> )*</code></td>
+                <td><code class="gRuleBody"><a href="#rPrologue">Prologue</a> ( ( <a href="#rRule">Rule</a> | <a href="#rData">Data</a> )+ ( <a href="#rPrologue1">Prologue1</a> ( <a href="#rRule">Rule</a> | <a href="#rData">Data</a> )? )* )?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
                 <td><code>[3]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPrologue">Prologue</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rPrologue1">Prologue1</a>*</code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[4]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rPrologue1">Prologue1</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rBaseDecl">BaseDecl</a> | <a href="#rPrefixDecl">PrefixDecl</a> | <a href="#rVersionDecl">VersionDecl</a> | <a href="#rImportsDecl">ImportsDecl</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[5]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBaseDecl">BaseDecl</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'BASE'</span> <a href="#rIRIREF">IRIREF</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[4]&nbsp;&nbsp;</code></td>
+                <td><code>[6]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPrefixDecl">PrefixDecl</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'PREFIX'</span> <a href="#rPNAME_NS">PNAME_NS</a> <a href="#rIRIREF">IRIREF</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[5]&nbsp;&nbsp;</code></td>
+                <td><code>[7]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVersionDecl">VersionDecl</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'VERSION'</span> <a href="#rVersionSpecifier">VersionSpecifier</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[6]&nbsp;&nbsp;</code></td>
+                <td><code>[8]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVersionSpecifier">VersionSpecifier</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rSTRING_LITERAL1">STRING_LITERAL1</a> | <a href="#rSTRING_LITERAL2">STRING_LITERAL2</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[7]&nbsp;&nbsp;</code></td>
+                <td><code>[9]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rImportsDecl">ImportsDecl</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'IMPORTS'</span> <a href="#riri">iri</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[8]&nbsp;&nbsp;</code></td>
+                <td><code>[10]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rRule">Rule</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rRule1">Rule1</a> |	<a href="#rRule2">Rule2</a> |	<a href="#rRule3">Rule3</a> |	<a href="#rDeclaration">Declaration</a></code></td>
+                <td><code class="gRuleBody"><a href="#rRule1">Rule1</a> | <a href="#rRule2">Rule2</a> | <a href="#rRule3">Rule3</a> | <a href="#rDeclaration">Declaration</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[9]&nbsp;&nbsp;</code></td>
+                <td><code>[11]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rRule1">Rule1</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'RULE'</span> <a href="#rHeadTemplate">HeadTemplate</a> <span class="token">'WHERE'</span> <a href="#rBodyPattern">BodyPattern</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[10]&nbsp;&nbsp;</code></td>
+                <td><code>[12]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rRule2">Rule2</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'IF'</span> <a href="#rBodyPattern">BodyPattern</a> <span class="token">'THEN'</span> <a href="#rHeadTemplate">HeadTemplate</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[11]&nbsp;&nbsp;</code></td>
+                <td><code>[13]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rRule3">Rule3</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rHeadTemplate">HeadTemplate</a> <span class="token">':-'</span> <a href="#rBodyPattern">BodyPattern</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[12]&nbsp;&nbsp;</code></td>
+                <td><code>[14]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rDeclaration">Declaration</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">( <span class="token">'TRANSITIVE'</span> <span class="token">'('</span> <a href="#riri">iri</a> <span class="token">')'</span> | <span class="token">'SYMMETRIC'</span> <span class="token">'('</span> <a href="#riri">iri</a> <span class="token">')'</span> | <span class="token">'INVERSE'</span> <span class="token">'('</span> <a href="#riri">iri</a> <span class="token">','</span> <a href="#riri">iri</a> <span class="token">')'</span> )</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[13]&nbsp;&nbsp;</code></td>
+                <td><code>[15]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rData">Data</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'DATA'</span> <a href="#rTriplesTemplateBlock">TriplesTemplateBlock</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[14]&nbsp;&nbsp;</code></td>
+                <td><code>[16]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rHeadTemplate">HeadTemplate</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rTriplesTemplateBlock">TriplesTemplateBlock</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[15]&nbsp;&nbsp;</code></td>
+                <td><code>[17]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBodyPattern">BodyPattern</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rBodyPattern1">BodyPattern1</a> <span class="token">'}'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[16]&nbsp;&nbsp;</code></td>
+                <td><code>[18]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBodyPattern1">BodyPattern1</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rBodyTriplesBlock">BodyTriplesBlock</a>? ( <a href="#rBodyNotTriples">BodyNotTriples</a> <a href="#rBodyTriplesBlock">BodyTriplesBlock</a>? )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[17]&nbsp;&nbsp;</code></td>
+                <td><code>[19]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBodyNotTriples">BodyNotTriples</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rFilter">Filter</a> | <a href="#rNegation">Negation</a> | <a href="#rAssignment">Assignment</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[18]&nbsp;&nbsp;</code></td>
+                <td><code>[20]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBodyTriplesBlock">BodyTriplesBlock</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rTriplesBlock">TriplesBlock</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[19]&nbsp;&nbsp;</code></td>
+                <td><code>[21]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rNegation">Negation</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'NOT'</span> <span class="token">'{'</span> <a href="#rBodyBasic">BodyBasic</a> <span class="token">'}'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[20]&nbsp;&nbsp;</code></td>
+                <td><code>[22]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBodyBasic">BodyBasic</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rBodyTriplesBlock">BodyTriplesBlock</a>? ( <a href="#rFilter">Filter</a> <a href="#rBodyTriplesBlock">BodyTriplesBlock</a>? )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[21]&nbsp;&nbsp;</code></td>
+                <td><code>[23]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTriplesTemplateBlock">TriplesTemplateBlock</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? <span class="token">'}'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[22]&nbsp;&nbsp;</code></td>
+                <td><code>[24]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTriplesTemplate">TriplesTemplate</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rTriplesSameSubject">TriplesSameSubject</a> ( <span class="token">'.'</span> <a href="#rTriplesTemplate">TriplesTemplate</a>? )?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[23]&nbsp;&nbsp;</code></td>
+                <td><code>[25]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTriplesBlock">TriplesBlock</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rTriplesSameSubjectPath">TriplesSameSubjectPath</a> ( <span class="token">'.'</span> <a href="#rTriplesBlock">TriplesBlock</a>? )?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[24]&nbsp;&nbsp;</code></td>
+                <td><code>[26]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rReifiedTripleBlock">ReifiedTripleBlock</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rReifiedTriple">ReifiedTriple</a> <a href="#rPropertyList">PropertyList</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[25]&nbsp;&nbsp;</code></td>
+                <td><code>[27]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rReifiedTripleBlockPath">ReifiedTripleBlockPath</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rReifiedTriple">ReifiedTriple</a> <a href="#rPropertyListPath">PropertyListPath</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[26]&nbsp;&nbsp;</code></td>
+                <td><code>[28]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rAssignment">Assignment</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'BIND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">'AS'</span> <a href="#rVar">Var</a> <span class="token">')'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[27]&nbsp;&nbsp;</code></td>
+                <td><code>[29]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rReifier">Reifier</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'~'</span> <a href="#rVarOrReifierId">VarOrReifierId</a>?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[28]&nbsp;&nbsp;</code></td>
+                <td><code>[30]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVarOrReifierId">VarOrReifierId</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rBlankNode">BlankNode</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[29]&nbsp;&nbsp;</code></td>
+                <td><code>[31]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rFilter">Filter</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'FILTER'</span> <a href="#rConstraint">Constraint</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[30]&nbsp;&nbsp;</code></td>
+                <td><code>[32]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rConstraint">Constraint</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#rFunctionCall">FunctionCall</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[31]&nbsp;&nbsp;</code></td>
+                <td><code>[33]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rFunctionCall">FunctionCall</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#riri">iri</a> <a href="#rArgList">ArgList</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[32]&nbsp;&nbsp;</code></td>
+                <td><code>[34]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rArgList">ArgList</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rNIL">NIL</a> | <span class="token">'('</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )* <span class="token">')'</span> </code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[33]&nbsp;&nbsp;</code></td>
+                <td><code>[35]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rExpressionList">ExpressionList</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rNIL">NIL</a> | <span class="token">'('</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )* <span class="token">')'</span> </code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[34]&nbsp;&nbsp;</code></td>
+                <td><code>[36]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTriplesSameSubject">TriplesSameSubject</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> |	<a href="#rTriplesNode">TriplesNode</a> <a href="#rPropertyList">PropertyList</a> |	<a href="#rReifiedTripleBlock">ReifiedTripleBlock</a></code></td>
+                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> | <a href="#rTriplesNode">TriplesNode</a> <a href="#rPropertyList">PropertyList</a> | <a href="#rReifiedTripleBlock">ReifiedTripleBlock</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[35]&nbsp;&nbsp;</code></td>
+                <td><code>[37]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPropertyList">PropertyList</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a>?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[36]&nbsp;&nbsp;</code></td>
+                <td><code>[38]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPropertyListNotEmpty">PropertyListNotEmpty</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rVerb">Verb</a> <a href="#rObjectList">ObjectList</a> ( <span class="token">';'</span> ( <a href="#rVerb">Verb</a> <a href="#rObjectList">ObjectList</a> )? )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[37]&nbsp;&nbsp;</code></td>
+                <td><code>[39]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVerb">Verb</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rVarOrIri">VarOrIri</a> | <span class="token">'a'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[38]&nbsp;&nbsp;</code></td>
+                <td><code>[40]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rObjectList">ObjectList</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rObject">Object</a> ( <span class="token">','</span> <a href="#rObject">Object</a> )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[39]&nbsp;&nbsp;</code></td>
+                <td><code>[41]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rObject">Object</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rGraphNode">GraphNode</a> <a href="#rAnnotation">Annotation</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[40]&nbsp;&nbsp;</code></td>
+                <td><code>[42]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTriplesSameSubjectPath">TriplesSameSubjectPath</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> |	<a href="#rTriplesNodePath">TriplesNodePath</a> <a href="#rPropertyListPath">PropertyListPath</a> |	<a href="#rReifiedTripleBlockPath">ReifiedTripleBlockPath</a></code></td>
+                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> | <a href="#rTriplesNodePath">TriplesNodePath</a> <a href="#rPropertyListPath">PropertyListPath</a> | <a href="#rReifiedTripleBlockPath">ReifiedTripleBlockPath</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[41]&nbsp;&nbsp;</code></td>
+                <td><code>[43]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPropertyListPath">PropertyListPath</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a>?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[42]&nbsp;&nbsp;</code></td>
+                <td><code>[44]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPropertyListPathNotEmpty">PropertyListPathNotEmpty</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> ( <span class="token">';'</span> ( ( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> )? )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[43]&nbsp;&nbsp;</code></td>
+                <td><code>[45]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVerbPath">VerbPath</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPath">Path</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[44]&nbsp;&nbsp;</code></td>
+                <td><code>[46]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVerbSimple">VerbSimple</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rVar">Var</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[45]&nbsp;&nbsp;</code></td>
+                <td><code>[47]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rObjectListPath">ObjectListPath</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rObjectPath">ObjectPath</a> ( <span class="token">','</span> <a href="#rObjectPath">ObjectPath</a> )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[46]&nbsp;&nbsp;</code></td>
+                <td><code>[48]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rObjectPath">ObjectPath</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rGraphNodePath">GraphNodePath</a> <a href="#rAnnotationPath">AnnotationPath</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[47]&nbsp;&nbsp;</code></td>
+                <td><code>[49]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPath">Path</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPathSequence">PathSequence</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[48]&nbsp;&nbsp;</code></td>
+                <td><code>[50]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPathSequence">PathSequence</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPathEltOrInverse">PathEltOrInverse</a> ( <span class="token">'/'</span> <a href="#rPathEltOrInverse">PathEltOrInverse</a> )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[49]&nbsp;&nbsp;</code></td>
+                <td><code>[51]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPathEltOrInverse">PathEltOrInverse</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPathElt">PathElt</a> | <span class="token">'^'</span> <a href="#rPathElt">PathElt</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[50]&nbsp;&nbsp;</code></td>
+                <td><code>[52]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPathElt">PathElt</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPathPrimary">PathPrimary</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[51]&nbsp;&nbsp;</code></td>
+                <td><code>[53]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPathPrimary">PathPrimary</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#riri">iri</a> | <span class="token">'a'</span> | <span class="token">'('</span> <a href="#rPath">Path</a> <span class="token">')'</span> </code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[52]&nbsp;&nbsp;</code></td>
+                <td><code>[54]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTriplesNode">TriplesNode</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rCollection">Collection</a> |	<a href="#rBlankNodePropertyList">BlankNodePropertyList</a></code></td>
+                <td><code class="gRuleBody"><a href="#rCollection">Collection</a> | <a href="#rBlankNodePropertyList">BlankNodePropertyList</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[53]&nbsp;&nbsp;</code></td>
+                <td><code>[55]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBlankNodePropertyList">BlankNodePropertyList</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'['</span> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> <span class="token">']'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[54]&nbsp;&nbsp;</code></td>
+                <td><code>[56]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTriplesNodePath">TriplesNodePath</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rCollectionPath">CollectionPath</a> |	<a href="#rBlankNodePropertyListPath">BlankNodePropertyListPath</a></code></td>
+                <td><code class="gRuleBody"><a href="#rCollectionPath">CollectionPath</a> | <a href="#rBlankNodePropertyListPath">BlankNodePropertyListPath</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[55]&nbsp;&nbsp;</code></td>
+                <td><code>[57]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBlankNodePropertyListPath">BlankNodePropertyListPath</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'['</span> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> <span class="token">']'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[56]&nbsp;&nbsp;</code></td>
+                <td><code>[58]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rCollection">Collection</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rGraphNode">GraphNode</a>+ <span class="token">')'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[57]&nbsp;&nbsp;</code></td>
+                <td><code>[59]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rCollectionPath">CollectionPath</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rGraphNodePath">GraphNodePath</a>+ <span class="token">')'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[58]&nbsp;&nbsp;</code></td>
+                <td><code>[60]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rAnnotationPath">AnnotationPath</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">( <a href="#rReifier">Reifier</a> | <a href="#rAnnotationBlockPath">AnnotationBlockPath</a> )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[59]&nbsp;&nbsp;</code></td>
+                <td><code>[61]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rAnnotationBlockPath">AnnotationBlockPath</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'{|'</span> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> <span class="token">'|}'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[60]&nbsp;&nbsp;</code></td>
+                <td><code>[62]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rAnnotation">Annotation</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">( <a href="#rReifier">Reifier</a> | <a href="#rAnnotationBlock">AnnotationBlock</a> )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[61]&nbsp;&nbsp;</code></td>
+                <td><code>[63]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rAnnotationBlock">AnnotationBlock</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'{|'</span> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> <span class="token">'|}'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[62]&nbsp;&nbsp;</code></td>
+                <td><code>[64]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rGraphNode">GraphNode</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> |	<a href="#rTriplesNode">TriplesNode</a> |	<a href="#rReifiedTriple">ReifiedTriple</a></code></td>
+                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> | <a href="#rTriplesNode">TriplesNode</a> | <a href="#rReifiedTriple">ReifiedTriple</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[63]&nbsp;&nbsp;</code></td>
+                <td><code>[65]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rGraphNodePath">GraphNodePath</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> |	<a href="#rTriplesNodePath">TriplesNodePath</a> |	<a href="#rReifiedTriple">ReifiedTriple</a></code></td>
+                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> | <a href="#rTriplesNodePath">TriplesNodePath</a> | <a href="#rReifiedTriple">ReifiedTriple</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[64]&nbsp;&nbsp;</code></td>
+                <td><code>[66]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVarOrTerm">VarOrTerm</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rNIL">NIL</a> | <a href="#rTripleTerm">TripleTerm</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[65]&nbsp;&nbsp;</code></td>
+                <td><code>[67]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rReifiedTriple">ReifiedTriple</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rReifiedTripleSubject">ReifiedTripleSubject</a> <a href="#rVerb">Verb</a> <a href="#rReifiedTripleObject">ReifiedTripleObject</a> <a href="#rReifier">Reifier</a>? <span class="token">'&gt;&gt;'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[66]&nbsp;&nbsp;</code></td>
+                <td><code>[68]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rReifiedTripleSubject">ReifiedTripleSubject</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rReifiedTriple">ReifiedTriple</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[67]&nbsp;&nbsp;</code></td>
+                <td><code>[69]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rReifiedTripleObject">ReifiedTripleObject</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rReifiedTriple">ReifiedTriple</a> | <a href="#rTripleTerm">TripleTerm</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[68]&nbsp;&nbsp;</code></td>
+                <td><code>[70]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTripleTerm">TripleTerm</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'&lt;&lt;('</span> <a href="#rTripleTermSubject">TripleTermSubject</a> <a href="#rVerb">Verb</a> <a href="#rTripleTermObject">TripleTermObject</a> <span class="token">')&gt;&gt;'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[69]&nbsp;&nbsp;</code></td>
+                <td><code>[71]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTripleTermSubject">TripleTermSubject</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[70]&nbsp;&nbsp;</code></td>
+                <td><code>[72]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTripleTermObject">TripleTermObject</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rTripleTerm">TripleTerm</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[71]&nbsp;&nbsp;</code></td>
+                <td><code>[73]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTripleTermData">TripleTermData</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'&lt;&lt;('</span> <a href="#rTripleTermDataSubject">TripleTermDataSubject</a> ( <a href="#riri">iri</a> | <span class="token">'a'</span> ) <a href="#rTripleTermDataObject">TripleTermDataObject</a> <span class="token">')&gt;&gt;'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[72]&nbsp;&nbsp;</code></td>
+                <td><code>[74]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTripleTermDataSubject">TripleTermDataSubject</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[73]&nbsp;&nbsp;</code></td>
+                <td><code>[75]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rTripleTermDataObject">TripleTermDataObject</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rTripleTermData">TripleTermData</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[74]&nbsp;&nbsp;</code></td>
+                <td><code>[76]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVarOrIri">VarOrIri</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[75]&nbsp;&nbsp;</code></td>
+                <td><code>[77]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVar">Var</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rVAR1">VAR1</a> | <a href="#rVAR2">VAR2</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[76]&nbsp;&nbsp;</code></td>
+                <td><code>[78]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rExpression">Expression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rConditionalOrExpression">ConditionalOrExpression</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[77]&nbsp;&nbsp;</code></td>
+                <td><code>[79]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rConditionalOrExpression">ConditionalOrExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rConditionalAndExpression">ConditionalAndExpression</a> ( <span class="token">'||'</span> <a href="#rConditionalAndExpression">ConditionalAndExpression</a> )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[78]&nbsp;&nbsp;</code></td>
+                <td><code>[80]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rConditionalAndExpression">ConditionalAndExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rValueLogical">ValueLogical</a> ( <span class="token">'&amp;&amp;'</span> <a href="#rValueLogical">ValueLogical</a> )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[79]&nbsp;&nbsp;</code></td>
+                <td><code>[81]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rValueLogical">ValueLogical</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rRelationalExpression">RelationalExpression</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[80]&nbsp;&nbsp;</code></td>
+                <td><code>[82]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rRelationalExpression">RelationalExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rNumericExpression">NumericExpression</a> ( <span class="token">'='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'!='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> | <span class="token">'NOT'</span> <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> )?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[81]&nbsp;&nbsp;</code></td>
+                <td><code>[83]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rNumericExpression">NumericExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rAdditiveExpression">AdditiveExpression</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[82]&nbsp;&nbsp;</code></td>
+                <td><code>[84]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rAdditiveExpression">AdditiveExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rMultiplicativeExpression">MultiplicativeExpression</a> ( <span class="token">'+'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | <span class="token">'-'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | ( <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a> ) ( ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) | ( <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) )* )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[83]&nbsp;&nbsp;</code></td>
+                <td><code>[85]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rMultiplicativeExpression">MultiplicativeExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rUnaryExpression">UnaryExpression</a> ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> | <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[84]&nbsp;&nbsp;</code></td>
+                <td><code>[86]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rUnaryExpression">UnaryExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'!'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<span class="token">'+'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<span class="token">'-'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>|	<a href="#rPrimaryExpression">PrimaryExpression</a></code></td>
+                <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'!'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>| <span class="token">'+'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>| <span class="token">'-'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>| <a href="#rPrimaryExpression">PrimaryExpression</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[85]&nbsp;&nbsp;</code></td>
+                <td><code>[87]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPrimaryExpression">PrimaryExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#ririOrFunction">iriOrFunction</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprTripleTerm">ExprTripleTerm</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[86]&nbsp;&nbsp;</code></td>
+                <td><code>[88]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rExprTripleTerm">ExprTripleTerm</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'&lt;&lt;('</span> <a href="#rExprTripleTermSubject">ExprTripleTermSubject</a> <a href="#rVerb">Verb</a> <a href="#rExprTripleTermObject">ExprTripleTermObject</a> <span class="token">')&gt;&gt;'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[87]&nbsp;&nbsp;</code></td>
+                <td><code>[89]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rExprTripleTermSubject">ExprTripleTermSubject</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[88]&nbsp;&nbsp;</code></td>
+                <td><code>[90]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rExprTripleTermObject">ExprTripleTermObject</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprTripleTerm">ExprTripleTerm</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[89]&nbsp;&nbsp;</code></td>
+                <td><code>[91]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBrackettedExpression">BrackettedExpression</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[90]&nbsp;&nbsp;</code></td>
+                <td><code>[92]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBuiltInCall">BuiltInCall</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'STR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LANGMATCHES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'DATATYPE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'BOUND'</span> <span class="token">'('</span> <a href="#rVar">Var</a> <span class="token">')'</span> <br/>|	<span class="token">'IRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'BNODE'</span> ( <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> | <a href="#rNIL">NIL</a> ) <br/>|	<span class="token">'RAND'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'ABS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CEIL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'FLOOR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'ROUND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CONCAT'</span> <a href="#rExpressionList">ExpressionList</a> <br/>|	<span class="token">'SUBSTR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span> <br/>|	<span class="token">'STRLEN'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'REPLACE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span> <br/>|	<span class="token">'UCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'LCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'ENCODE_FOR_URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'CONTAINS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRSTARTS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRENDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRBEFORE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRAFTER'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'YEAR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'MONTH'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'DAY'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'HOURS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'MINUTES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SECONDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TIMEZONE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TZ'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'NOW'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'UUID'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'STRUUID'</span> <a href="#rNIL">NIL</a> <br/>|	<span class="token">'MD5'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA1'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA256'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA384'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SHA512'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'COALESCE'</span> <a href="#rExpressionList">ExpressionList</a> <br/>|	<span class="token">'IF'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRLANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'STRDT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'sameTerm'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isIRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isURI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isBLANK'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isLITERAL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'isNUMERIC'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'hasLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'hasLANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'REGEX'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span> <br/>|	<span class="token">'isTRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'TRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'SUBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'PREDICATE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>|	<span class="token">'OBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
+                <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'STR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'LANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'LANGMATCHES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'LANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'DATATYPE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'IRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'BNODE'</span> ( <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> | <a href="#rNIL">NIL</a> ) <br/>| <span class="token">'RAND'</span> <a href="#rNIL">NIL</a> <br/>| <span class="token">'ABS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'CEIL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'FLOOR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'ROUND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'CONCAT'</span> <a href="#rExpressionList">ExpressionList</a> <br/>| <span class="token">'SUBSTR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span> <br/>| <span class="token">'STRLEN'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'REPLACE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span> <br/>| <span class="token">'UCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'LCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'ENCODE_FOR_URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'CONTAINS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRSTARTS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRENDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRBEFORE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRAFTER'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'YEAR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'MONTH'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'DAY'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'HOURS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'MINUTES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'SECONDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'TIMEZONE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'TZ'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'NOW'</span> <a href="#rNIL">NIL</a> <br/>| <span class="token">'UUID'</span> <a href="#rNIL">NIL</a> <br/>| <span class="token">'STRUUID'</span> <a href="#rNIL">NIL</a> <br/>| <span class="token">'MD5'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'SHA1'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'SHA256'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'SHA384'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'SHA512'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'COALESCE'</span> <a href="#rExpressionList">ExpressionList</a> <br/>| <span class="token">'IF'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRLANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRDT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'sameTerm'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isIRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isURI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isBLANK'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isLITERAL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isNUMERIC'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'hasLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'hasLANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'REGEX'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span> <br/>| <span class="token">'isTRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'TRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'SUBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'PREDICATE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'OBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[91]&nbsp;&nbsp;</code></td>
+                <td><code>[93]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="ririOrFunction">iriOrFunction</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#riri">iri</a> <a href="#rArgList">ArgList</a>?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[92]&nbsp;&nbsp;</code></td>
+                <td><code>[94]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rRDFLiteral">RDFLiteral</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rString">String</a> ( <a href="#rLANG_DIR">LANG_DIR</a> | <span class="token">'^^'</span> <a href="#riri">iri</a> )?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[93]&nbsp;&nbsp;</code></td>
+                <td><code>[95]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rNumericLiteral">NumericLiteral</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rNumericLiteralUnsigned">NumericLiteralUnsigned</a> | <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[94]&nbsp;&nbsp;</code></td>
+                <td><code>[96]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rNumericLiteralUnsigned">NumericLiteralUnsigned</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rINTEGER">INTEGER</a> |	<a href="#rDECIMAL">DECIMAL</a> |	<a href="#rDOUBLE">DOUBLE</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[95]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNumericLiteralPositive">NumericLiteralPositive</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rINTEGER_POSITIVE">INTEGER_POSITIVE</a> |	<a href="#rDECIMAL_POSITIVE">DECIMAL_POSITIVE</a> |	<a href="#rDOUBLE_POSITIVE">DOUBLE_POSITIVE</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[96]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNumericLiteralNegative">NumericLiteralNegative</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rINTEGER_NEGATIVE">INTEGER_NEGATIVE</a> |	<a href="#rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</a> |	<a href="#rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</a></code></td>
+                <td><code class="gRuleBody"><a href="#rINTEGER">INTEGER</a> | <a href="#rDECIMAL">DECIMAL</a> | <a href="#rDOUBLE">DOUBLE</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
                 <td><code>[97]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBooleanLiteral">BooleanLiteral</span></code></td>
+                <td><code><span class="doc-ref" id="rNumericLiteralPositive">NumericLiteralPositive</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'true'</span> |	<span class="token">'false'</span></code></td>
+                <td><code class="gRuleBody"><a href="#rINTEGER_POSITIVE">INTEGER_POSITIVE</a> | <a href="#rDECIMAL_POSITIVE">DECIMAL_POSITIVE</a> | <a href="#rDOUBLE_POSITIVE">DOUBLE_POSITIVE</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
                 <td><code>[98]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rNumericLiteralNegative">NumericLiteralNegative</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><a href="#rINTEGER_NEGATIVE">INTEGER_NEGATIVE</a> | <a href="#rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</a> | <a href="#rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</a></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[99]&nbsp;&nbsp;</code></td>
+                <td><code><span class="doc-ref" id="rBooleanLiteral">BooleanLiteral</span></code></td>
+                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+                <td><code class="gRuleBody"><span class="token">'true'</span> | <span class="token">'false'</span></code></td>
+              </tr>
+
+              <tr style="vertical-align: baseline">
+                <td><code>[100]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rString">String</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rSTRING_LITERAL1">STRING_LITERAL1</a> | <a href="#rSTRING_LITERAL2">STRING_LITERAL2</a> | <a href="#rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</a> | <a href="#rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[99]&nbsp;&nbsp;</code></td>
+                <td><code>[101]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="riri">iri</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rIRIREF">IRIREF</a> |	<a href="#rPrefixedName">PrefixedName</a></code></td>
+                <td><code class="gRuleBody"><a href="#rIRIREF">IRIREF</a> | <a href="#rPrefixedName">PrefixedName</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[100]&nbsp;&nbsp;</code></td>
+                <td><code>[102]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPrefixedName">PrefixedName</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPNAME_LN">PNAME_LN</a> | <a href="#rPNAME_NS">PNAME_NS</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[101]&nbsp;&nbsp;</code></td>
+                <td><code>[103]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBlankNode">BlankNode</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rBLANK_NODE_LABEL">BLANK_NODE_LABEL</a> |	<a href="#rANON">ANON</a></code></td>
+                <td><code class="gRuleBody"><a href="#rBLANK_NODE_LABEL">BLANK_NODE_LABEL</a> | <a href="#rANON">ANON</a></code></td>
               </tr>
         </tbody></table>
       </div>
@@ -1661,238 +1675,238 @@ the result is GI
         <table><tbody>
 
               <tr style="vertical-align: baseline">
-                <td><code>[102]&nbsp;&nbsp;</code></td>
+                <td><code>[104]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rIRIREF">IRIREF</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'&lt;' ([^&lt;&gt;"{}|^`\]-[#x00-#x20])* '&gt;'</span></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[103]&nbsp;&nbsp;</code></td>
+                <td><code>[105]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPNAME_NS">PNAME_NS</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPN_PREFIX">PN_PREFIX</a>? ':'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[104]&nbsp;&nbsp;</code></td>
+                <td><code>[106]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPNAME_LN">PNAME_LN</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPNAME_NS">PNAME_NS</a> <a href="#rPN_LOCAL">PN_LOCAL</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[105]&nbsp;&nbsp;</code></td>
+                <td><code>[107]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rBLANK_NODE_LABEL">BLANK_NODE_LABEL</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'_:' ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] ) ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[106]&nbsp;&nbsp;</code></td>
+                <td><code>[108]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVAR1">VAR1</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'?' <a href="#rVARNAME">VARNAME</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[107]&nbsp;&nbsp;</code></td>
+                <td><code>[109]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVAR2">VAR2</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'$' <a href="#rVARNAME">VARNAME</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[108]&nbsp;&nbsp;</code></td>
+                <td><code>[110]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rLANG_DIR">LANG_DIR</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)* ('--' [a-zA-Z]+)?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[109]&nbsp;&nbsp;</code></td>
+                <td><code>[111]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rINTEGER">INTEGER</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">[0-9]+</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[110]&nbsp;&nbsp;</code></td>
+                <td><code>[112]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rDECIMAL">DECIMAL</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">[0-9]* '.' [0-9]+</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[111]&nbsp;&nbsp;</code></td>
+                <td><code>[113]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rDOUBLE">DOUBLE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">( ([0-9]+ ('.'[0-9]*)? ) | ( '.' ([0-9])+ ) ) [eE][+-]?[0-9]+</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[112]&nbsp;&nbsp;</code></td>
+                <td><code>[114]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rINTEGER_POSITIVE">INTEGER_POSITIVE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rINTEGER">INTEGER</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[113]&nbsp;&nbsp;</code></td>
+                <td><code>[115]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rDECIMAL_POSITIVE">DECIMAL_POSITIVE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[114]&nbsp;&nbsp;</code></td>
+                <td><code>[116]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rDOUBLE_POSITIVE">DOUBLE_POSITIVE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[115]&nbsp;&nbsp;</code></td>
+                <td><code>[117]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rINTEGER_NEGATIVE">INTEGER_NEGATIVE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rINTEGER">INTEGER</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[116]&nbsp;&nbsp;</code></td>
+                <td><code>[118]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[117]&nbsp;&nbsp;</code></td>
+                <td><code>[119]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[118]&nbsp;&nbsp;</code></td>
+                <td><code>[120]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rSTRING_LITERAL1">STRING_LITERAL1</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">"'" ( ([^#x27#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* "'"</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[119]&nbsp;&nbsp;</code></td>
+                <td><code>[121]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rSTRING_LITERAL2">STRING_LITERAL2</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'"' ( ([^#x22#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* '"'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[120]&nbsp;&nbsp;</code></td>
+                <td><code>[122]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">"'''" ( ( "'" | "''" )? ( [^'\] | <a href="#rECHAR">ECHAR</a> ) )* "'''"</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[121]&nbsp;&nbsp;</code></td>
+                <td><code>[123]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'"""' ( ( '"' | '""' )? ( [^"\] | <a href="#rECHAR">ECHAR</a> ) )* '"""'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[122]&nbsp;&nbsp;</code></td>
+                <td><code>[124]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rECHAR">ECHAR</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'\' [tbnrf\"']</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[123]&nbsp;&nbsp;</code></td>
+                <td><code>[125]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rNIL">NIL</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'(' <a href="#rWS">WS</a>* ')'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[124]&nbsp;&nbsp;</code></td>
+                <td><code>[126]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rWS">WS</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">#x20 | #x9 | #xD | #xA</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[125]&nbsp;&nbsp;</code></td>
+                <td><code>[127]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rANON">ANON</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'['  <a href="#rWS">WS</a>* ']'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[126]&nbsp;&nbsp;</code></td>
+                <td><code>[128]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_CHARS_BASE">PN_CHARS_BASE</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">[A-Z] | [a-z] | [#x00C0-#x00D6] | [#x00D8-#x00F6] | [#x00F8-#x02FF] | [#x0370-#x037D] | [#x037F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[127]&nbsp;&nbsp;</code></td>
+                <td><code>[129]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_CHARS_U">PN_CHARS_U</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> | '_'</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[128]&nbsp;&nbsp;</code></td>
+                <td><code>[130]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rVARNAME">VARNAME</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">( <a href="#rPN_CHARS_U">PN_CHARS_U</a>  | [0-9] ) ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040] )*</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[129]&nbsp;&nbsp;</code></td>
+                <td><code>[131]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_CHARS">PN_CHARS</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPN_CHARS_U">PN_CHARS_U</a> | '-' | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040]</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[130]&nbsp;&nbsp;</code></td>
+                <td><code>[132]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_PREFIX">PN_PREFIX</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[131]&nbsp;&nbsp;</code></td>
+                <td><code>[133]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_LOCAL">PN_LOCAL</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">(<a href="#rPN_CHARS_U">PN_CHARS_U</a> | ':' | [0-9] | <a href="#rPLX">PLX</a> ) ((<a href="#rPN_CHARS">PN_CHARS</a> | '.' | ':' | <a href="#rPLX">PLX</a>)* (<a href="#rPN_CHARS">PN_CHARS</a> | ':' | <a href="#rPLX">PLX</a>) )?</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[132]&nbsp;&nbsp;</code></td>
+                <td><code>[134]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPLX">PLX</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody"><a href="#rPERCENT">PERCENT</a> | <a href="#rPN_LOCAL_ESC">PN_LOCAL_ESC</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[133]&nbsp;&nbsp;</code></td>
+                <td><code>[135]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPERCENT">PERCENT</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'%' <a href="#rHEX">HEX</a> <a href="#rHEX">HEX</a></code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[134]&nbsp;&nbsp;</code></td>
+                <td><code>[136]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rHEX">HEX</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">[0-9] | [A-F] | [a-f]</code></td>
               </tr>
 
               <tr style="vertical-align: baseline">
-                <td><code>[135]&nbsp;&nbsp;</code></td>
+                <td><code>[137]&nbsp;&nbsp;</code></td>
                 <td><code><span class="doc-ref" id="rPN_LOCAL_ESC">PN_LOCAL_ESC</span></code></td>
                 <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
                 <td><code class="gRuleBody">'\' ( '_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | "'" | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%' )</code></td>


### PR DESCRIPTION
This PR updates the SRL grammar:

1. Allow a prologue anywhere between rules or data blocks (c.f. SPARQL Update)
   A prologue is `PREFIX`/`BASE`/`VERSION`/`IMPORTS`
3. Remove `BOUND` as a function.

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/afs/rules-grammar/shacl12-rules/index.html)
