### PR TITLE
Dependency graph: Triple patterns inside negation elements

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -486,8 +486,8 @@ RULE { ?x :name ?FN } WHERE {
 
           <dt><dfn>Negation element</dfn></dt>
           <dd>
-            A [=negation element=] is a [=rule body element=].
-            It takes a sequence of [=triple patterns=] and
+            A [=negation element=] is a [=rule body element=]
+            comprised of a sequence of [=triple pattern elements=] and
             [=condition elements=].
           </dd>
 
@@ -690,7 +690,7 @@ RULE { ?x :name ?FN } WHERE {
             The following algorithm gives one
             possible method for constructing the [=dependency graph=] from a
             [=rule set=]. Conformance depends on the dependency definitions 
-			in this section, not on use of this procedure.
+            in this section, not on use of this procedure.
           </p>
           <div class="algorithm">
             <pre>
@@ -711,27 +711,34 @@ define buildDependencyGraph(ruleSet):
         endif
         enddefine
 
+    ## Classify all triple patterns in a rule, looking inside negation elements.
     foreach rule R1 in ruleSet:
 
         let bodyDependencies = {}
-        foreach triplePatternElement TP in the body of R1:
-            let item be a new pair (triplePattern, depLabel)
-            item.triplePattern = TP
-            if TP is a negation element:
-                item.depLabel="negative"
-            else:
-                item.depLabel="positive"
-            add item to bodyDependencies
+        foreach rule body element RBE in the body of R1:
+            if RBE is a negation element:
+                foreach triple pattern element TPE in RBE:
+                    let item be a pair (TPE, "negative")
+                    add item to bodyDependencies
+                endfor
+            else if RBE is a triple pattern element:
+                let item be a pair (RBE, "postive")
+                add item to bodyDependencies
+            else if RBE is a condition element:
+                ## Do nothing
+            else if RBE is an assignment element:
+                ## Do nothing
+            endif
         endfor
 
-        foreach pair (triplePattern bodyTP, depLabel) in bodyDependencies:
+        foreach pair ( triple pattern TP, depLabel) in bodyDependencies:
 
             foreach rule R2 in ruleSet:
-                foreach triple template TT in head of R2:
 
+                foreach triple template TT in head of R2:
                     ## "possibly generate" / matching is defined in
                     ## 3.3 Rule Dependency.
-                    if TT can possibly generate a triple matching bodyTP:
+                    if TT can possibly generate a triple pattern TP:
                         let key = (R1, R2)
                         if edgeLabelMap contains key:
                             let oldLabel = edgeLabelMap.get(key)
@@ -741,9 +748,10 @@ define buildDependencyGraph(ruleSet):
                             edgeLabelMap.set(key, depLabel)
                         endif
                     endif
-
                 endfor
+
             endfor
+
         endfor
     endfor
 


### PR DESCRIPTION
The dependency graph algorithm needs to look inside negation elements to find triple patterns.

<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

* [See the algorithm rendered online here](https://raw.githack.com/w3c/data-shapes/afs/dependency-graph-negation-elements/shacl12-rules/index.html#dependency-graph-construction-algorithm)
