### PR TITLE
Prepare rule set for evaluation

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -1124,7 +1124,7 @@ PREFIX sparql: &lt;http://www.w3.org/ns/sparql#&gt;
     </section>
 
     <section id="rule-set-evaluation">
-      <h3>Rule Set Evaluation</h3>
+      <h2>Rule Set Evaluation</h2>
       <p>
         This section defines the outcome of evaluating a rule set on given data.
         It does not prescribe the algorithm as the method of implementation.
@@ -1142,7 +1142,7 @@ Output: an RDF graph GI of inferred triples
       </p>
 
       <section id="rule-eval-definitions">
-      <h4>Evaluation Definitions</h4>
+        <h3>Evaluation Definitions</h3>
 
         <dl>
           <dt><dfn 
@@ -1254,9 +1254,74 @@ merge(S1, S2) = { <var>μ</var> |
         </dl>
       </section>
 
-      <section id="eval-expression">
-        <h4>Evaluation of an Expression</h4>        
+      <section id="evaluation-preparation">
+        <h3>Preparation for Evaluation</h3>
+        <p>
+          The first step in evaluating a [=rule set=] is to prepare a single,
+          valid rule set. This involves gathering all imported rule sets, building
+          a single, combined rule set, and then calculating the stratification for
+          the combined rule set.
+        </p>
 
+        <section id="process-imports">
+          <h4>Process Imports</h4>
+          <p>
+            @@Walk imports - visit only once@@
+          </p>
+          <p class="ednote">
+            @@TODO: consider defining a rule set as having two components and a
+            separate set of imports. i.e. imports are in the parsing and sorted out 
+            to give a usable "rule set" of "rules + data"
+          </p>
+          <div class="def">
+            <p>
+            A [=rule set=] has three components: R.rules, R.data and R.imports.
+            The <dfn>rule set merge</dfn> of two rule sets RS1 and RS2 giving
+            rule set MR:
+            </p>
+            <pre>
+                MR.rules = RS1.rules &cups; RS2.rules
+                MR.data = merge(RS1.data, RS2.data)
+                MR.imports = {}
+            </pre>
+            <p>
+              where `merge` is the 
+              <a data-cite="RDF12-SEMANTICS#dfn-rdf-graph-merge">RDF merge</a>
+              operation.
+            </p>
+          </div>
+
+          <div class="algorithm"><pre>
+define imports(rule set RS, set of URLs V), returning rule set
+    let I = the set of import URLs declared for the rule set RS
+    let RS2 = RS
+    foreach URL x in I:
+       if x &notin; V:
+           V = V &cups; { x }
+           read rule set RS3 from URL x
+           RS2 = rulesetMerge(RS2, imports(RS3, V))
+        endif
+    endfor
+    result is RS2
+enddefine
+
+let RS be a ruleset
+let V = {}
+if RS has a location, V = { location of RS }
+result is imports(RS, V)
+</pre>
+          </div>
+        </section>
+        <section id="calculate-stratification">
+          <h4>Calculate Stratification</h4>
+          <p>@@ See <a href="#stratification-algorithm" class="sectionRef"></a>
+          </p>
+        </section>
+
+      </section>
+
+      <section id="eval-expression">
+        <h3>Evaluation of an Expression</h3>
         <p class=ednote>Sketch</p>
         <div class="algorithm">
 <pre>
@@ -1275,7 +1340,7 @@ define evalFunction(F, <var>μ</var>):
       </section>
 
       <section id="eval-rule">
-        <h4>Evaluation of a Rule</h4>
+        <h3>Evaluation of a Rule</h3>
         <div  class="algorithm">
 <pre>
 let R be a well-formed rule.
@@ -1369,7 +1434,7 @@ result eval(R, G) is H
       </section>
 
       <section id="eval-rule-set">
-        <h4>Evaluation of a Rule Set</h4>
+        <h3>Evaluation of a Rule Set</h3>
 
         <div class="algorithm">
 <pre>


### PR DESCRIPTION
Add a section to prepare a ruleset for evaluation : calculate the imports closure, perform stratification on the closure.


<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

* [See the section on preparation for evaluation](https://raw.githack.com/w3c/data-shapes/afs/imports/shacl12-rules/index.html#evaluation-preparation)
