### PR TITLE
Added infer() and query() among the definitions

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -427,7 +427,7 @@ RULE { ?x :name ?FN } WHERE {
             and a collection of zero or more [=data blocks=].
           </dd>
 
-          <dt><dfn>infer()</dfn></dt>
+          <dt><dfn>infer</dfn></dt>
           <dd>
             [=infer()=] is the operation that applies the rules to a given [=base graph=] and produces a new [=inference graph=] containing the RDF
             triples derived from rule execution.

--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -441,7 +441,8 @@ RULE { ?x :name ?FN } WHERE {
           
           <dt><dfn>base graph</dfn></dt>
           <dd>
-            The [=base graph=] is the [=RDF Graph=] provided as input to the evaluation process, and it is used by both the [=infer()=] and [=query()=] operations.
+            The [=base graph=] is the [=RDF Graph=] provided as input to the evaluation process,
+            and it is used by both the [=infer()=] and [=query()=] operations.
           </dd>
           
           <dt><dfn>inference graph</dfn></dt>

--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -427,17 +427,26 @@ RULE { ?x :name ?FN } WHERE {
             and a collection of zero or more [=data blocks=].
           </dd>
 
-          <dt><dfn>base graph</dfn></dt>
+          <dt><dfn>infer()</dfn></dt>
           <dd>
-            The [=base graph=] is the [=RDF Graph=] given as input to the evaluation
-            process.
+            [=infer()=] is the operation that applies the rules to a given [=base graph=] and produces a new [=inference graph=] containing the RDF
+            triples derived from rule execution.
           </dd>
 
+          <dt><dfn>query()</dfn></dt>
+          <dd>
+            [=query()=] is the operation that determines whether a given goal pattern can be derived from a [=base graph=] using the rules.
+          </dd>
+          
+          <dt><dfn>base graph</dfn></dt>
+          <dd>
+            The [=base graph=] is the [=RDF Graph=] provided as input to the evaluation process, and it is used by both the [=infer()=] and [=query()=] operations.
+          </dd>
+          
           <dt><dfn>inference graph</dfn></dt>
           <dd>
-            The [=inference graph=] is an [=RDF Graph=] that is the outcome of rule set evaluation.
-            It contains all triples not found in the [=base graph=] that are inferred from
-            evaluation of the [=rule set=] on the [=base graph=].
+            The [=inference graph=] is an [=RDF Graph=] produced by evaluating a [=rule set=]. It contains all triples not present in the [=base graph=] that are inferred
+            from applying the [=rule set=] to the [=base graph=].
           </dd>
 
         </dl>
@@ -949,7 +958,7 @@ Apply stratification to RS
 let L be the sequence of layers after stratification
 
 # Inference graph
-let GI = { t &isin;D  | t &notin; in G0 }
+let GI = { t &isin; D  | t &notin; in G0 }
 
 # Evaluation graph.
 let GE = G0 &cups; D

--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -436,7 +436,7 @@ RULE { ?x :name ?FN } WHERE {
 
           <dt><dfn>query</dfn></dt>
           <dd>
-            [=query()=] is the operation that determines whether a given goal pattern can be derived from a [=base graph=] using the rules.
+            [=query=] is the operation that determines whether a given goal pattern can be derived from a [=base graph=] using the rules.
           </dd>
           
           <dt><dfn>base graph</dfn></dt>

--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -429,7 +429,8 @@ RULE { ?x :name ?FN } WHERE {
 
           <dt><dfn>infer</dfn></dt>
           <dd>
-            [=infer()=] is the operation that applies the rules to a given [=base graph=] and produces a new [=inference graph=] containing the RDF
+            [=infer=] is the operation that applies the rules to a given [=base graph=] and produces an
+            [=inference graph=] containing inferred triples.
             triples derived from rule execution.
           </dd>
 

--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -434,7 +434,7 @@ RULE { ?x :name ?FN } WHERE {
             triples derived from rule execution.
           </dd>
 
-          <dt><dfn>query()</dfn></dt>
+          <dt><dfn>query</dfn></dt>
           <dd>
             [=query()=] is the operation that determines whether a given goal pattern can be derived from a [=base graph=] using the rules.
           </dd>


### PR DESCRIPTION
* [See this section of the document rendered online here](https://raw.githack.com/w3c/data-shapes/adding-infer-and-query-among-definitions/shacl12-rules/index.html#rules-abstract-syntax)

As discussed in the 11/02/2026 TF meeting, I have added the definitions of `infer()` and `query()` among the definitions in §3.

