### PR TITLE
More for the media type registration. Add issue markers.

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -1954,18 +1954,21 @@ the result is GI
         The information that follows has been submitted to the Internet Engineering
         Steering Group (IESG) for review, approval, and registration with IANA.
       </p>
-
-
       <div class="mediatype"><div id="mime"></div>
         <dl>
+
           <dt>Type name:</dt>
           <dd>application</dd>
+
           <dt>Subtype name:</dt>
           <dd>shape-rules</dd>
+
           <dt>Required parameters:</dt>
           <dd>None</dd>
+
           <dt>Optional parameters:</dt>
           <dd>@@version, @@profile</dd>
+
           <dt>Encoding considerations:</dt>
           <dd>The syntax of the @@@ Language is expressed over code points in Unicode
             [[UNICODE]]. The encoding is always UTF-8 [[RFC3629]].</dd>
@@ -1973,36 +1976,54 @@ the result is GI
             \UXXXXXXXX syntax (for U+10000 onwards) where X is a hexadecimal digit [0-9A-F]</dd>
           <dt>Security considerations:</dt>
           <dd>
-            @@
-            See appendix C?, <a href="#security">Security Considerations</a> as well as
+            See appendix C, <a href="#security" class="sectionRef">Security Considerations</a> as well as
             [[[RFC3629]]] [[RFC3629]] section 7, Security Considerations.
           </dd>
+
           <dt>Interoperability considerations:</dt>
           <dd>There are no known interoperability issues.</dd>
+
           <dt>Published specification:</dt>
           <dd>This specification.</dd>
+
           <dt>Applications which use this media type:</dt>
           <dd>@@</dd>
+
           <dt>Additional information:</dt>
-          <dt>Magic number(s):</dt>
-          <dd>A SHACL rules file may have the string 'PREFIX' (case independent) near the beginning of
-            the document.</dd>
-          <dt>File extension(s):</dt>
-          <dd>".srl"</dd>
-          <dt>Base URI:</dt>
-          <dd>The SHACL Rules 'BASE &lt;IRIref&gt;' term can change the current base URI for relative
-            IRIrefs in the query language that are used sequentially later in the document.</dd>
-          <dt>Macintosh file type code(s):</dt>
-          <dd>"TEXT"</dd>
+
+          <dd>
+            <dl>
+              <dt>Magic number(s):</dt>
+              <dd>A SHACL rules file may have the string 'PREFIX' 
+                (case independent) near the beginning
+                of the document.</dd>
+
+              <dt>File extension(s):</dt>
+              <dd>".srl"</dd>
+              <dt>Base URI:</dt>
+              <dd>
+                The SHACL Rules 'BASE &lt;IRIref&gt;' term can change the
+                current base URI for relative IRIrefs in the query language that
+                are used sequentially later in the document.
+              </dd>
+              <dt>Macintosh file type code(s):</dt>
+              <dd>"TEXT"</dd>
+            </dl>
+          </dd>
+
           <dt>Person & email address to contact for further information:</dt>
-          <dd>@@</dd>
+          <dd>Data Shapes Working Group &lt;public-shacl@w3.org;</dd>
+
           <dt>Intended usage:</dt>
           <dd>COMMON</dd>
+
           <dt>Restrictions on usage:</dt>
           <dd>None</dd>
+
           <dt>Author/Change controller:</dt>
-          <dd>The SHACL Rules 1.2 specification is a work product of the World Wide Web Consortium's
-            Data Shapes Working Group. The W3C has change control over these specifications.</dd>
+          <dd>The SHACL 1.2 Rules specification is a work product of the World
+            Wide Web Consortium's Data Shapes Working Group. The W3C has change
+            control over these specifications.</dd>
         </dl>
       </div>
     </section>

--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -174,8 +174,9 @@
       <section class="conventions">
         <h3>Document Conventions</h3>
         <p>
-          Some examples in this document use Turtle [[turtle]]. The reader is expected to be familiar with SHACL [[shacl]] and SPARQL
-          [[sparql-query]].
+          Some examples in this document use Turtle [[turtle]].
+          The reader is expected to be familiar with SHACL [[shacl]] 
+          and SPARQL [[sparql-query]].
         </p>
         <p>Within this document, the following namespace prefix bindings are used:</p>
         <table class="term-table">
@@ -213,7 +214,8 @@
           </tr>
         </table>
         <p>
-          Throughout the document, color-coded boxes containing RDF graphs in Turtle will appear. These fragments of Turtle documents use the prefix
+          Throughout the document, color-coded boxes containing RDF graphs in
+          Turtle will appear. These fragments of Turtle documents use the prefix
           bindings given above.
         </p>
         <!--
@@ -260,7 +262,7 @@
     </section>
 
     <section id="overview">
-      <h2>Outline</h2>
+      <h2>SHACL Rules</h2>
 
       <p>
         SHACL rules infer new triples. The input is a data graph
@@ -314,6 +316,96 @@ RULE { ?x :name ?FN } WHERE {
 }
 </pre>
       </section>
+
+      <section id="import">
+        <h3>Importing rules</h3>
+        <p>
+          `IMPORTS`
+        </p>
+        <div class="issue" data-number="780">
+          <p>Gives some modularity/sharing of rules.</p>
+          <p>"IMPORTS" vs "IMPORT" (c.f. `owl:imports`)</p>
+        </div>
+      </section>
+
+      <section id="creating-rdf-terms">
+        <h3>Assignment and Creating RDF Terms</h3>
+        <div class="issue" data-number="749">
+          <p>
+            Generating new terms without restriction can lead to unbounded
+            inferred triples.  There are function-like forms that do not have
+            repeatable results: `BNODE`, `UUID`.  Blank nodes in the rule head
+            behave like SPARQL `CONSTRUCT`.  Assignment can be used to have an
+            incrementing counter.
+          </p>
+        </div>
+      </section>
+      
+      <section id="rule-tuples">
+        <h3>Rule Tuples</h3>
+        <div class="issue" data-number="752">
+          <p><em>At risk:</em></p>
+          <p>
+            Rule tuples are workspace elements and are disjoint from triples.
+            They are tuples of RDF terms (no variables).
+          </p>
+          <p>
+            Syntax of tuple patterns, templates and tuples:
+          </p>
+          <ul>
+            <li>`TUPLE(termOrVar , ...)`</li>
+            <li>Shorthand: `$(termOrVar , ...)`</li>
+          </ul>
+          <p>
+            Often, the first argument will be a fixed name.
+          </p>
+          <p>
+            There is a tuple store which holds tuples for the lifetime of the
+            evaluation. The tuple store holds duplicate data tuples (unlike
+            an RDF graph which is a set).
+          </p>
+        </div>
+      </section>
+
+      <section id="attaching-rules-to-shapes">
+        <h3>Attaching Rules To Shapes</h3>
+
+        <div class="issue" data-number="765">
+          <p>
+            Should we include attaching SHACL (1.2) Rules to shapes?
+            If so, what does it mean given the difference in execution semantics?
+          </p>
+          <p>
+            In practice, how often are constriants and AF-rules written on the same shape?
+            If they are, how are the rules being used, in practice, to influence the validation?
+          </p>
+          <p>Sketch:</p>
+          <pre>
+[] rdf:type sh:NodeShape ;
+    sh:rule                   ## Different property?
+      [ a srl:SHACLRule ;
+        srl:ruleSet "...";    ## SRL syntax
+        sh:prefixes ... ;
+      ];
+[] rdf:type sh:NodeShape ;
+    sh:rule
+      [ a srl:SHACLRule ;
+        srl:ruleSet [ ... RDF syntax ... ] ;
+      ];
+</pre>
+
+</div>
+
+      </section>
+
+      <section>
+        <h3>Relationship between `RULE` and SPARQL `CONSTRUCT`</h3>
+        <div class="issue" data-number="516">
+          <p>
+          </p>
+        </div>
+      </section>
+
     </section>
 
     <section id="rules-abstract-syntax">
@@ -561,10 +653,10 @@ RULE { ?x :name ?FN } WHERE {
         <li><a href="#rdf-rules-syntax">RDF Rules syntax</a></li>
       </ul>
 
-      <p class="note">
+      <aside class="note">
         The Shape Rules Language (SRL) syntax has an equivalent RDF syntax form.
         Well-formed RDF syntax can be translated to the Shape Rules Language syntax.
-      </p>
+      </aside>
 
       <p>Shape Rules Language:</p>
       <div class="example-rules">
@@ -638,7 +730,7 @@ PREFIX sparql: &lt;http://www.w3.org/ns/sparql#&gt;
           <p>Additional helpers (short-hand abbreviations):</p>
 
           <p class=note>
-            These allow for well-known rule patterns and also specialised implementations in basic engines
+            These allow for well-known rule patterns and also specialised implementations in basic engines.
           </p>
 
           <ul>
@@ -646,6 +738,15 @@ PREFIX sparql: &lt;http://www.w3.org/ns/sparql#&gt;
             <li><code>SYMMETRIC(<em>uri</em>)</code></li>
             <li><code>INVERSE(<em>uri</em>)</code></li>
           </ul>
+
+          <div class="issue" data-number="779">
+            <p><em>At risk:</em></p>
+            <p>
+              `TRANSITIVE` has both implementation and concise expression advantages.
+              Implementation advantages for `SYMMETRIC` and `INVERSE` are not clear.
+            </p>
+          </div>
+
         </section>
       </section>
 
@@ -667,10 +768,8 @@ PREFIX sparql: &lt;http://www.w3.org/ns/sparql#&gt;
           </ul>
         </div>
         <div class="ednote">
-          <p>Describe how the abstract model maps to triples??.
-            way round - copes with extra triples.
-            Output is the instance of the abtract model that generates the triples -
-            but need to define "maximal".
+          <p>
+            Describe how the abstract model maps to triples.
         </p>
         </div>
 
@@ -805,16 +904,13 @@ merge(S1, S2) = { <var>μ</var> |
             </div>
             <div class="ednote">
               <p>
-              Say the domain is `dom(S1) &cups; dom(S2)`.
+                Say the domain is `dom(S1) &cups; dom(S2)`.
               </p>
               <p>
                 Say that two solutions that have no variables in common are compatible.
               </p>
             </div>
-            
-
           </dd>
-
         </dl>
       </section>
 
@@ -1970,7 +2066,7 @@ the result is GI
           <dd>@@version, @@profile</dd>
 
           <dt>Encoding considerations:</dt>
-          <dd>The syntax of the @@@ Language is expressed over code points in Unicode
+          <dd>The syntax of the SHACL Rules Language is expressed over code points in Unicode
             [[UNICODE]]. The encoding is always UTF-8 [[RFC3629]].</dd>
           <dd>Unicode code points may also be expressed using an \uXXXX (U+0 to U+FFFF) or
             \UXXXXXXXX syntax (for U+10000 onwards) where X is a hexadecimal digit [0-9A-F]</dd>


### PR DESCRIPTION
* Nearly complete the media type registration 
  (Parameters `version=` and `profile=` still to do -- see #788)

* Put in boxes to link the document to issues.

[See this document rendered online here](https://raw.githack.com/w3c/data-shapes/afs-rules-doc-misc/shacl12-rules/index.html)
