### PR TITLE
SHACL RDF Resources metadata additions

### DIFF
--- a/shacl12-profiling/index.html
+++ b/shacl12-profiling/index.html
@@ -809,6 +809,13 @@ ex:ont-N
       >SHACL 1.2 Overview's SHACL-SHACL appendix</a>.
     </p>
   </section>
+  <section id="other-profiles">
+    <h3>Other Profiles</h3>
+    <p>
+      Here are some other profiles of SHACL that use different logic to scope their contents.
+    </p>
+    <div class="issue" data-number="826"></div>
+  </section>
   <section id="creating-profiles">
     <h3>Creating other Profiles</h3>
     <p>

--- a/shacl12-vocabularies/shacl-profiling.ttl
+++ b/shacl12-vocabularies/shacl-profiling.ttl
@@ -10,6 +10,7 @@ PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
 
 shpr:
 	a owl:Ontology ;
+	owl:versionIRI shpr:1.2 ;
 	rdfs:label "W3C Shapes Constraint Language (SHACL) Profiling Vocabulary"@en ;
 	rdfs:comment "This vocabulary defines terms used profiling SHACL and profiling RDF data with SHACL, the W3C Shapes Constraint Language."@en ;
 	sh:declare [
@@ -17,7 +18,7 @@ shpr:
 		sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
 	] ;
     schema:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
-    schema:creator "W3C Data Shapes 1.2 Working Group" ;
+    schema:creator "W3C Data Shapes Working Group" ;
     schema:dateCreated "2026-03-16"^^xsd:date ;
     # schema:dateIssued ""^^xsd:date ;
     schema:dateModified "2026-03-16"^^xsd:date ;

--- a/shacl12-vocabularies/shacl-profiling.ttl
+++ b/shacl12-vocabularies/shacl-profiling.ttl
@@ -10,18 +10,20 @@ PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
 
 shpr:
 	a owl:Ontology ;
-	rdfs:label "W3C Shapes Constraint Language (SHACL) Profiling Vocabulary"@en ;
-	rdfs:comment "This vocabulary defines terms used profiling SHACL and profiling RDF data with SHACL, the W3C Shapes Constraint Language."@en ;
+	owl:imports <http://www.w3.org/ns/shacl#> ;
+	owl:versionIRI shpr:1.2 ;
+	rdfs:label "W3C SHACL Profiling Vocabulary"@en ;
+	rdfs:comment "This vocabulary defines terms used in the SHACL Profiling specification."@en ;
+    schema:creator "W3C Data Shapes 1.2 Working Group" ;
+    # schema:dateCreated ""^^xsd:date ;
+    # schema:dateIssued ""^^xsd:date ;
+    # schema:dateModified ""^^xsd:date ;
+    schema:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
+    schema:version "1.2" ;
 	sh:declare [
 		sh:prefix "shpr" ;
 		sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
 	] ;
-    schema:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
-    schema:creator "W3C Data Shapes 1.2 Working Group" ;
-    schema:dateCreated "2026-03-16"^^xsd:date ;
-    # schema:dateIssued ""^^xsd:date ;
-    schema:dateModified "2026-03-16"^^xsd:date ;
-    schema:version "1.2" ;
     rdfs:member
         shpr:conformsTo ;
 .

--- a/shacl12-vocabularies/shacl-profiling.ttl
+++ b/shacl12-vocabularies/shacl-profiling.ttl
@@ -32,6 +32,6 @@ shpr:conformsTo
     rdfs:label "conforms to" ;
     rdfs:comment "An established standard to which the described resource conforms." ;
     rdfs:isDefinedBy shpr: ;
-    rdfs:range dcterms:Standard ;
-    skos:scopeNote "This property is just an OWL ObjectProerty version of DCTERM's conformsTo created to allow for OWL reasoning" ;
+    rdfs:range dcterms:Standard , sh:ShapesGraph ;
+    skos:scopeNote "This property's usage is for a special case of conformance, where the subject conforms to the object by merit of SHACL validation when using the object as a shapes graph." ;
 .

--- a/shacl12-vocabularies/shacl-profiling.ttl
+++ b/shacl12-vocabularies/shacl-profiling.ttl
@@ -11,7 +11,7 @@ PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
 shpr:
 	a owl:Ontology ;
 	rdfs:label "W3C Shapes Constraint Language (SHACL) Profiling Vocabulary"@en ;
-	rdfs:comment "This vocabulary defines terms used profiling SHACL and profiling RDF data with SHACL, the W3C Shapes Constraint Language."@en ;
+	rdfs:comment "This vocabulary defines terms applicable when using SHACL, the W3C Shapes Constraint Language, to profile SHACL and to profile RDF data."@en ;
 	sh:declare [
 		sh:prefix "shpr" ;
 		sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;

--- a/shacl12-vocabularies/shacl-profiling.ttl
+++ b/shacl12-vocabularies/shacl-profiling.ttl
@@ -26,6 +26,10 @@ shpr:
         shpr:conformsTo ;
 .
 
+dcterms:conformsTo
+    a owl:ObjectProperty ;
+.
+
 shpr:conformsTo
     a owl:ObjectProperty ;
     rdfs:subPropertyOf dcterms:conformsTo ;

--- a/shacl12-vocabularies/shacl-profiling.ttl
+++ b/shacl12-vocabularies/shacl-profiling.ttl
@@ -1,0 +1,37 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX owl:  <http://www.w3.org/2002/07/owl#>
+PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX sh:   <http://www.w3.org/ns/shacl#>
+PREFIX shpr: <http://www.w3.org/ns/shacl-pr#>
+PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+
+shpr:
+	a owl:Ontology ;
+	rdfs:label "W3C Shapes Constraint Language (SHACL) Profiling Vocabulary"@en ;
+	rdfs:comment "This vocabulary defines terms used profiling SHACL and profiling RDF data with SHACL, the W3C Shapes Constraint Language."@en ;
+	sh:declare [
+		sh:prefix "shpr" ;
+		sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
+	] ;
+    schema:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
+    schema:creator "W3C Data Shapes 1.2 Working Group" ;
+    schema:dateCreated "2026-03-16"^^xsd:date ;
+    # schema:dateIssued ""^^xsd:date ;
+    schema:dateModified "2026-03-16"^^xsd:date ;
+    schema:version "1.2" ;
+    rdfs:member
+        shpr:conformsTo ;
+.
+
+shpr:conformsTo
+    a owl:ObjectProperty ;
+    rdfs:subPropertyOf dcterms:conformsTo ;
+    rdfs:label "conforms to" ;
+    rdfs:comment "An established standard to which the described resource conforms." ;
+    rdfs:isDefinedBy shpr: ;
+    rdfs:range dcterms:Standard ;
+    skos:scopeNote "This property is just an OWL ObjectProerty version of DCTERM's conformsTo created to allow for OWL reasoning" ;
+.

--- a/shacl12-vocabularies/shacl-shacl-pr.ttl
+++ b/shacl12-vocabularies/shacl-shacl-pr.ttl
@@ -13,7 +13,7 @@ shshpr:
 	owl:versionIRI shshpr:1.2 ;
 	rdfs:label "W3C SHACL for SHACL Profiling Validator" ;
 	rdfs:comment "This shapes graph can be used to validate SHACL Profiling shapes graphs against a subset of the syntax rules." ;
-    schema:creator "W3C Data Shapes 1.2 Working Group" ;
+    schema:creator "W3C Data Shapes Working Group" ;
     # schema:dateCreated ""^^xsd:date ;
     # schema:dateIssued ""^^xsd:date ;
     # schema:dateModified ""^^xsd:date ;

--- a/shacl12-vocabularies/shacl-shacl-pr.ttl
+++ b/shacl12-vocabularies/shacl-shacl-pr.ttl
@@ -1,0 +1,25 @@
+PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh:   <http://www.w3.org/ns/shacl#>
+PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>
+PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+
+PREFIX shshpr: <http://www.w3.org/ns/shacl-shacl-pr#>
+
+shshpr:
+	rdfs:label "SHACL for SHACL Profiling" ;
+	rdfs:comment "This shapes graph can be used to validate SHACL Profiling shapes graphs against a subset of the syntax rules." ;
+	sh:declare [
+		sh:prefix "shshpr" ;
+		sh:namespace "http://www.w3.org/ns/shacl-shacl-pr#"^^xsd:anyURI ;
+	] ;
+    schema:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
+    schema:creator "W3C Data Shapes 1.2 Working Group" ;
+    schema:dateCreated "2026-03-16"^^xsd:date ;
+    # schema:dateIssued ""^^xsd:date ;
+    schema:dateModified "2026-03-16"^^xsd:date ;
+    schema:version "1.2" ;
+    # rdfs:member
+    #     shpr:conformsTo ;
+.
+

--- a/shacl12-vocabularies/shacl-shacl-pr.ttl
+++ b/shacl12-vocabularies/shacl-shacl-pr.ttl
@@ -4,7 +4,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sh:   <http://www.w3.org/ns/shacl#>
 PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>
 PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
-
+PREFIX schema: <https://schema.org/>
 PREFIX shshpr: <http://www.w3.org/ns/shacl-shacl-pr#>
 
 shshpr:

--- a/shacl12-vocabularies/shacl-shacl.ttl
+++ b/shacl12-vocabularies/shacl-shacl.ttl
@@ -18,7 +18,7 @@ shsh:
     owl:versionIRI shsh:1.2 ;
 	rdfs:label "W3C SHACL for SHACL Validator"@en ;
 	rdfs:comment "This shapes graph can be used to validate SHACL shapes graphs against a subset of the syntax rules."@en ;
-    schema:creator "W3C Data Shapes 1.2 Working Group" ;
+    schema:creator "W3C Data Shapes Working Group" ;
     # schema:dateCreated ""^^xsd:date ;
     # schema:dateIssued ""^^xsd:date ;
     # schema:dateModified ""^^xsd:date ;

--- a/shacl12-vocabularies/shacl-shacl.ttl
+++ b/shacl12-vocabularies/shacl-shacl.ttl
@@ -4,6 +4,7 @@
 
 # THIS VERSION IS UNDER DEVELOPMENT BY THE DATA-SHAPES (SHACL 1.2) WG
 
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh:   <http://www.w3.org/ns/shacl#> .
@@ -12,12 +13,22 @@
 @prefix shsh: <http://www.w3.org/ns/shacl-shacl#> .
 
 shsh:
-	rdfs:label "SHACL for SHACL"@en ;
+    a owl:Ontology ;
+    owl:imports <http://www.w3.org/ns/shacl#> ;
+    owl:versionIRI shsh:1.2 ;
+	rdfs:label "W3C SHACL for SHACL Validator"@en ;
 	rdfs:comment "This shapes graph can be used to validate SHACL shapes graphs against a subset of the syntax rules."@en ;
+    schema:creator "W3C Data Shapes 1.2 Working Group" ;
+    # schema:dateCreated ""^^xsd:date ;
+    # schema:dateIssued ""^^xsd:date ;
+    # schema:dateModified ""^^xsd:date ;
+    schema:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
+    schema:version "1.2" ;
 	sh:declare [
 		sh:prefix "shsh" ;
 		sh:namespace "http://www.w3.org/ns/shacl-shacl#"^^xsd:anyURI ;
-	] .
+	] ;
+.
 
 	
 shsh:ListShape

--- a/shacl12-vocabularies/shacl-shacl.ttl
+++ b/shacl12-vocabularies/shacl-shacl.ttl
@@ -11,6 +11,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 
 @prefix shsh: <http://www.w3.org/ns/shacl-shacl#> .
+@prefix schema: <https://schema.org/> .
 
 shsh:
     a owl:Ontology ;

--- a/shacl12-vocabularies/shacl-ui.ttl
+++ b/shacl12-vocabularies/shacl-ui.ttl
@@ -5,14 +5,14 @@ PREFIX sh:   <http://www.w3.org/ns/shacl#>
 PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>
 PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
 
-PREFIX shshpr: <http://www.w3.org/ns/shacl-shacl-pr#>
+PREFIX shui: <http://www.w3.org/ns/shacl-ui#>
 
-shshpr:
+shui:
 	a owl:Ontology ;
 	owl:imports <http://www.w3.org/ns/shacl#> ;
-	owl:versionIRI shshpr:1.2 ;
-	rdfs:label "W3C SHACL for SHACL Profiling Validator" ;
-	rdfs:comment "This shapes graph can be used to validate SHACL Profiling shapes graphs against a subset of the syntax rules." ;
+	owl:versionIRI shui:1.2 ;
+	rdfs:label "W3C SHACL User Interfaces Vocabulary" ;
+	rdfs:comment "This vocabulary defines terms used in the SHACL User Interfaces specification." ;
     schema:creator "W3C Data Shapes 1.2 Working Group" ;
     # schema:dateCreated ""^^xsd:date ;
     # schema:dateIssued ""^^xsd:date ;
@@ -20,8 +20,8 @@ shshpr:
     schema:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
     schema:version "1.2" ;
 	sh:declare [
-		sh:prefix "shshpr" ;
-		sh:namespace "http://www.w3.org/ns/shacl-shacl-pr#"^^xsd:anyURI ;
+		sh:prefix "shui" ;
+		sh:namespace "http://www.w3.org/ns/shacl-ui#"^^xsd:anyURI ;
 	] ;
 .
 

--- a/shacl12-vocabularies/shacl-ui.ttl
+++ b/shacl12-vocabularies/shacl-ui.ttl
@@ -4,7 +4,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sh:   <http://www.w3.org/ns/shacl#>
 PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>
 PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
-
+PREFIX schema: <https://schema.org/>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui#>
 
 shui:

--- a/shacl12-vocabularies/shacl-ui.ttl
+++ b/shacl12-vocabularies/shacl-ui.ttl
@@ -13,7 +13,7 @@ shui:
 	owl:versionIRI shui:1.2 ;
 	rdfs:label "W3C SHACL User Interfaces Vocabulary" ;
 	rdfs:comment "This vocabulary defines terms used in the SHACL User Interfaces specification." ;
-    schema:creator "W3C Data Shapes 1.2 Working Group" ;
+    schema:creator "W3C Data Shapes Working Group" ;
     # schema:dateCreated ""^^xsd:date ;
     # schema:dateIssued ""^^xsd:date ;
     # schema:dateModified ""^^xsd:date ;

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -15,13 +15,21 @@
 
 sh:
 	a owl:Ontology ;
+	owl:versionIRI sh:1.2 ;
 	rdfs:label "W3C Shapes Constraint Language (SHACL) Vocabulary"@en ;
 	rdfs:comment "This vocabulary defines terms used in SHACL, the W3C Shapes Constraint Language."@en ;
+    schema:creator "W3C Data Shapes 1.2 Working Group" ;
+    # schema:dateCreated ""^^xsd:date ;
+    # schema:dateIssued ""^^xsd:date ;
+    # schema:dateModified ""^^xsd:date ;
+    schema:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
+    schema:version "1.2" ;
 	sh:declare [
 		sh:prefix "sh" ;
 		sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
 	] ;
-	sh:suggestedShapesGraph <http://www.w3.org/ns/shacl-shacl#> .
+	sh:suggestedShapesGraph <http://www.w3.org/ns/shacl-shacl#> ;
+.
 
 
 # Shapes vocabulary -----------------------------------------------------------

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -10,7 +10,7 @@
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
-
+@prefix schema: <https://schema.org/> .
 @prefix sh:   <http://www.w3.org/ns/shacl#> .
 
 sh:

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -18,7 +18,7 @@ sh:
 	owl:versionIRI sh:1.2 ;
 	rdfs:label "W3C Shapes Constraint Language (SHACL) Vocabulary"@en ;
 	rdfs:comment "This vocabulary defines terms used in SHACL, the W3C Shapes Constraint Language."@en ;
-    schema:creator "W3C Data Shapes 1.2 Working Group" ;
+    schema:creator "W3C Data Shapes Working Group" ;
     # schema:dateCreated ""^^xsd:date ;
     # schema:dateIssued ""^^xsd:date ;
     # schema:dateModified ""^^xsd:date ;

--- a/shacl12-vocabularies/shnex-sparql.ttl
+++ b/shacl12-vocabularies/shnex-sparql.ttl
@@ -17,13 +17,21 @@
 
 shnex-sparql:
 	a owl:Ontology ;
-	rdfs:label "W3C SHACL SPARQL Functions Vocabulary"@en ;
-	rdfs:comment "This vocabulary defines SPARQL functions for use with SHACL."@en ;
+	owl:imports <http://www.w3.org/ns/shacl-node-expr#>  ;
+	owl:versionIRI shnex-sparql:1.2 ;
+	rdfs:label "W3C SHACL SPARQL Extensions Vocabulary"@en ;
+	rdfs:comment "This vocabulary defines terms used in the SHACL SPARQL specification."@en ;
+    schema:creator "W3C Data Shapes 1.2 Working Group" ;
+    # schema:dateCreated ""^^xsd:date ;
+    # schema:dateIssued ""^^xsd:date ;
+    # schema:dateModified ""^^xsd:date ;
+    schema:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
+    schema:version "1.2" ;
 	sh:declare [
-		sh:prefix "sparql" ;
-		sh:namespace "http://www.w3.org/ns/sparql#"^^xsd:anyURI ;
+		sh:prefix "shnex-sparql" ;
+		sh:namespace "http://www.w3.org/ns/shacl-node-expr-sparql#"^^xsd:anyURI ;
 	] ;
-	owl:imports <http://www.w3.org/ns/shacl-node-expr#>  .
+.
 
 
 shnex-sparql:category

--- a/shacl12-vocabularies/shnex-sparql.ttl
+++ b/shacl12-vocabularies/shnex-sparql.ttl
@@ -14,6 +14,7 @@
 @prefix shnex: <http://www.w3.org/ns/shacl-node-expr#> .
 @prefix shnex-sparql: <http://www.w3.org/ns/shacl-node-expr-sparql#> .
 @prefix sparql:  <http://www.w3.org/ns/sparql#> .
+@prefix schema: <https://schema.org/> .
 
 shnex-sparql:
 	a owl:Ontology ;

--- a/shacl12-vocabularies/shnex-sparql.ttl
+++ b/shacl12-vocabularies/shnex-sparql.ttl
@@ -21,7 +21,7 @@ shnex-sparql:
 	owl:versionIRI shnex-sparql:1.2 ;
 	rdfs:label "W3C SHACL SPARQL Extensions Vocabulary"@en ;
 	rdfs:comment "This vocabulary defines terms used in the SHACL SPARQL specification."@en ;
-    schema:creator "W3C Data Shapes 1.2 Working Group" ;
+    schema:creator "W3C Data Shapes Working Group" ;
     # schema:dateCreated ""^^xsd:date ;
     # schema:dateIssued ""^^xsd:date ;
     # schema:dateModified ""^^xsd:date ;

--- a/shacl12-vocabularies/shnex.ttl
+++ b/shacl12-vocabularies/shnex.ttl
@@ -16,13 +16,21 @@
 
 shnex:
 	a owl:Ontology ;
+	owl:imports <http://www.w3.org/ns/shacl#> ;
+	owl:versionIRI shnex:1.2 ;
 	rdfs:label "W3C SHACL Node Expressions Vocabulary"@en ;
-	rdfs:comment "This vocabulary defines Node Expression functions built into compliant SHACL engines."@en ;
+	rdfs:comment "This vocabulary defines terms used in the SHACL Node Expressions specification."@en ;
+    schema:creator "W3C Data Shapes 1.2 Working Group" ;
+    # schema:dateCreated ""^^xsd:date ;
+    # schema:dateIssued ""^^xsd:date ;
+    # schema:dateModified ""^^xsd:date ;
+    schema:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
+    schema:version "1.2" ;
 	sh:declare [
 		sh:prefix "shnex" ;
 		sh:namespace "http://www.w3.org/ns/shacl-node-expr#"^^xsd:anyURI ;
 	] ;
-	owl:imports <http://www.w3.org/ns/shacl#> .
+.
 
 
 shnex:nodes

--- a/shacl12-vocabularies/shnex.ttl
+++ b/shacl12-vocabularies/shnex.ttl
@@ -10,7 +10,7 @@
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
-
+@prefix schema: <https://schema.org/> .
 @prefix sh:    <http://www.w3.org/ns/shacl#> .
 @prefix shnex: <http://www.w3.org/ns/shacl-node-expr#> .
 

--- a/shacl12-vocabularies/shnex.ttl
+++ b/shacl12-vocabularies/shnex.ttl
@@ -20,7 +20,7 @@ shnex:
 	owl:versionIRI shnex:1.2 ;
 	rdfs:label "W3C SHACL Node Expressions Vocabulary"@en ;
 	rdfs:comment "This vocabulary defines terms used in the SHACL Node Expressions specification."@en ;
-    schema:creator "W3C Data Shapes 1.2 Working Group" ;
+    schema:creator "W3C Data Shapes Working Group" ;
     # schema:dateCreated ""^^xsd:date ;
     # schema:dateIssued ""^^xsd:date ;
     # schema:dateModified ""^^xsd:date ;


### PR DESCRIPTION
* added some standard properties for all SHACL RDF resources:
    * `owl:versionIRI`
    * `schema:version "1.2" ;`
    * `schema:creator "W3C Data Shapes Working Group" ;`
    * `schema:dateCreated` - placeholder
    * `schema:dateIssued` - placeholder
    * `schema:dateModified` - placeholder
* starts the SHACL Profiling ontology
* adds a SHACL UI ontology stub