### PR TITLE
GH#812 - [shacl12-sparql] fix broken link in SHACL 1.2 SPARQL Extensions

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -116,7 +116,7 @@
 						name:       "Holger Knublauch",
 						company:    "TopQuadrant, Inc.",
 						companyURL: "https://topquadrant.com/",
-						mailto:     "holger@topquadrant.com",
+						mailto:     "holger@knublauch.com",
 						w3cid:      46500
 					},
 					{
@@ -2017,9 +2017,10 @@ ex:SomeClass-alternativePathExample
 			</div>
 			<p>
 				The SHACL Core specification only exactly defines the <a>node expression functions</a> based on the next two subsections.
+				[[shacl12-node-expr]] provides more background on the general design of node expressions and includes a comprehensive
+				library of node expression functions.
 				Other specifications such as [[shacl12-sparql]] introduce additional functions, using <a>blank nodes</a>.
 				Therefore <a>node expressions</a> serve as an extension point of SHACL.
-				<span class="todo">TODO: Add link to shacl12-node-expr once that is stable.</span>
 			</p>
 			<section id="IRIExpression">
 				<h3>IRI Expressions</h3>

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -426,7 +426,7 @@
 					name:       "Holger Knublauch",
 					company:    "TopQuadrant, Inc.",
 					companyURL: "https://topquadrant.com/",
-					mailto:     "holger@topquadrant.com",
+					mailto:     "holger@knublauch.com",
 					w3cid:      46500
 				},
 				{

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -112,7 +112,7 @@
 						name:       "Holger Knublauch",
 						company:    "TopQuadrant, Inc.",
 						companyURL: "http://topquadrant.com/",
-						mailto:     "holger@topquadrant.com",
+						mailto:     "holger@knublauch.com",
 						w3cid:      46500
 					},
 					{
@@ -225,7 +225,6 @@
 						<dfn data-cite="shacl12-core#dfn-node-expression" data-lt="node expression|node expresssions">node expression</dfn>,
 						<dfn data-cite="shacl12-core#dfn-node-expression-function" data-lt="node expression function|node expresssion functions">node expression function</dfn>,
 						<dfn data-cite="shacl12-core#dfn-function-name" data-lt="node expression function name">function name</dfn>,
-						<dfn data-cite="shacl12-core#dfn-key-parameter" data-lt="key parameter">key parameter</dfn>,
 						<dfn data-cite="shacl12-core#dfn-output-nodes" data-lt="output nodes">output nodes</dfn>,
 						<dfn data-cite="shacl12-core#dfn-focus-graph" data-lt="focus graph">focus graph</dfn>,
 						<dfn data-cite="shacl12-core#dfn-conform" data-lt="conform|conforms">conform</dfn>,


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #812

The definition was unused so I just removed it. On this occasion I also fixed a reference to the node-expr spec from core.