### PR TITLE
Misc editorial clean-up, esp of TODOs

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5810,16 +5810,6 @@ ex:NameGroup
 			</p>
 		</section>
 
-		<section class="appendix informative">
-		  <h2>Revision History</h2>
-			<p>
-				The detailed list of changes and their diffs can be found in the <a href="https://github.com/w3c/data-shapes">Git repository</a>.
-			</p>
-			<ul>
-				<li><b>2024-02-14</b>: New work started by cloning the main SHACL spec and splitting it into SHACL Core and SHACL-SPARQL</li>
-			</ul>
-		</section>
-
 		<section class="appendix informative" id="changes-12">
 			<h2>Changes between the original SHACL Core and SHACL 1.2 Core</h2>
 			<ul>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -586,7 +586,17 @@
 				</p>
 			</section>
 			<section id="conformance">
-				<p>TODO</p>
+				<p>
+					This document defines the <strong>SHACL Node Expressions</strong> language that extends SHACL Core.
+					This specification describes conformance criteria for:
+				</p>
+				<ul>
+					<li><strong>SHACL Node Expressions processors</strong> as processors that support the evaluation of SHACL Node Expressions,
+					in particular as part of SHACL validation</li>
+				</ul>
+				<p>
+					See also the definitions of well-formedness in the <a data-cite="shacl12-core#conformance">SHACL Core Conformance section</a>.
+				</p>
 			</section>
 		</section>
 
@@ -3780,23 +3790,19 @@ ex:Address-state
 		</section>
 
 		<section id="security">
-			<h2>Security Considerations</h2>
-			<p>TODO</p>
-		</section>
-
-		<section id="privacy">
-			<h2>Privacy Considerations</h2>
-			<p>TODO</p>
+			<h2>Security and Privacy Considerations</h2>
+			<p>
+				Security considerations of SHACL Node Expressions include all the
+				security considerations of
+				<a data-cite="shacl12-core/#security">SHACL Core</a>.
+			</p>
 		</section>
 
 		<section id="ack" class="appendix informative">
 			<h2>Acknowledgements</h2>
-			<p>Many people contributed to this document, including members of the RDF Data Shapes Working Group.</p>
-		</section>
-
-		<section id="internationalization">
-			<h2>Internationalization Considerations</h2>
-			<p>TODO</p>
+			<p>
+				Many people contributed to this document, including members of the RDF Data Shapes Working Group.
+			</p>
 		</section>
 
 		<section id="index">

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -399,12 +399,7 @@
 					<li><strong>SHACL-SPARQL processors</strong> as processors that support validation with the SHACL-SPARQL Language</li>
 				</ul>
 				<p>
-					This document includes syntactic rules that shapes and other nodes need to fulfill in the <a>shapes graph</a>.
-					These rules are typically of the form <em>A shape must have...</em> or <em>The values of X are literals</em> or <em>All objects of triples with predicate P must be IRIs</em>.
-					The complete list of these rules can be found in the <a href="#syntax-rules">appendix</a>.
-					Nodes that violate any of these rules are called <dfn>ill-formed</dfn>.
-					Nodes that violate none of these rules are called <dfn>well-formed</dfn>.
-					A <a>shapes graph</a> is ill-formed if it contains at least one ill-formed node.
+					See also the definitions of well-formedness in the <a data-cite="shacl12-core#conformance">SHACL Core Conformance section</a>.
 				</p>
 			</section>
 
@@ -1797,7 +1792,6 @@ ex:Resource-uriLength
 			</p>
 			<p>
 				SPARQL variables using the <code>$</code> marker represent external <a>bindings</a> that are <a>pre-bound</a> or, in the case of <code>$PATH</code>, <a>substituted</a> in the SPARQL query before execution (as explained in <a href="#constraint-components-validation"></a>).
-				<span class="todo">TODO: Assuming SHACL Core 1.2 allows node expressions as constraint parameters, explain that they are evaluated prior to substitution.</span>
 			</p>
 			<section id="sparql-definition-targetClass">
 				<h3>sh:targetClass</h3>
@@ -2013,16 +2007,6 @@ WHERE {
 				See the <a href="https://www.w3.org/TR/2017/REC-shacl-20170720/#ack">Core specification's Acknowledgements section</a> and
         the <a href="https://www.w3.org/TR/2017/NOTE-shacl-af-20170608/#ack">Advanced Features specification's Acknowledgements section</a>.
 			</p>
-		</section>
-
-		<section class="appendix informative">
-			<h2>Revision History</h2>
-			  <p>
-				  The detailed list of changes and their diffs can be found in the Git repository.
-			  </p>
-			  <ul>
-				  <li><b>2024-02-14</b>: New work started by cloning the main SHACL spec and splitting it into SHACL Core and SHACL-SPARQL</li>
-			  </ul>
 		</section>
 
 		<section class="appendix informative" id="changes-12">


### PR DESCRIPTION
- For Core and SPARQL: Removed Revision History which is redundant (links to the change history are auto-generated in the header section)
- For SPARQL and NodeExpr: Merged Privacy considerations into Security section, as done in Core
- For NodeExpr: Added Conformance section, put something into the Security section
