### PR TITLE
Editorial (shacl12-rules)

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -208,7 +208,7 @@
             <td><code>http://www.w3.org/ns/shacl#</code></td>
           </tr>
           <tr>
-            <td><code>shrl:</code></td>
+            <td><code>srl:</code></td>
             <td><code>http://www.w3.org/ns/shacl-rules#</code></td>
           </tr>
           <tr>
@@ -437,7 +437,7 @@ RULE { ?x :name ?FN } WHERE {
           <dt><dfn>Expression</dfn></dt>
           <dd>
             <p>
-              An [=expression=] is a function, or functional form.
+              An [=expression=] is a function or a functional form.
               It's arguments are [=RDF terms=].
               An expression is evaluated with respect to a [=solution mapping=] to give
               an [=RDF term=] as the result.
@@ -474,7 +474,7 @@ RULE { ?x :name ?FN } WHERE {
           <dt><dfn data-lt="condition element|condition">Condition element</dfn></dt>
           <dd>
             A [=condition element=] is an [=expression=]
-            that evaluates to true or false.
+            that evaluatease s to true or false.
             [=Condition elements=] appear in the [=body=] of a [=rule=].
           </dd>
 
@@ -546,29 +546,30 @@ RULE { ?x :name ?FN } WHERE {
 
           <dt><dfn>Base graph</dfn></dt>
           <dd>    
-            The [=base graph=] is the [=RDF Graph=] given as input to the
+            A [=base graph=] is the [=RDF Graph=] given as input to the
             evaluation process.
           </dd>
 
           <dt><dfn>Inference graph</dfn></dt>
           <dd>
-            The [=inference graph=] is an [=RDF Graph=] produced by evaluating a
+            An [=inference graph=] is an [=RDF Graph=] produced by evaluating a
             [=rule set=].  It contains all triples not present in the [=base
-            graph=] that are inferred from applying the [=rule set=] to the
+            graph=] that are inferred by applying the [=rule set=] to the
             [=base graph=].
           </dd>
 
           <dt><dfn>Infer</dfn></dt>
           <dd>
-            [=Infer=] is the operation that applies the rules to a given [=base
-            graph=] and produces an [=inference graph=] containing inferred
-            triples.  triples derived from rule execution.
+            [=Infer=] is the operation that applies a [=rule set=] to a given
+            [=base graph=] and produces an [=inference graph=] containing inferred
+            triples.
           </dd>
 
           <dt><dfn>Query</dfn></dt>
           <dd>
             [=Query=] is the operation that determines whether a given goal
-            pattern can be derived from a [=base graph=] using the rules.
+            pattern can be derived from a [=base graph=] using the
+            [=rule set=].
           </dd>
 
         </dl>
@@ -734,14 +735,14 @@ RULE { ?x :name ?FN } WHERE {
         <p>
           [=Stratification=] is the process of partitioning a [=rule set=]
           into an ordered sequence of [=stratification layers=] (also known
-          as "strata", singular "stratum="), forming a [=stratification=].
+          as "strata", singular "stratum"), forming a [=stratification=].
           Rules in lower [=strata=] are evaluated before rules in higher
           [=strata=].
         </p>
         <p>
           [=Stratification=] imposes constraints on dependencies between [=rules=]
           to ensure that [=negation elements=] depend only on results computed
-          in earlier [=strata=], guaranteeing a single, well-defined outcome
+          in earlier (lower) [=stratum=], guaranteeing a single, well-defined outcome
           from the evaluation of a [=rule set=] over a given [=base graph=].
         </p>
         <div class="ednote">
@@ -750,7 +751,7 @@ RULE { ?x :name ?FN } WHERE {
             decisions. This document describes the necessary conditions for
             consistent evaluation and gives one possible way to form a
             stratification. Implementations need to meet the conditions
-            described here in order to get compatible behavior but are not
+            described here in order to get compatible behavior but they are not
             required to implement the algorithm as presented.
           </p>
         </div>
@@ -759,7 +760,8 @@ RULE { ?x :name ?FN } WHERE {
           <dt><dfn>Stratification</dfn></dt>
           <dd>
             A [=stratification=] of a [=rule set=] is a sequence of sets of
-            rules. Each rule in a [=rule set=] appears in exactly one [=stratification layer=].
+            rules. Each rule in a [=rule set=] appears in exactly one
+            [=stratification layer=].
           </dd>
           <dt><dfn 
                 data-lt="stratification layer|layer|stratum"
@@ -913,39 +915,39 @@ WHERE { ?x :p ?v1 ;  :q ?v2  FILTER ( ( ?v1 = 0 ) || ( ?v2 = 0 ) )  }
 PREFIX :       &lt;http://example/&gt;
 PREFIX rdf:    &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
 PREFIX sh:     &lt;http://www.w3.org/ns/shacl#&gt;
-PREFIX shrl:   &lt;http://www.w3.org/ns/shacl-rules#&gt;
+PREFIX srl:    &lt;http://www.w3.org/ns/shacl-rules#&gt;
 PREFIX sparql: &lt;http://www.w3.org/ns/sparql#&gt;
 
 :ruleSet-1
-  rdf:type shrl:RuleSet;
-  shrl:data (
+  rdf:type srl:RuleSet;
+  srl:data (
     &lt;&lt;( :x :p 1 )&gt;&gt;
     &lt;&lt;( :x :q 2 )&gt;&gt;
   );
-  shrl:ruleSet (
+  srl:ruleSet (
     [
-      rdf:type shrl:Rule;
-      shrl:head (
-        [ shrl:subject [ shrl:var "x" ] ; shrl:predicate :bothPositive; shrl:object true ]
+      rdf:type srl:Rule;
+      srl:head (
+        [ srl:subject [ srl:var "x" ] ; srl:predicate :bothPositive; srl:object true ]
       ) ;
-      shrl:body (
-        [ shrl:subject [ shrl:var "x" ]; shrl:predicate :p; shrl:object [ shrl:var "v1" ] ]
-        [ shrl:expr [ sparql:greaterThan ( [ shrl:var "v1" ] 0 ) ] ]
-        [ shrl:subject [ shrl:var "x" ] ; shrl:predicate :q; shrl:object [ shrl:var "v2" ] ]
-        [ shrl:expr [ sparql:greaterThan ( [ shrl:var "v2" ] 0 ) ] ]
+      srl:body (
+        [ srl:subject [ srl:var "x" ]; srl:predicate :p; srl:object [ srl:var "v1" ] ]
+        [ srl:expr [ sparql:greaterThan ( [ srl:var "v1" ] 0 ) ] ]
+        [ srl:subject [ srl:var "x" ] ; srl:predicate :q; srl:object [ srl:var "v2" ] ]
+        [ srl:expr [ sparql:greaterThan ( [ srl:var "v2" ] 0 ) ] ]
       );
     ]
     [
-      rdf:type shrl:Rule;
-      shrl:head (
-        [ shrl:subject [ shrl:var "x" ] ; shrl:predicate :oneIsZero ; shrl:object true ]
+      rdf:type srl:Rule;
+      srl:head (
+        [ srl:subject [ srl:var "x" ] ; srl:predicate :oneIsZero ; srl:object true ]
       ) ;
-      shrl:body (
-        [ shrl:subject [ shrl:var "x" ] ; shrl:predicate :p ; shrl:object [ shrl:var "v1" ] ]
-        [ shrl:subject [ shrl:var "x" ] ; shrl:predicate :q ; shrl:object [ shrl:var "v2" ] ]
-        [ shrl:expr [ sparql:function-or (
-              [ sparql:equals ( [ shrl:var "v1" ] 0 ) ]
-              [ sparql:equals ( [ shrl:var "v2" ] 0 ) ]
+      srl:body (
+        [ srl:subject [ srl:var "x" ] ; srl:predicate :p ; srl:object [ srl:var "v1" ] ]
+        [ srl:subject [ srl:var "x" ] ; srl:predicate :q ; srl:object [ srl:var "v2" ] ]
+        [ srl:expr [ sparql:function-or (
+              [ sparql:equals ( [ srl:var "v1" ] 0 ) ]
+              [ sparql:equals ( [ srl:var "v2" ] 0 ) ]
             ) ]
         ]
       );
@@ -964,7 +966,8 @@ PREFIX sparql: &lt;http://www.w3.org/ns/sparql#&gt;
           <p>Additional helpers (short-hand abbreviations):</p>
 
           <p class=note>
-            These allow for well-known rule patterns and also specialised implementations in basic engines.
+            These allow for well-known rule patterns and also specialised
+            implementations in basic engines.
           </p>
 
           <ul>
@@ -1021,7 +1024,7 @@ PREFIX sparql: &lt;http://www.w3.org/ns/sparql#&gt;
 
           <p>
             All triples not in the syntax are ignored.
-            No other "shrl:" predicates are allowed (??).
+            No other "srl:" predicates are allowed (??).
           </p>
         </div>
       </section>
@@ -1054,7 +1057,7 @@ Output: an RDF graph GI of inferred triples
                 data-lt="solution|sparql12-query#defn_sparqlSolutionMapping"
                 >solution mapping</dfn></dt>
           <dd> 
-            A <a data-lt="sparql12-query#defn_sparqlSolutionMapping">solution mapping</a>, 
+            A <a data-lt="sparql12-query#defn_sparqlSolutionMapping">Solution mapping</a>, 
             <var>μ</var>, is a partial function 
             <code><var>μ</var> : <var>V</var> → <var>T</var></code>,
             where <var>V</var> is the set of all variables 
@@ -1063,13 +1066,13 @@ Output: an RDF graph GI of inferred triples
             by <code><var>dom</var>(<var>μ</var>)</code>, and it is the subset
             of <var>V</var> for which <var>μ</var> is defined. We use the term
             [=solution=] where it is clear that a [=solution mapping=] is meant.
-            Write <var>μ<sub>0</sub></var> for the solution mapping such that
+            Write <var>μ<sub>0</sub></var> for the solution mapping, such that
             <code><var>dom</var>(<var>μ<sub>0</sub></var>)</code> is the empty set.
           </dd>
 
-          <dt><dfn data-lt="substitution">substitution function</dfn></dt>
+          <dt><dfn data-lt="substitution">Substitution function</dfn></dt>
           <dd>
-            A <a>substitution function</a>, or just <i>substitution</i>,
+            A <a>substitution function</a>, or just a <i>substitution</i>,
             is a function 
             <code>subst(<var>μ</var>, [=triple pattern=])</code>
             that returns a [=triple pattern=]
@@ -1080,13 +1083,13 @@ Output: an RDF graph GI of inferred triples
             If the triple pattern result has no variables, then it is an [=RDF Triple=].
           </dd>
           
-          <dt><dfn>evaluation graph</dfn></dt>
+          <dt><dfn>Evaluation graph</dfn></dt>
           <dd>
             A [=evaluation graph=] is an [=RDF Graph=] that combines the [=base graph=]
             and all triples produced during the evaluation of a rule set.
           </dd>
 
-          <dt><dfn>graph match</dfn></dt>
+          <dt><dfn>Graph match</dfn></dt>
           <dd>
               A [=graph match=] finds the ways to 
               map a triple pattern onto triples in an [=RDF Graph=].
@@ -1105,7 +1108,7 @@ Output: an RDF graph GI of inferred triples
             </div>
           </dd>
 
-          <dt><dfn data-lt="compatible">solution compatible</dfn></dt>
+          <dt><dfn data-lt="compatible">Solution compatible</dfn></dt>
           <dd>
             Two solutions S1 and S2 are [=compatible=] if they agree on the variables in common.
             <div class="def">
@@ -1120,14 +1123,14 @@ compatible(<var>μ</var><sub>1</sub>, <var>μ</var><sub>2</sub>) = false otherwi
               </div>  
           </dd>
 
-          <dt><dfn>solution sequence</dfn></dt>
+          <dt><dfn>Solution sequence</dfn></dt>
           <dd>
             A [=solution sequence=] is a multi-set of solutions.
             There is no defined order to the sequence.
             It is equivalent to an unordered list and it can contain duplicates.
           </dd>
 
-          <dt><dfn data-lt="merge">solution merge</dfn></dt>
+          <dt><dfn data-lt="merge">Solution merge</dfn></dt>
           <dd>
             If two solutions are compatible, the merge of two solutions is the solution
             that maps variables of each solution to the [=RDF term=]


### PR DESCRIPTION
Editorial changes to SHACL 1.2 Rules.

[See this document rendered online here](https://raw.githack.com/w3c/data-shapes/rules/editorial/shacl12-rules/index.html)

It does use `srl:` consistently so at least there is now one usual prefix.

We have a mismatch between issues discussions (usually `srl:`, rarely `shrl:`) and the document mostly `shrl:`, a few `srl:`.

