### PR TITLE
Added infer() and query() among the definitions

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -531,17 +531,32 @@ RULE { ?x :name ?FN } WHERE {
           </dd>
 
           <dt><dfn>Base graph</dfn></dt>
-          <dd>
-            The [=base graph=] is the [=RDF Graph=] given as input to the evaluation
-            process.
+          <dd>    
+            The [=base graph=] is the [=RDF Graph=] given as input to the
+            evaluation process.
           </dd>
 
           <dt><dfn>Inference graph</dfn></dt>
           <dd>
-            The [=inference graph=] is an [=RDF Graph=] that is the outcome of rule set evaluation.
-            It contains all triples not found in the [=base graph=] that are inferred from
-            evaluation of the [=rule set=] on the [=base graph=].
+            The [=inference graph=] is an [=RDF Graph=] produced by evaluating a
+            [=rule set=].  It contains all triples not present in the [=base
+            graph=] that are inferred from applying the [=rule set=] to the
+            [=base graph=].
           </dd>
+
+          <dt><dfn>Infer</dfn></dt>
+          <dd>
+            [=Infer=] is the operation that applies the rules to a given [=base
+            graph=] and produces an [=inference graph=] containing inferred
+            triples.  triples derived from rule execution.
+          </dd>
+
+          <dt><dfn>Query</dfn></dt>
+          <dd>
+            [=Query=] is the operation that determines whether a given goal
+            pattern can be derived from a [=base graph=] using the rules.
+          </dd>
+
         </dl>
 
         <p>
@@ -1190,7 +1205,7 @@ Apply stratification to RS
 let L be the sequence of layers after stratification
 
 # Inference graph
-let GI = { t &isin;D  | t &notin; in G0 }
+let GI = { t &isin; D  | t &notin; in G0 }
 
 # Evaluation graph.
 let GE = G0 &cups; D


### PR DESCRIPTION
This is PR #783 with the following steps:

1. Rebased to the current document and the merge conflict sorted out 
2. Reorder infer/query as per https://github.com/w3c/data-shapes/pull/783#discussion_r2807304533
3. Line wrap long lines.
4. Squashed down to one commit 
   `40432737+liviorobaldo@users.noreply.github.com (8 days ago) - Added infer and query among the definitions`

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/adding-infer-and-query-among-definitions-cleaned/shacl12-rules/index.html)
