### PR TITLE
Issue 737: Added support for rdf:dirLangString to sh:uniqueLang

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5785,7 +5785,7 @@ ex:NameGroup
 				<li>Added annotation property <a href="#codeIdentifier"></a>; see <a href="https://github.com/w3c/data-shapes/issues/559">Issue 559</a></li>
 				<li>Added the target types <a href="#targetWhere"></a> and <a href="#explicit-shape-target"></a>, see <a href="https://github.com/w3c/data-shapes/issues/517">Issue 517</a></li>
 				<li>Added support for units and currencies <a href="#unit"></a>, see <a href="https://github.com/w3c/data-shapes/issues/709">Issue 709</a></li>
-				<li>Added support for rdf:dirLangString to <a href="#UniqueLangConstraintComponent"></a>, see <a href="https://github.com/w3c/data-shapes/issues/737">Issue 737</a></li>
+				<li>Added support for `rdf:dirLangString` to <a href="#UniqueLangConstraintComponent"></a>, see <a href="https://github.com/w3c/data-shapes/issues/737">Issue 737</a></li>
 			</ul>
 		</section>
   </body>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -3588,7 +3588,7 @@ ex:Mountain
 							there is a <a>validation result</a>.
 							For <a>value nodes</a> of <a>datatype</a> <code>rdf:dirLangString</code>,
 							the <a>base direction</a> is included in the uniqueness condition,
-							e.g. <code>"1"@ar--rtl</code>,  <code>"1"@ar-ltr</code> are different,
+							e.g., <code>"1"@ar--rtl</code> and <code>"1"@ar-ltr</code> are different,
 							as is the pair <code>"1"@ar--rtl</code> and <code>"1"@ar</code>.
 						</div>
 					</div>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -3589,7 +3589,7 @@ ex:Mountain
 							For <a>value nodes</a> of <a>datatype</a> <code>rdf:dirLangString</code>,
 							the <a>base direction</a> is included in the uniqueness condition,
 							e.g. <code>"1"@ar--rtl</code>,  <code>"1"@ar-ltr</code> are different,
-							as is the pair <code>"1"@ar--rtl</code>,  <code>"1"@ar</code>.
+							as is the pair <code>"1"@ar--rtl</code> and <code>"1"@ar</code>.
 						</div>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -3553,7 +3553,7 @@ ex:Mountain
 				<section id="UniqueLangConstraintComponent">
 					<h4>sh:uniqueLang</h4>
 					<p>
-						The property <code>sh:uniqueLang</code> can be set to <code>true</code> to specify that no pair of <a>value nodes</a> may use the same language tag and text direction.
+						The property <code>sh:uniqueLang</code> is set to <code>true</code> to specify that no pair of <a>value nodes</a> may use the same language tag, including considering the text direction, if present.
 					</p>
 					<p>
 						<span class="component-class">Constraint Component IRI</span>: <code>sh:UniqueLangConstraintComponent</code>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -3586,8 +3586,10 @@ ex:Mountain
 							If <code>$uniqueLang</code> is <code>true</code>
 							then for each non-empty language tag that is used by at least two <a>value nodes</a>,
 							there is a <a>validation result</a>.
-							For <a>value nodes</a> of <a>datatype</a> <code>rdf:dirLangString</code>, the <a>base direction</a>
-							is considered part of the language tag, e.g. <code>"1"@ar--ltr</code> counts as distinct from <code>"1"@ar--rtl</code>.
+							For <a>value nodes</a> of <a>datatype</a> <code>rdf:dirLangString</code>,
+							the <a>base direction</a> is included in the uniqueness condition,
+							e.g. <code>"1"@ar--rtl</code>,  <code>"1"@ar-ltr</code> are different,
+							as is the pair <code>"1"@ar--rtl</code>,  <code>"1"@ar</code>.
 						</div>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5783,6 +5783,7 @@ ex:NameGroup
 				<li>Added annotation property <a href="#codeIdentifier"></a>; see <a href="https://github.com/w3c/data-shapes/issues/559">Issue 559</a></li>
 				<li>Added the target types <a href="#targetWhere"></a> and <a href="#explicit-shape-target"></a>, see <a href="https://github.com/w3c/data-shapes/issues/517">Issue 517</a></li>
 				<li>Added support for units and currencies <a href="#unit"></a>, see <a href="https://github.com/w3c/data-shapes/issues/709">Issue 709</a></li>
+				<li>Added support rdf:dirLangString to <a href="#UniqueLangConstraintComponent"></a>, see <a href="https://github.com/w3c/data-shapes/issues/737">Issue 737</a></li>
 			</ul>
 		</section>
   </body>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -256,6 +256,7 @@
 						<dfn data-cite="rdf12-concepts#dfn-iri" data-lt="IRI|IRIs">IRI</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-rdf-literal" data-lt="literal|literals">literal</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-datatype" data-lt="datatype">datatype</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-base-direction" data-lt="base direction">base direction</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-blank-node" data-lt="blank node|blank nodes">blank node</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-triple-term" data-lt="triple term|triple terms">triple term</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-reifier" data-lt="reifier">reifier</dfn>,
@@ -3552,7 +3553,7 @@ ex:Mountain
 				<section id="UniqueLangConstraintComponent">
 					<h4>sh:uniqueLang</h4>
 					<p>
-						The property <code>sh:uniqueLang</code> can be set to <code>true</code> to specify that no pair of <a>value nodes</a> may use the same language tag.
+						The property <code>sh:uniqueLang</code> can be set to <code>true</code> to specify that no pair of <a>value nodes</a> may use the same language tag and text direction.
 					</p>
 					<p>
 						<span class="component-class">Constraint Component IRI</span>: <code>sh:UniqueLangConstraintComponent</code>
@@ -3585,6 +3586,8 @@ ex:Mountain
 							If <code>$uniqueLang</code> is <code>true</code>
 							then for each non-empty language tag that is used by at least two <a>value nodes</a>,
 							there is a <a>validation result</a>.
+							For <a>value nodes</a> of <a>datatype</a> <code>rdf:dirLangString</code>, the <a>base direction</a>
+							is considered part of the language tag, e.g. <code>"1"@ar--ltr</code> counts as distinct from <code>"1"@ar--rtl</code>.
 						</div>
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5783,7 +5783,7 @@ ex:NameGroup
 				<li>Added annotation property <a href="#codeIdentifier"></a>; see <a href="https://github.com/w3c/data-shapes/issues/559">Issue 559</a></li>
 				<li>Added the target types <a href="#targetWhere"></a> and <a href="#explicit-shape-target"></a>, see <a href="https://github.com/w3c/data-shapes/issues/517">Issue 517</a></li>
 				<li>Added support for units and currencies <a href="#unit"></a>, see <a href="https://github.com/w3c/data-shapes/issues/709">Issue 709</a></li>
-				<li>Added support rdf:dirLangString to <a href="#UniqueLangConstraintComponent"></a>, see <a href="https://github.com/w3c/data-shapes/issues/737">Issue 737</a></li>
+				<li>Added support for rdf:dirLangString to <a href="#UniqueLangConstraintComponent"></a>, see <a href="https://github.com/w3c/data-shapes/issues/737">Issue 737</a></li>
 			</ul>
 		</section>
   </body>

--- a/shacl12-test-suite/tests/core/property/manifest.ttl
+++ b/shacl12-test-suite/tests/core/property/manifest.ttl
@@ -52,5 +52,6 @@
 	mf:include <someValue-001.ttl> ;
 	mf:include <uniqueLang-001.ttl> ;
 	mf:include <uniqueLang-002.ttl> ;
+	mf:include <uniqueLang-003.ttl> ;
 	mf:include <uniqueMembers-001.ttl> ;
 	.

--- a/shacl12-test-suite/tests/core/property/uniqueLang-003.ttl
+++ b/shacl12-test-suite/tests/core/property/uniqueLang-003.ttl
@@ -17,6 +17,7 @@ ex:InvalidInstance
 ex:ValidInstance
   rdf:type ex:TestShape ;
   ex:testProperty "A" ;
+  ex:testProperty "A"@ar ;
   ex:testProperty "A"@ar--ltr ;
   ex:testProperty "A"@ar--rtl ;
 .

--- a/shacl12-test-suite/tests/core/property/uniqueLang-003.ttl
+++ b/shacl12-test-suite/tests/core/property/uniqueLang-003.ttl
@@ -1,0 +1,60 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance
+  rdf:type ex:TestShape ;
+  ex:testProperty "A" ;
+  ex:testProperty "A"@ar--ltr ;
+  ex:testProperty "B"@ar--ltr ;
+.
+ex:ValidInstance
+  rdf:type ex:TestShape ;
+  ex:testProperty "A" ;
+  ex:testProperty "A"@ar--ltr ;
+  ex:testProperty "A"@ar--rtl ;
+.
+ex:TestShape
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-testProperty ;
+.
+ex:TestShape-testProperty
+  sh:path ex:testProperty ;
+  rdfs:label "test property" ;
+  sh:uniqueLang "true"^^xsd:boolean ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <uniqueLang-003>
+    ) ;
+.
+<uniqueLang-003>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:uniqueLang with rdf:dirLangString values" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance ;
+          sh:resultPath ex:testProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:UniqueLangConstraintComponent ;
+          sh:sourceShape ex:TestShape-testProperty ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #737

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-737/shacl12-core/index.html#UniqueLangConstraintComponent)
