### PR TITLE
Definitions for dependency and stratification

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -13,13 +13,13 @@
         group: "wg/data-shapes",
         github: "w3c/data-shapes",
         //preProcess:     [  ],
-        //@@
         edDraftURI: "https://w3c.github.io/data-shapes/shacl12-rules/",
         shortName: "shacl12-rules",
         copyrightStart: "2025",
         // Can remove SHACL12-*?
         xref: ["RDF12-CONCEPTS", "SPARQL12-QUERY", "SHACL12-CORE", "SHACL12-SPARQL", "SHACL12-NODE-EXPR" ] ,
         lint: { "no-unused-dfns": false },
+        maxTocLevel: 2,
 
         editors: [
           {
@@ -58,8 +58,6 @@
         //previousMaturity: "REC",
         //prevRecShortname: "shacl",
         //prevRecURI: "https://www.w3.org/TR/2017/REC-shacl-20170720/",
-
-
         localBiblio: {
           "shacl12-shacl-shacl": {
             title: "SHACL 1.2 SHACL-SHACL",
@@ -67,12 +65,12 @@
             status: "ED",
             publisher: "W3C",
           }
-        }
+        },
         // Remove in final version
-        , lint: {
+        lint: {
           "informative-dfn": false,
           "no-unused-dfns": false
-        }
+        },
       };
     </script>
     <link rel="stylesheet" href="style.css"/>
@@ -317,19 +315,21 @@ RULE { ?x :name ?FN } WHERE {
     </section>
 
     <section id="rules-abstract-syntax">
-        <!-- Export -->
-        <h2>Shape Rules Abstract Syntax</h2>
+      <h2>Shape Rules Abstract Syntax</h2>
 
-        <p>The Shape Rules Abstract Syntax</p>
+      <p>The Shape Rules Abstract Syntax</p>
 
+      <section id="rules-defns">
+        <h3>Elements of the Abstract Syntax</h3>
         <dl>
-          <dt><dfn data-cite="sparql12-query#defn_QueryVariable">variable</dfn></dt>
+
+          <dt><dfn data-cite="sparql12-query#defn_QueryVariable">Variable</dfn></dt>
           <dd>
             A [=variable=] represents a possible [=RDF term=] in a triple pattern.
             Variables are also used in <a>expressions</a>.
           </dd>
 
-          <dt><dfn>expression</dfn></dt>
+          <dt><dfn>Expression</dfn></dt>
           <dd>
             <p>
               An [=expression=] is a function, or functional form.
@@ -342,13 +342,13 @@ RULE { ?x :name ?FN } WHERE {
               and with <a data-cite="sparql12-query#expressions">SPARQL expressions</a>.</p>
           </dd>
 
-          <dt><dfn data-lt="data-block">data block</dfn></dt>
+          <dt><dfn data-lt="data-block">Data block</dfn></dt>
           <dd>
             A [=data block=] is a set of triples.
             These form extra facts that are included in the inference process.
           </dd>
 
-          <dt><dfn>triple template</dfn></dt>
+          <dt><dfn>Triple template</dfn></dt>
           <dd>
             A [=triple template=] is 3-tuple where each element is either
             a [=variable=] or an [=RDF term=] (which might be a [=triple term=]).
@@ -356,28 +356,36 @@ RULE { ?x :name ?FN } WHERE {
             [=Triple templates=] appear in the [=head=] of a [=rule=].
           </dd>
 
-          <dt><dfn>triple pattern</dfn></dt>
+          <dt><dfn>Triple pattern</dfn></dt>
           <dd>
             A [=triple pattern=] is 3-tuple where each element is either a
-            [=variable=], or an [=RDF term=] (which might be a triple term).
-            The second element of the tuple must be an [=IRI=].
-            [=Triple patterns=] appear in the [=body=] of a [=rule=].
+            [=variable=] or an [=RDF term=] (which might be a triple term).
+            The second element of the tuple must be an [=IRI=] or a [=variable=].
+            [=Triple patterns=] can appear as [=triple pattern elements=]
+            as well as inside [=negation elements=].
           </dd>
 
-          <dt><dfn>condition expression</dfn></dt>
+          <dt><dfn>Condition expression</dfn></dt>
           <dd>
             A [=condition expression=] is a function, or functional form,
             that evaluates to true or false.
             [=Condition expressions=] appear in the [=body=] of a [=rule=].
           </dd>
 
-          <dt><dfn>negation element</dfn></dt>
+          <dt><dfn>Triple pattern element</dfn></dt>
           <dd>
-            A [=negation element=] is ..@@.. .
-            [=Negation elements=] appear in the [=body=] of a [=rule=].
+            A [=triple pattern element=] is a [=triple pattern=]
+            used as a [=rule body element=].
           </dd>
 
-          <dt><dfn>assignment</dfn></dt>
+          <dt><dfn>Negation element</dfn></dt>
+          <dd>
+            A [=negation element=] is a [=rule body element=].
+            It takes a sequence of [=triple patterns=] and
+            [=condition expressions=].
+          </dd>
+
+          <dt><dfn>Assignment</dfn></dt>
           <dd>
             An [=assignment=] is a pair of a <a>variable</a>, called the
             <dfn>assignment variable</dfn>, and an <a>expression</a>, called the
@@ -385,61 +393,63 @@ RULE { ?x :name ?FN } WHERE {
             [=Assignments=] appear in the [=body=] of a [=rule=].
           </dd>
 
+          <!-- Pending
           <dt><dfn>aggregation element</dfn></dt>
           <dd>
             An [=aggregation element=] is ..@@.. .
              [=Aggregation elements=] appear in the [=body=] of a [=rule=].
           </dd>
+          -->
 
-          <dt><dfn data-lt="rule body element|rule element|element">rule body element</dfn></dt>
+          <dt><dfn 
+                data-lt="rule body element|rule element"
+                >Rule body element</dfn></dt>
           <dd>
             A [=rule body element=] (often just "rule element") is any element that
-            can appear in a [=rule body=];
+            can appear in a [=rule body=],
             a [=triple pattern=],
             a [=condition expression=],
             a [=negation element=],
-            an [=assignment=],
+            or an [=assignment=].
+            <!-- Pending
             or an [=aggregation element=].
+            -->
           </dd>
 
-          <dt><dfn data-lt="rule head|head">rule head</dfn></dt>
+          <dt><dfn data-lt="rule head|head">Rule head</dfn></dt>
           <dd>
-            A [=rule head=] is a sequence where each element
-            of the sequence is a [=triple template=].
+            A [=rule head=] is a sequence of [=triple templates=].
           </dd>
 
-          <dt>
-            <dfn data-lt="rule body|body">rule body</dfn>
-          </dt>
+          <dt><dfn data-lt="rule body|body">Rule body</dfn></dt>
           <dd> 
             A [=rule body=] is a sequence of [=rule body elements=].
           </dd>
 
-          <dt><dfn>rule</dfn></dt>
+          <dt><dfn>Rule</dfn></dt>
           <dd>
             A [=rule=] is a pair of a [=rule head=] (often just "head") and
             a [=rule body=] (often just "body").
           </dd>
 
-          <dt><dfn>rule set</dfn></dt>
+          <dt><dfn>Rule set</dfn></dt>
           <dd>
             A [=rule set=] is a collection of zero or more [=rules=]
             and a collection of zero or more [=data blocks=].
           </dd>
 
-          <dt><dfn>base graph</dfn></dt>
+          <dt><dfn>Base graph</dfn></dt>
           <dd>
             The [=base graph=] is the [=RDF Graph=] given as input to the evaluation
             process.
           </dd>
 
-          <dt><dfn>inference graph</dfn></dt>
+          <dt><dfn>Inference graph</dfn></dt>
           <dd>
             The [=inference graph=] is an [=RDF Graph=] that is the outcome of rule set evaluation.
             It contains all triples not found in the [=base graph=] that are inferred from
             evaluation of the [=rule set=] on the [=base graph=].
           </dd>
-
         </dl>
 
         <p>
@@ -449,108 +459,241 @@ RULE { ?x :name ?FN } WHERE {
           position 3 is informally called the <em>object</em>.
         </p>
 
-        <section id="stratification">
-          <h3>Stratification</h3>
-          <p>
-            Stratification is the process of labelling <a>rules</a> based on their
-            <a>dependency</a> relationships in a <a>rule set</a>.
-            The set of rules with the same label are called a <a>layer</a>.
-          </p>
-          
-          <dl>
-            <dt><dfn data-lt="stratification layer|layer">stratification layer</dfn></dt>
-            <dd>
-              A stratification layer, usually, just "layer", is the set of rules 
-              with same stratification labelling.
-              <a>stratification layer</a>, <a>layer</a>
-            </dd>
+      </section>
 
-            <dt><dfn data-lt="rule element dependency|element dependency">rule element dependency</dfn></dt>
+      <section id="wellformed">
+        <h3>Well-formedness Conditions</h3>
+        <p>
+          Well-formedness is a set of conditions on the abstract syntax of
+          SHACL rules. Together, these conditions ensure that a [=variable=] in the
+          [=head=] of a rule has a value defined in the [=body=] of the rule;
+          that each variable in an [=condition expression=]
+          or [=assignment expression=]
+          has a value at the point of evaluation; and that each
+          assignment in a rule introduces a new variable,
+          one that has not been used earlier in the rule body.
+        </p>
+        <p>
+          A [=rule=] is a <dfn>well-formed rule</dfn> if all of the following
+          conditions are met:
+        </p>
+        <ul>
+          <li>For every [=variable=] appearing in a [=triple template=]
+            of the [=head=] of the [=rule=],
+            there is one or more occurrences of a [=variable=]
+            of the same name in the [=triple patterns=] in the [=body=],
+            in an [=assignment=] in the body, or both.
+          </li>
+          <li>
+            For every [=variable=] in an [=expression=] at position <em>i</em>
+            of the [=body=], there is a corresponding [=variable=] of the same
+            name occurring in a [=triple pattern=] at a position <em>j</em>,
+            or occurring as an [=assignment variable=] at a position <em>j</em>,
+            where <em>i &gt; j</em>.
+          </li>
+          <li>
+            Each [=assignment variable=] is used in only one [=assignment=] in
+            the [=body=] of the [=rule=].
+          </li>
+          <li>
+            An [=assignment variable=] at position <em>i</em> of a [=rule body=] does not
+            occur in any [=triple pattern=] at position <em>j</em> where <em>i &gt; j</em>.
+          </li>
+          <li>
+            For every [=variable=] in an [=assignment expression=] at position <em>i</em>,
+            there is a corresponding variable in a [=triple pattern=] at position
+            <em>j</em> where <em>i &gt; j</em>,
+            or there is an [=assignment variable=] in an [=assignment=] at position
+            <em>j</em> where <em>i &gt; j</em>.
+          </li>
+        </ul>
+        <p>
+          A [=rule set=] is "well-formed" if and only if all of the [=rules=] of the
+          rule set are "well-formed".
+        </p>
+      </section>
+
+      <section id="rule-dependency">
+        <h3>Rule Dependency</h3>
+
+        <dl>
+          <dt><dfn>Triple pattern dependency</dfn></dt>
+          <dd>
+            A [=triple pattern=] in the rule body of rule `R1` depends on a
+            rule `R2` if the head of `R2` can possibly generate triples that
+            match the [=triple pattern=] in `R1`.
+            The dependency is <em>positive</em> 
+            if the [=triple pattern=] is a [=rule body element=]
+            and the dependency is <em>negative</em> if the
+            [=triple pattern=] appears in a [=negation element=].
+          </dd>
+
+          <dt><dfn>Rule dependency</dfn></dt>
+          <dd>
+            A rule `R1` depends on rule `R2` if any rule element of `R1`
+            depends on `R2`.
+            The dependency is <em>negative</em> if any of the rule elements
+            have a negative dependency on `R2`; otherwise the dependency is
+            <em>positive</em>.
+          </dd>
+
+          <dt><dfn>Dependency graph</dfn></dt>
+          <dd>
+            A [=dependency graph=] of a [=rule set=] is a graph where the
+            vertices are rules and an edge exists where one rule R1 depends on
+            rule R2. An edge is labeled either <em>positive</em> 
+            or <em>negative</em> according to the [=rule dependency=].
+          </dd>
+
+          <dt><dfn
+                data-lt="transitive rule dependency|transitive dependency"
+                >Transitive rule dependency</dfn></dt>
+          <dd>
+            A rule `R1` has a [=transitive dependency=] on rule `R2` 
+            if there is a path in the [=dependency graph=] from `R1` to `R2`.
+          </dd>
+
+          <dt><dfn
+                data-lt="recursive rule dependency|recursive dependency"
+                >Recursive rule dependency</dfn></dt>
+          <dd>
+            A rule `R` has a [=recursive dependency=] if there is a cyclic path
+            in the [=dependency graph=] involving `R`.
+          </dd>
+        </dl>
+          
+        
+        <p>Notes:</p>
+        <ul>
+          <li>
+            <p>
+              A [=triple template=] with components `ts`, `tp`, `to`
+              can possibly generate a triple with component RDF terms
+              `s`, `p`, `o` if 
+              `ts` is a variable or `ts` is the
+              <a data-cite="RDF12-CONCEPTS#dfn-rdf-term-equality"
+                 >same RDF term</a> as `s`,
+              `tp` is a variable or `tp` is the
+              <a data-cite="RDF12-CONCEPTS#dfn-rdf-term-equality"
+                 >same RDF term</a> as `p`,
+              and
+              `to` is a variable or `to` is the
+              <a data-cite="RDF12-CONCEPTS#dfn-rdf-term-equality"
+                 >same RDF term</a> as `o`.
+            </p>
+            <p>
+              In addition, if any pair of `ts`, `tp`, and `to` are the same variable,
+              then the corresponding pair of `s`, `p`, and `o` must be the same.
+            </p>
+            <p class="ednote">
+              Revise
+            </p>
+          <li>
+            The dependency graph is not affected by the data graph.
+          </li>
+        </ul>
+
+        <p>
+          Examples:
+        </p>
+        <div class="rules">
+          <pre>
+            @@ Examples of triple patttern dependencies.
+          </pre>
+        </div>
+        <div class="rules">
+          <pre>
+            @@ Examples of rule dependencies.
+          </pre>
+        </div>
+      </section>
+      
+      <section id="stratification">
+        <h3>Stratification</h3>
+        <p>
+          [=Stratification=] is the process of partitioning a [=rule set=]
+          into an ordered sequence of [=stratification layers=] (also known
+          as "strata", singular "stratum="), forming a [=stratification=].
+          Rules in lower [=strata=] are evaluated before rules in higher
+          [=strata=].
+        </p>
+        <p>
+          [=Stratification=] imposes constraints on dependencies between [=rules=]
+          to ensure that [=negation elements=] depend only on results computed
+          in earlier [=strata=], guaranteeing a single, well-defined outcome
+          from the evaluation of a [=rule set=] over a given [=base graph=].
+        </p>
+        <div class="ednote">
+          <p>
+            A stratification process may also be used to make other evaluation
+            decisions. This document describes the necessary conditions for
+            consistent evaluation and gives one possible way to form a
+            stratification. Implementations need to meet the conditions
+            described here in order to get compatible behavior but are not
+            required to implement the algorithm as presented.
+          </p>
+        </div>
+
+        <dl>
+          <dt><dfn>Stratification</dfn></dt>
+          <dd>
+            A [=stratification=] of a [=rule set=] is a sequence of sets of
+            rules. Each rule in a [=rule set=] appears in exactly one [=stratification layer=].
+          </dd>
+          <dt><dfn 
+                data-lt="stratification layer|layer|stratum"
+                >Stratification layer</dfn></dt>
+          <dd>
+            Each set of rules in a [=stratification=] is called a 
+            [=stratification layer=], also called a "stratum".
+          </dd>
+        </dl>
+
+        <section id="stratification-condition">
+          <h4>Stratification Condition</h4>
+          <p>
+            [=Stratification=] is only defined when the following condition is
+            satisfied. If a [=rule set=] does not meet this condition, then this
+            specification does not define the outcome of [=rule set=] evaluation.
+          </p>
+          <dl>
+            <dt><dfn>Stratification Condition</dfn></dt>
             <dd>
-              A [=rule body element=] `E` depends on a rule `R` if the head of rule `R`
-              contains a [=triple template=] that may provide a triple that is matched by
-              a triple pattern in `E`.
-            </dd>
-              
-            <dt><dfn data-lt="rule dependency|dependency">rule dependency</dfn></dt>
-            <dd>
-              A rule `R1` depends on rule `R2` if any rule element of `R1` depends on `R2`.
-              <br/>@@formalize
+              The [=stratification Condition=] requires that
+              there is no [=recursive dependency=] involving a
+              <em>negative</em> dependency
+              in the [=dependency graph=] for a [=rule set=].
             </dd>
           </dl>
-          
-          <p>Process</p>
-          <ul>
-            <li>Layer 0 = base graph</li>
-            <li>For each rule, determine the label of all rule elements if possible yet.</li>
-            <li>Label of a rule is the max label of its [=rule body elements=]</li>
-            <li>repeat</li>
-          </ul>
-          
-          <p>Conditions</p>
-          <ul>
-            <li>For a rule, all its (rule elements) negation/aggregation dependencies must 
-              have a label that is less than the layer label of this rule.
-            </li> 
-          </ul>
+          <p>
+            In other words, there is no `NOT` used in any rule that
+            transitively depends on itself.
+          </p>
         </section>
 
-        <section id="wellformed">
-          <h3>Well-formedness Conditions</h3>
+        <section id="stratification-algorithm">
+          <h4>Stratification Algorithm</h4>
           <p>
-            Well-formedness is a set of conditions on the abstract syntax of
-            shapes rules.  Together, these rules ensure that a [=variable=] in the
-            [=head=] of a rule has a value defined in the [=body=] of the rule;
-            that each variable in an condition expression or assignment
-            expression has a value at the point of evaluation; and that each
-            assignment in a rule introduces a new variable,
-            not used earlier in the rule body.
+            The following algorithm gives one possible stratification based solely
+            on the rule set.
           </p>
-          <div class=ednote>
-            <p>
-              Add a rule for nested patterns e.g. negation.
-            </p>
+          <div class="algorithm">
+            <pre>
+              @@ one possible stratification algorithm
+            </pre>
           </div>
 
           <p>
-            A [=rule=] is a <dfn>well-formed rule</dfn> if all of the following
-            conditions are met:
+            A consequence of the [=stratification condition=] is that when 
+            a rule containing a [=negation element=] is
+            <a href="#eval-rule">evaluated</a>, the data used to determine the
+            outcome of that [=negation element=], whether in the
+            [=base graph=] or the [=inference graph=], is fixed and will not
+            change during evaluation.
           </p>
-          <ul>
-            <li>For every [=variable=] appearing in a [=triple template=]
-              of the [=head=] of the [=rule=],
-              there is one or more occurrences of a [=variable=]
-              of the same name in the [=triple patterns=] in the [=body=],
-              or in an [=assignment=] in the body, or both.
-            </li>
-            <li>
-              For every [=variable=] in an [=expression=] at position <em>i</em>
-              of the [=body=], there is a corresponding [=variable=] of the same
-              name occurring in a [=triple pattern=] at a position <em>j</em>,
-              or occurring as an [=assignment variable=] at a position <em>j</em>,
-              where <em>i &gt; j</em>.
-            </li>
-            <li>
-              Each [=assignment variable=] is used in only one [=assignment=] in
-              the [=body=] of the [=rule=].
-            </li>
-            <li>
-              An [=assignment variable=] at position <em>i</em> of a [=rule body=] does not
-              occur in any [=triple pattern=] at position <em>j</em> where <em>i &gt; j</em>.
-            </li>
-            <li>
-              For every [=variable=] in an [=assignment expression=] at position <em>i</em>,
-              there is a corresponding variable in a triple pattern at position
-              <em>j</em> where <em>i &gt; j</em>,
-              or there is an [=assignment variable=] in an [=assignment=] at position
-              <em>j</em> where <em>i &gt; j</em>.
-            </li>
-          </ul>
-          <p>
-            A [=rule set=] is "well-formed" if and only if all of the [=rules=] of the
-            rule set are "well-formed".
-          </p>
+
         </section>
+      </section>
     </section>
 
     <section id="concrete-syntax">
@@ -715,14 +858,19 @@ Output: an RDF graph GI of inferred triples
       <h4>Evaluation Definitions</h4>
 
         <dl>
-          <dt><dfn data-lt="solution|sparql12-query#defn_sparqlSolutionMapping">solution mapping</dfn></dt>
+          <dt><dfn 
+                data-lt="solution|sparql12-query#defn_sparqlSolutionMapping"
+                >solution mapping</dfn></dt>
           <dd> 
             A <a data-lt="sparql12-query#defn_sparqlSolutionMapping">solution mapping</a>, 
-            <var>μ</var>, is a partial function <code><var>μ</var> : <var>V</var> → <var>T</var></code>, 
-            where <var>V</var> is the set of all variables and <var>T</var> is the set of all RDF terms.
-            The domain of <var>μ</var> is denoted by <code><var>dom</var>(<var>μ</var>)</code>,
-            and it is the subset of <var>V</var> for which <var>μ</var> is defined.
-            We use the term [=solution=] where it is clear that a [=solution mapping=] is meant.
+            <var>μ</var>, is a partial function 
+            <code><var>μ</var> : <var>V</var> → <var>T</var></code>,
+            where <var>V</var> is the set of all variables 
+            and <var>T</var> is the set of all [=RDF terms=].
+            The domain of <var>μ</var> is denoted
+            by <code><var>dom</var>(<var>μ</var>)</code>, and it is the subset
+            of <var>V</var> for which <var>μ</var> is defined. We use the term
+            [=solution=] where it is clear that a [=solution mapping=] is meant.
             Write <var>μ<sub>0</sub></var> for the solution mapping such that
             <code><var>dom</var>(<var>μ<sub>0</sub></var>)</code> is the empty set.
           </dd>
@@ -730,10 +878,13 @@ Output: an RDF graph GI of inferred triples
           <dt><dfn data-lt="substitution">substitution function</dfn></dt>
           <dd>
             A <a>substitution function</a>, or just <i>substitution</i>,
-            is a function <code>subst(<var>μ</var>, [=triple pattern=])</code> that returns a triple pattern
-            where each occurrence in the triple pattern of a variable that is in the 
+            is a function 
+            <code>subst(<var>μ</var>, [=triple pattern=])</code>
+            that returns a [=triple pattern=]
+            where each occurrence in the [=triple pattern=] of a variable that is in the 
             <code><var>dom</var>(<var>μ</var>)</code>
-            is replaced by the [=RDF term=] given by the [=solution mapping=] for <var>var</var>.
+            is replaced by the [=RDF term=] given by the 
+            [=solution mapping=] for <var>var</var>.
             If the triple pattern result has no variables, then it is an [=RDF Triple=].
           </dd>
           
@@ -824,8 +975,8 @@ merge(S1, S2) = { <var>μ</var> |
         <p class=ednote>Sketch</p>
 
 <pre class="algorithm">
-@@ Reference SPARQL expression evaluation <a data-cite="SPARQL12-QUERY/#expression-evaluation">EXPR</a>
-@@ Reference SPARQL EBV <a data-cite="SPARQL12-QUERY/#expression-evaluation">EXPR</a>
+@@ Reference SPARQL expression evaluation <a data-cite="SPARQL12-QUERY/#expression-evaluation">Expression Evaluation</a>
+@@ Reference SPARQL EBV <a data-cite="SPARQL12-QUERY/#ebv">Effective Boolean Value (EBV)</a>
 
 define evalFunction(F, <var>μ</var>):
     Let [x/<var>μ</var>] be
@@ -839,12 +990,6 @@ define evalFunction(F, <var>μ</var>):
 
       <section id="eval-rule">
         <h4>Evaluation of a Rule</h4>
-
-        <div class=ednote>
-          <p>Sketch</p>
-          <p>Turn into definitions of the step components</p>
-        </div>
-
 
 <pre class="algorithm">
 let R be a well-formed rule.
@@ -880,7 +1025,7 @@ define evalRuleElements(B, SEQ, G):
         if rElt is a condition expression with expression F:
             SEQ1 = {}
             for each solution <var>μ</var> in SEQ:
-                if evalFunction(F, <var>μ</var>) is <var>true<var>:
+                if evalFunction(F, <var>μ</var>) is <var>true</var>:
                     add <var>μ</var> to SEQ1
                     endif
                 endfor
@@ -1967,7 +2112,7 @@ the result is GI
           <dt>Optional parameters:</dt>
           <dd>@@version, @@profile</dd>
           <dt>Encoding considerations:</dt>
-          <dd>The syntax of the @@@ Language is expressed over code points in Unicode
+          <dd>The syntax of the SHACL Rules Language is expressed over code points in Unicode
             [[UNICODE]]. The encoding is always UTF-8 [[RFC3629]].</dd>
           <dd>Unicode code points may also be expressed using an \uXXXX (U+0 to U+FFFF) or
             \UXXXXXXXX syntax (for U+10000 onwards) where X is a hexadecimal digit [0-9A-F]</dd>


### PR DESCRIPTION
Closes #674
Closes #687 - this is a general issue. Further work has been recorded in #767.

This PR puts in sub-sections for dependency and stratification into the abstract syntax section.
The earlier general definitions have some indentation and formatting fixes.

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/afs/dependency-stratification/shacl12-rules/index.html)
