### PR TITLE
Revise SHACL 1.2 Rules abstract

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -123,11 +123,21 @@
   </head>
   <body>
     <section id="abstract">
-      <p>This document describes Shapes Constraint Language (SHACL) Rules.</p>
+      <p>This document defines <em>SHACL Rules</em>.</p>
+      <p>
+        SHACL, the Shapes Constraint Language, is a language for describing the structure
+        of RDF graphs.
+        SHACL may be used for a variety of purposes such as validating, inferencing,
+        modeling domains, generating ontologies to inform other agents, building user
+        interfaces, generating code, and integrating data.
+      </p>
+      <p>
+        SHACL Rules provides inferencing with the generation of new RDF data from a
+        combination of a set of rules and a base data graph. Rules can be expressed as RDF
+        or in the SHACL Rules Language (SRL).
       <p>
         This specification is published by the
-        <a href="https://www.w3.org/groups/wg/data-shapes/">Data Shapes Working Group</a>
-        .
+        <a href="https://www.w3.org/groups/wg/data-shapes/">Data Shapes Working Group</a>.
       </p>
     </section>
 


### PR DESCRIPTION
This PR takes text from the revised SHACL 12. Core abstract as related to SHACL Rules.

This is no more than a slightly better abstract. The final abstract can be written when the document is complete.

* [See the revised abstract online here](https://raw.githack.com/w3c/data-shapes/afs/rules-abstract/shacl12-rules/index.html#abstract)
