### PR TITLE
#803: Added example and explanation on sh:node between node shapes

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2265,7 +2265,7 @@ ex:SomeClass-alternativePathExample
 					<p><em>The remainder of this section is informative.</em></p>
 					<p>
 						The recursion policy above has been selected to support a large variety of implementation strategies.
-						By leaving recursion undefined, implementations may chose to not support recursion so that they
+						By leaving recursion undefined, implementations may choose to not support recursion so that they
 						can issue a static set of SPARQL queries (against SPARQL end points) without having to support cycles.
 						The Working Group is aware that other implementations may support recursion and that some shapes graphs may
 						rely on these specific characteristics.
@@ -4723,10 +4723,11 @@ ex:Carla a ex:Person ;
 					</div>
 					<p><em>The remainder of this section is informative.</em></p>
 					<p>
-						In the following example, all values of the property <code>ex:address</code> must fulfill the
+						The following example illustrates the use of <code>sh:node</code> in property shapes.
+						All values of the property <code>ex:address</code> must fulfill the
 						constraints expressed by the <a>shape</a> <code>ex:AddressShape</code>.
 					</p>
-					<aside class="example">
+					<aside class="example" title="Example of sh:node in a property shape">
 						<div class="shapes-graph">
 							<div class="turtle">
 ex:AddressShape
@@ -4787,6 +4788,53 @@ ex:RetosAddress
 							</div>
 						</div>
 					</aside>
+					<p>
+						The following example illustrates the use of <code>sh:node</code> in node shapes.
+					</p>
+					<aside class="example" title="Example of sh:node in node shapes">
+						<div class="shapes-graph">
+							<div class="turtle">
+ex:PostalCodeShape
+    a sh:NodeShape ;
+    rdfs:label "Postal code" ;
+    rdfs:comment "General constraints for postal codes around the world." ;
+    sh:datatype xsd:string ;
+    sh:minLength 3 ;
+.
+ex:AustralianPostalCode
+    a sh:NodeShape ;
+    rdfs:label "Postal code (Australia)" ;
+    rdfs:comment "Constraints that specialize those from ex:PostalCodeShape." ;
+    sh:intent "Australian postal codes consist of 4 digits." ;
+    sh:pattern "^\\d{4}$" ;
+    sh:minLength 4 ;
+    sh:maxLength 4 ;
+    <b>sh:node ex:PostalCodeShape</b> ;
+.
+ex:USZipCode
+    a sh:NodeShape ;
+    rdfs:label "Zip code (USA)" ;
+    rdfs:comment "Constraints that specialize those from ex:PostalCodeShape." ;
+    sh:intent "US zip codes are either 5 digits or 5 plus 4 with a dash in between." ;
+    sh:pattern "^\\d{5}(-\\d{4})?$" ;
+    sh:minLength 5 ;
+    sh:maxLength 10 ;
+    <b>sh:node ex:PostalCodeShape</b> ;
+.
+							</div>
+						</div>
+						<p>
+							This example defines a general base shape for postal codes and two specializations
+							for specific countries.
+							The base constraints such as <code>sh:datatype xsd:string</code> and <code>sh:minLength 3</code>
+							apply to all postal codes.
+							The property <code>sh:node</code> is used to link the narrower shapes to the broader shape,
+							similar to how <code>rdfs:subClassOf</code> is used to link a subclass with a superclass.
+						</p>
+					</aside>
+					<p>
+						See <a href="#shapes-recursion"></a> on the handling of recursive shapes in SHACL.
+					</p>
 				</section>
 
 				<section id="PropertyConstraintComponent">


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #803

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-803/shacl12-core/index.html#NodeConstraintComponent)
