### PR TITLE
Revise SHACL 1.2 Profiling abstract

### DIFF
--- a/shacl12-profiling/index.html
+++ b/shacl12-profiling/index.html
@@ -163,20 +163,21 @@
 </head>
 <body>
 <section id="abstract">
+  <p>This document defines <em>SHACL Profiling</em>.</p>
   <p>
-    This specification defines elements of the SHACL Shapes Constraint Language created to allow for profiles of SHACL
-    and profiling with SHACL.
+    SHACL, the Shapes Constraint Language, is a language for describing the structure
+    of RDF graphs.
+    SHACL may be used for a variety of purposes such as validating, inferencing,
+    modeling domains, generating ontologies to inform other agents, building user
+    interfaces, generating code, and integrating data.
   </p>
   <p>
-    SHACL is a language for validating RDF graphs against a set of conditions, so this document's scope is limited to
-    profiling of RDF graphs, including graphs containing SHACL Shapes.
+    SHACL Profiling defines elements of the SHACL Shapes Constraint Language created to allow for profiles of SHACL
+    and profiling with SHACL. This document's scope is limited to    profiling of RDF graphs, including graphs
+    containing SHACL Shapes.
   </p>
-
-  <p style="text-indent: 100px;">
-    The namespace for SHACL Profiling terms is <code><a href="http://www.w3.org/ns/dcat#">http://www.w3.org/ns/shpr#</a></code>
-  </p>
-  <p style="text-indent: 100px;">
-    The suggested prefix for the SHACL Profiling namespace is <code>shpr</code>
+    This specification is published by the
+    <a href="https://www.w3.org/groups/wg/data-shapes/">Data Shapes Working Group</a>.
   </p>
 </section>
 
@@ -419,6 +420,10 @@
         <td><code>http://www.w3.org/ns/shacl#</code></td>
       </tr>
       <tr>
+        <td><code>shpr:</code></td>
+        <td><code>http://www.w3.org/ns/shpr#</code></td>
+      </tr>
+      <tr>
         <td><code>ex:</code></td>
         <td><code>http://example.com/ns#</code></td>
       </tr>
@@ -432,6 +437,7 @@
     "owl": "http://www.w3.org/2002/07/owl#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "sh": "http://www.w3.org/ns/shacl#",
+    "shpr": "http://www.w3.org/ns/shpr#",
     "ex": "http://example.com/ns#"
   }
 }</pre>


### PR DESCRIPTION
This PR takes text from the revised SHACL 1.2 Rules abstract and adds the defined prefix to Section [1.4, Document Conventions](https://raw.githack.com/w3c/data-shapes/issue-747-abstract-shacl-profiling/shacl12-profiling/index.html#conventions).

[See the revised abstract online here](https://raw.githack.com/w3c/data-shapes/issue-747-abstract-shacl-profiling/shacl12-profiling/index.html#abstract)