### PR TITLE
Align naming of rule body elements

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -457,11 +457,11 @@ RULE { ?x :name ?FN } WHERE {
             as well as inside [=negation elements=].
           </dd>
 
-          <dt><dfn>Condition expression</dfn></dt>
+          <dt><dfn data-lt="condition element|condition">Condition element</dfn></dt>
           <dd>
-            A [=condition expression=] is a function, or functional form,
+            A [=condition element=] is an [=expression=]
             that evaluates to true or false.
-            [=Condition expressions=] appear in the [=body=] of a [=rule=].
+            [=Condition elements=] appear in the [=body=] of a [=rule=].
           </dd>
 
           <dt><dfn>Triple pattern element</dfn></dt>
@@ -474,15 +474,15 @@ RULE { ?x :name ?FN } WHERE {
           <dd>
             A [=negation element=] is a [=rule body element=].
             It takes a sequence of [=triple patterns=] and
-            [=condition expressions=].
+            [=condition elements=].
           </dd>
 
-          <dt><dfn>Assignment</dfn></dt>
+          <dt><dfn data-lt="assignment element">Assignment element</dfn></dt>
           <dd>
-            An [=assignment=] is a pair of a <a>variable</a>, called the
-            <dfn>assignment variable</dfn>, and an <a>expression</a>, called the
-            <dfn>assignment expression</dfn>.
-            [=Assignments=] appear in the [=body=] of a [=rule=].
+            An [=assignment element=] is a pair consisting 
+            of a <a>variable</a>, called the <dfn>assignment variable</dfn>, 
+            and an <a>expression</a>, called the <dfn>assignment expression</dfn>.
+            [=Assignment elements=] appear in the [=body=] of a [=rule=].
           </dd>
 
           <!-- Pending
@@ -500,9 +500,9 @@ RULE { ?x :name ?FN } WHERE {
             A [=rule body element=] (often just "rule element") is any element that
             can appear in a [=rule body=],
             a [=triple pattern=],
-            a [=condition expression=],
+            a [=condition element=],
             a [=negation element=],
-            or an [=assignment=].
+            or an [=assignment element=].
             <!-- Pending
             or an [=aggregation element=].
             -->
@@ -574,7 +574,7 @@ RULE { ?x :name ?FN } WHERE {
           Well-formedness is a set of conditions on the abstract syntax of
           SHACL rules. Together, these conditions ensure that a [=variable=] in the
           [=head=] of a rule has a value defined in the [=body=] of the rule;
-          that each variable in an [=condition expression=]
+          that each variable in an [=condition element=]
           or [=assignment expression=]
           has a value at the point of evaluation; and that each
           assignment in a rule introduces a new variable,
@@ -589,7 +589,7 @@ RULE { ?x :name ?FN } WHERE {
             of the [=head=] of the [=rule=],
             there is one or more occurrences of a [=variable=]
             of the same name in the [=triple patterns=] in the [=body=],
-            in an [=assignment=] in the body, or both.
+            in an [=assignment element=] in the body, or both.
           </li>
           <li>
             For every [=variable=] in an [=expression=] at position <em>i</em>
@@ -599,7 +599,7 @@ RULE { ?x :name ?FN } WHERE {
             where <em>i &gt; j</em>.
           </li>
           <li>
-            Each [=assignment variable=] is used in only one [=assignment=] in
+            Each [=assignment variable=] is used in only one [=assignment element=] in
             the [=body=] of the [=rule=].
           </li>
           <li>
@@ -610,7 +610,7 @@ RULE { ?x :name ?FN } WHERE {
             For every [=variable=] in an [=assignment expression=] at position <em>i</em>,
             there is a corresponding variable in a [=triple pattern=] at position
             <em>j</em> where <em>i &gt; j</em>,
-            or there is an [=assignment variable=] in an [=assignment=] at position
+            or there is an [=assignment variable=] in an [=assignment element=] at position
             <em>j</em> where <em>i &gt; j</em>.
           </li>
         </ul>
@@ -1107,9 +1107,9 @@ let R be a well-formed rule.
 
 let rule R = (H, B) where
              H is the sequence of triple templates in the head
-             B is the sequence of triple patterns,
-                condition expressions, negation elements,
-                and assignments in the body
+             B is the sequence of triple pattern elements,
+                condition elements, negation elements,
+                and assignment elements in the body
 
 # Solution sequence of one solution that does not map any variables.
 let SEQ0: Solution sequence = { <var>μ</var><sub>0</sub> }
@@ -1133,7 +1133,7 @@ define evalRuleElements(B, SEQ, G):
                 endfor
             endif
 
-        if rElt is a condition expression with expression F:
+        if rElt is a condition element with expression F:
             SEQ1 = {}
             for each solution <var>μ</var> in SEQ:
                 if evalFunction(F, <var>μ</var>) is <var>true</var>:


### PR DESCRIPTION
Make all rule body elements have a name that includes "element".

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/afs/align-defn-names/shacl12-rules/index.html#rules-defns)
