### PR TITLE
address GH#573 -- Allow `sh:severity` at SPARQL constraints

### DIFF
--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -657,6 +657,8 @@ ex:
 					and these are <a>literals</a> with <a>datatype</a> <code>xsd:string</code>, <code>rdf:dirLangString</code>, <code>rdf:langString</code>, or <code>rdf:HTML</code>.</span>
 					<span data-syntax-rule="SPARQLConstraint-deactivated-maxCount"><a>SPARQL-based constraints</a> may have at most one value for the property <code>sh:deactivated</code></span>
 					and this value is either <code>true</code> or <code>false</code>.
+					<span data-syntax-rule="SPARQLConstraint-severity"><a>SPARQL-based constraints</a> may have at most one value for the property <code>sh:severity</code>
+					and this value is an <a>IRI</a>.</span>
 				</p>
 				<p>
 					SELECT queries used in the context of <a>property shapes</a> use a special variable named <code>PATH</code> as a placeholder for the path used by the shape.
@@ -783,6 +785,8 @@ ex:
 						specified via <code>sh:path</code> at the <a>property shape</a>.
 						<span id="sparql-constraints-validation-rule">There is one <a>validation result</a> for each <a>solution</a> that does not have <code>true</code> as the <a>binding</a> for the variable <code>failure</code>.
 						These <a>validation results</a> MUST have the property values explained in <a href="#sparql-constraints-variables"></a>.
+						If <code>$sparql</code> has a <a>value</a> for <code>sh:severity</code> then the <a>validation result</a> MUST
+						have that value as its (only) <code>sh:resultSeverity</code>.
 						A <a>failure</a> MUST be produced if and only if one of the <a>solutions</a> has <code>true</code> as the <a>binding</a> for <code>failure</code>.</span>
 					</div>
 				</div>
@@ -2016,6 +2020,7 @@ WHERE {
 				<li>Added the <a>node expression function</a> <a href="#SPARQLExprExpression"><code>sh:SPARQLExprExpression</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/315">Issue 315</a></li>
 				<li>Clarified that VALUES clauses are only disallowed when they mention <a href="#pre-binding">pre-bound variables</a> and removed the restriction on sub-SELECTs, see <a href="https://github.com/w3c/data-shapes/issues/159">Issue 159</a></li>
 				<li>Removed support for the optional pre-bound variables <code>shapesGraph</code> and <code>currentShape</code>, see <a href="https://github.com/w3c/data-shapes/issues/426">Issue 426</a></li>
+				<li>SPARQL constraints can now directly specify a <code>sh:severity</code>, see <a href="https://github.com/w3c/data-shapes/issues/573">Issue 573</a></li>
 			</ul>
 		</section>
 	</body>

--- a/shacl12-test-suite/tests/sparql/node/sparql-001.ttl
+++ b/shacl12-test-suite/tests/sparql/node/sparql-001.ttl
@@ -33,6 +33,7 @@ ex:TestShape-sparql
 		$this ?path ?value .
 		FILTER (?path = <http://www.w3.org/2000/01/rdf-schema#label>) .
 	}""" ;
+  sh:severity sh:Warning ;
 .
 ex:ValidResource1
   rdf:type rdfs:Resource ;
@@ -58,7 +59,7 @@ ex:ValidResource1
           sh:focusNode ex:InvalidResource1 ;
           sh:resultMessage "Cannot have a label" ;
           sh:resultPath rdfs:label ;
-          sh:resultSeverity sh:Violation ;
+          sh:resultSeverity sh:Warning ;
           sh:sourceConstraint ex:TestShape-sparql ;
           sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
           sh:sourceShape ex:TestShape ;
@@ -69,7 +70,7 @@ ex:ValidResource1
           sh:focusNode ex:InvalidResource2 ;
           sh:resultMessage "Cannot have a label" ;
           sh:resultPath rdfs:label ;
-          sh:resultSeverity sh:Violation ;
+          sh:resultSeverity sh:Warning ;
           sh:sourceConstraint ex:TestShape-sparql ;
           sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
           sh:sourceShape ex:TestShape ;
@@ -80,7 +81,7 @@ ex:ValidResource1
           sh:focusNode ex:InvalidResource2 ;
           sh:resultMessage "Cannot have a label" ;
           sh:resultPath rdfs:label ;
-          sh:resultSeverity sh:Violation ;
+          sh:resultSeverity sh:Warning ;
           sh:sourceConstraint ex:TestShape-sparql ;
           sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
           sh:sourceShape ex:TestShape ;


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #573

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-573/shacl12-sparql/index.html)

Sorry I don't see my co-editor of the SHACL-SPARQL spec in the list of reviewers, so I need someone else to review this.
