### PR TITLE
Rewrite the SHACL Rules introduction

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -139,20 +139,33 @@
       <h2>Introduction</h2>
 
       <p>
-        This document introduces the concept of inference rules for SHACL 1.2, a mechanism for
-        deriving new RDF triples from existing data using declarative rules defined in shapes
-        graphs. This extends SHACL’s capabilities beyond validation, enabling reasoning and data
-        enrichment.
+        This document introduces inference rules for SHACL 1.2, a mechanism for
+        deriving new RDF triples from existing RDF data through declarative rules. 
+        The document defines the syntax and semantics of rule-based inference.
       </p>
-
       <p>
-        This document complements other SHACL 1.2 specifications, such as SHACL Core, by defining
-        the syntax and semantics of rule-based inference. While SHACL Core focuses on constraint
-        validation, the SHACL Rules specification provides a standardized way to express and
-        evaluate rules that generate new data.
+        Implementations of SHACL Rules provide two operations.
+        The <em>infer</em> operation that applies the rules to a given
+        <i>base graph</i> and produces an <i>inference graph</i> containing the
+        RDF triples derived by rule execution.
+        Combining the inference graph with the base graph is optional and
+        left to users. The <em>query</em> operation determines whether a
+        given goal pattern can be derived from the base graph using the rules
       </p>
-
-      <section id="terminolgy">
+      <p>
+        The inference graph may contain RDF triples with IRIs, blank nodes or
+        literals that were not present in the base graph. Users are responsible to
+        ensure that iterative applications of rules that generate new blank nodes or
+        literals do not result in infinite loops.
+      </p>
+      <p>
+        SHACL Rules also support constructs, such as negation as failure, 
+        that could lead to different inferred graphs depending on the order in which
+        rules are executed. To avoid this, rules are evaluated using the technique
+        of <em>stratification</em>, which establishes a single, implicit ordering
+        among rules, ensuring that the same inference graph is always produced.
+      </p>
+      <section id="terminology">
         <h3>Terminology</h3>
 
         <p class="ednote">Connect to definitions in RDF 1.2 Concepts.</p>


### PR DESCRIPTION
PR #722 (as of 2026-02-26) with the commits squashed to one commit with log message "[Rewrite the SHACL Rules introduction](https://github.com/w3c/data-shapes/commit/71a6cd1112779cfb66bbe468c588bb90f226309a)"

* [Section rendered online](https://raw.githack.com/w3c/data-shapes/SHACL-rules-introduction-cleaned/shacl12-rules/index.html#introduction)

This PR has the same diff as #722 

https://github.com/w3c/data-shapes/pull/722.diff
https://github.com/w3c/data-shapes/pull/801.diff

