### PR TITLE
Updates permitted datatypes of `sh:message` and `sh:description`, and other properties previously permitting `rdf:langString` (Issues 723 & 724)

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -881,7 +881,7 @@ ex:Person
 						</div>
 						<div class="diagram-class-properties-section">
 							<div><a href="#deactivated">sh:deactivated</a> : xsd:boolean</div>
-							<div><a href="#message">sh:message</a> : xsd:string or rdf:langString</div>
+							<div><a href="#message">sh:message</a> : text</div>
 							<div><a href="#severity">sh:severity</a> : sh:Severity</div>
 						</div>
 					</div>
@@ -913,8 +913,8 @@ ex:Person
 							<div><a href="#NodeConstraintComponent">sh:node</a> : sh:NodeShape</div>
 						</div>
 						<div class="diagram-class-properties-section">
-							<div><a href="#name">sh:name</a> : xsd:string or rdf:langString</div>
-							<div><a href="#description">sh:description</a> : xsd:string or rdf:langString</div>
+							<div><a href="#name">sh:name</a> : xsd:string or rdf:dirLangString or rdf:langString</div>
+							<div><a href="#description">sh:description</a> : text</div>
 							<div><a href="#syntax-rule-path-defaultValue">sh:defaultValue</a> : any</div>
 							<div><a href="#syntax-rule-path-defaultValue">sh:values</a> : any</div>
 							<div><a href="#group">sh:group</a> : sh:PropertyGroup</div>
@@ -1606,7 +1606,8 @@ ex:MyShape-myProperty2
 					<h4>Declaring Messages for a Shape or Constraint</h4>
 					<p class="syntax">
 						Shapes can have values for the property <code>sh:message</code>.
-						<span data-syntax-rule="message-datatype">The values of <code>sh:message</code> are either <code>xsd:string</code> literals or literals with a language tag.</span>
+						<span data-syntax-rule="message-datatype">The values of <code>sh:message</code> are <a>literals</a> with <a>datatype</a>
+						<code>xsd:string</code>, <code>rdf:dirLangString</code>, <code>rdf:langString</code>, or <code>rdf:HTML</code>.
 						A subject should not have more than one value for <code>sh:message</code> with the same language tag.
 					</p>
 					<p>
@@ -2774,7 +2775,6 @@ ex:Alice ex:age "23"^^xsd:integer .
 					<p>
 						The following example illustrates the list-based syntax, meaning that all values of
 						<code>rdfs:label</code> must be either <code>xsd:string</code> or <code>rdf:langString</code>.
-						Note that using <code>rdf:langString</code> as value of <code>sh:datatype</code> can be used to test if value nodes have a language tag.
 					</p>
 					<aside class="example" title="Shape with a list of IRIs as sh:datatype property constraint">
 						<div class="shapes-graph">
@@ -3461,7 +3461,7 @@ ex:SingleLineExampleShape-label
 ex:SingleLineExampleShape-comment
     a sh:PropertyShape ;
     sh:path rdfs:comment ;
-    sh:datatype ( xsd:string rdf:langString ) ;
+    sh:datatype ( xsd:string rdf:dirLangString rdf:langString ) ;
     sh:singleLine false ;
 .
 							</div>
@@ -5338,8 +5338,16 @@ ex:RainbowPony ex:color ex:Pink .
 					over globally specified labels at the <code>rdf:Property</code> itself.
 					For example, if a form displays a node that is in the target of a given property shape
 					with an <code>sh:name</code>, then the tool SHOULD use the provided name.
+					The <a>values</a> of <code>sh:name</code> must be <a>literals</a> with <a>datatype</a>
+					<code>xsd:string</code>, <code>rdf:dirLangString</code>, or <code>rdf:langString</code>.
+				</p>
+				<p>
 					Similarly, property shapes may have values for <code id="description">sh:description</code>
 					to provide descriptions of the property in the given context.
+					The <a>values</a> of <code>sh:description</code> must be <a>literals</a> with <a>datatype</a>
+					<code>xsd:string</code>, <code>rdf:dirLangString</code>, <code>rdf:langString</code>, or <code>rdf:HTML</code>.
+				</p>
+				<p>
 					Both <code>sh:name</code> and <code>sh:description</code> may have
 					multiple <a>values</a>, but should only have one <a>value</a> per language tag.
 				</p>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -150,7 +150,7 @@
 				While the Core part of SHACL defines the basic syntax of shapes and the most common constraint components
 				supported by SHACL, the SPARQL-related extensions cover features that extend the expressiveness of Core
 				by means of SPARQL.
-				In particular, this document defines how constraints and constraint components can be defined using SPARQL
+				In particular, this document defines how constraints and constraint components can be defined using SPARQL,
 				and SPARQL-based node expressions.
 			</p>
 		</section>
@@ -660,7 +660,7 @@ ex:
 				</p>
 				<p class="syntax">
 					<span data-syntax-rule="SPARQLConstraint-message-datatype"><a>SPARQL-based constraints</a> may have values for the property <code>sh:message</code>
-					and these are <a>literals</a> with <a>datatype</a> <code>xsd:string</code>, <code>rdf:dirLangString</code>, <code>rdf:langString</code> or <code>rdf:HTML</code>.</span>
+					and these are <a>literals</a> with <a>datatype</a> <code>xsd:string</code>, <code>rdf:dirLangString</code>, <code>rdf:langString</code>, or <code>rdf:HTML</code>.</span>
 					<span data-syntax-rule="SPARQLConstraint-deactivated-maxCount"><a>SPARQL-based constraints</a> may have at most one value for the property <code>sh:deactivated</code></span>
 					and this value is either <code>true</code> or <code>false</code>.
 				</p>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -147,12 +147,11 @@
 		<section id="abstract">
 			<p>
 				This document defines SPARQL-related extensions of the SHACL Shapes Constraint Language.
-				SHACL is a language for validating RDF graphs against a set of conditions.
-				These conditions are provided as shapes and other constructs expressed in the form of an RDF graph.
 				While the Core part of SHACL defines the basic syntax of shapes and the most common constraint components
 				supported by SHACL, the SPARQL-related extensions cover features that extend the expressiveness of Core
 				by means of SPARQL.
-				In particular, this document defines how constraints and constraint components can be defined using SPARQL.
+				In particular, this document defines how constraints and constraint components can be defined using SPARQL
+				and SPARQL-based node expressions.
 			</p>
 		</section>
 
@@ -660,7 +659,8 @@ ex:
 					The following two properties are similar to their use in <a>shapes</a>:
 				</p>
 				<p class="syntax">
-					<span data-syntax-rule="SPARQLConstraint-message-datatype"><a>SPARQL-based constraints</a> may have values for the property <code>sh:message</code> and these are either <code>xsd:string</code> literals or literals with a language tag.</span>
+					<span data-syntax-rule="SPARQLConstraint-message-datatype"><a>SPARQL-based constraints</a> may have values for the property <code>sh:message</code>
+					and these are <a>literals</a> with <a>datatype</a> <code>xsd:string</code>, <code>rdf:dirLangString</code>, <code>rdf:langString</code> or <code>rdf:HTML</code>.</span>
 					<span data-syntax-rule="SPARQLConstraint-deactivated-maxCount"><a>SPARQL-based constraints</a> may have at most one value for the property <code>sh:deactivated</code></span>
 					and this value is either <code>true</code> or <code>false</code>.
 				</p>

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -116,7 +116,7 @@ sh:targetWhere
 sh:message
 	a rdf:Property ;
 	# domain: sh:Shape or sh:SPARQLConstraint or sh:SPARQLSelectValidator or sh:SPARQLAskValidator
-	# range: xsd:string or rdf:langString
+	# range: xsd:string or rdf:dirLangString or rdf:langString or rdf:HTML
 	rdfs:label "message"@en ;
 	rdfs:comment "A human-readable message (possibly with placeholders for variables) explaining the cause of the result."@en ;
 	rdfs:isDefinedBy sh: .
@@ -299,7 +299,7 @@ sh:resultMessage
 	rdfs:label "result message"@en ;
 	rdfs:comment "Human-readable messages explaining the cause of the result."@en ;
 	rdfs:domain sh:AbstractResult ;
-	# range: xsd:string or rdf:langString
+	# range: xsd:string or rdf:dirLangString or rdf:langString or rdf:HTML
 	rdfs:isDefinedBy sh: .
 
 sh:resultPath
@@ -443,7 +443,7 @@ sh:labelTemplate
 	rdfs:label "label template"@en ;
 	rdfs:comment "Outlines how human-readable labels of instances of the associated Parameterizable shall be produced. The values can contain {?paramName} as placeholders for the actual values of the given parameter."@en ;
 	rdfs:domain sh:Parameterizable ;
-	# range: xsd:string or rdf:langString
+	# range: xsd:string or rdf:dirLangString or rdf:langString
 	rdfs:isDefinedBy sh: .
 
 sh:Parameter
@@ -1723,7 +1723,7 @@ sh:description
 	rdfs:label "description"@en ;
 	rdfs:comment "Human-readable descriptions for the property in the context of the surrounding shape."@en ;
 	rdfs:domain sh:PropertyShape ;
-	# range: xsd:string or rdf:langString
+	# range: xsd:string or rdf:dirLangString or rdf:langString or rdf:HTML
 	rdfs:isDefinedBy sh: .
 
 sh:group
@@ -1739,7 +1739,7 @@ sh:name
 	rdfs:label "name"@en ;
 	rdfs:comment "Human-readable labels for the property in the context of the surrounding shape."@en ;
 	rdfs:domain sh:PropertyShape ;
-	# range: xsd:string or rdf:langString
+	# range: xsd:string or rdf:dirLangString or rdf:langString
 	rdfs:isDefinedBy sh: .
 
 sh:order


### PR DESCRIPTION
Also allowing rdf:dirLangString where rdf:langString was allowed.

Also allowing rdf:HTML at sh:message and sh:description.

<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #723
Closes #724

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-723-724/shacl12-core/index.html)
