### PR TITLE
Add support for owl:versionIRI

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2100,8 +2100,8 @@ ex:SomeClass-alternativePathExample
 					In the following example, the shapes graph imports <code>&lt;http://example.com/shapes/company/v2&gt;</code>.
 					When the processor retrieves the graph at that IRI,
 					it finds that IRI declared as the <code>owl:versionIRI</code> of <code>&lt;http://example.com/shapes/company&gt;</code>.
-					The processor then uses <code>&lt;http://example.com/shapes/company&gt;</code> as the canonical identity of that graph
-					to follow further <code>owl:imports</code> statements, in this case importing <code>&lt;http://example.com/shapes/base&gt;</code>.
+					The processor then uses <code>&lt;http://example.com/shapes/company&gt;</code> to identify that graph
+					when following further <code>owl:imports</code> statements, in this case importing <code>&lt;http://example.com/shapes/base&gt;</code>.
 				</p>
 
 				<aside class="example" title="Importing a versioned shapes graph using owl:versionIRI">

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2245,7 +2245,7 @@ ex:CompanyShape
 					A <a>data graph</a> can include triples used to suggest one or more graphs to a SHACL processor with the predicate <code>sh:shapesGraph</code>.
 					<span data-syntax-rule="shapesGraph-nodeKind">Every <a>value</a> of <code>sh:shapesGraph</code> is an <a>IRI</a></span> representing a graph that SHOULD be included into the <a>shapes graph</a> used to validate the <a>data graph</a>.
 					The value of <code>sh:shapesGraph</code> may be a value of <a data-cite="owl2-syntax/#Ontology_IRI_and_Version_IRI"><code>owl:versionIRI</code></a>,
-					so the same version IRI resolution strategy described for <a href="#shapes-graph">Shapes Graphs</a> applies here.
+					so the same strategy of resolving a shapes graph IRI from a version IRI, described for <a href="#shapes-graph">Shapes Graphs</a>, applies here.
 				</p>
 				<p>
 					In the following example, a SHACL processor SHOULD use the union of <code>ex:graph-shapes1</code> and <code>ex:graph-shapes2</code> graphs (and their <code>owl:imports</code>) as the <a>shapes graph</a> when validating the given graph.

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2095,6 +2095,97 @@ ex:SomeClass-alternativePathExample
 					for the purpose of following further <code>owl:imports</code> statements.
 					Formally, processors SHOULD use the property path <code>^owl:versionIRI?/owl:imports</code> iteratively
 					to resolve imports, so that version IRIs can be used to import versioned shapes graphs.
+				</p>
+				<p>
+					In the following example, the shapes graph imports <code>&lt;http://example.com/shapes/company/v2&gt;</code>.
+					When the processor retrieves the graph at that IRI,
+					it finds that IRI declared as the <code>owl:versionIRI</code> of <code>&lt;http://example.com/shapes/company&gt;</code>.
+					The processor then uses <code>&lt;http://example.com/shapes/company&gt;</code> as the canonical identity of that graph
+					to follow further <code>owl:imports</code> statements, in this case importing <code>&lt;http://example.com/shapes/base&gt;</code>.
+				</p>
+
+				<aside class="example" title="Importing a versioned shapes graph using owl:versionIRI">
+					<div class="shapes-graph">
+						<div class="turtle">
+# Shapes graph that imports a versioned shapes module
+&lt;http://example.com/shapes/myapp&gt;
+	owl:imports &lt;http://example.com/shapes/company/v2&gt; .
+
+ex:PersonShape
+	a sh:NodeShape ;
+	sh:targetClass ex:Person ;
+	sh:property [
+		sh:path ex:worksFor ;
+		sh:class ex:Company ;
+	] .
+						</div>
+						<div class="jsonld">
+							<pre class="jsonld">{
+	"@graph": [
+		{
+			"@id": "http://example.com/shapes/myapp",
+			"owl:imports": {
+				"@id": "http://example.com/shapes/company/v2"
+			}
+		},
+		{
+			"@id": "ex:PersonShape",
+			"@type": "sh:NodeShape",
+			"sh:targetClass": { "@id": "ex:Person" },
+			"sh:property": {
+				"sh:path": { "@id": "ex:worksFor" },
+				"sh:class": { "@id": "ex:Company" }
+			}
+		}
+	]
+}</pre>
+						</div>
+					</div>
+					<div class="shapes-graph">
+						<div class="turtle">
+# Graph retrieved from &lt;http://example.com/shapes/company/v2&gt;
+&lt;http://example.com/shapes/company&gt;
+	owl:versionIRI &lt;http://example.com/shapes/company/v2&gt; ;
+	owl:imports &lt;http://example.com/shapes/base&gt; .
+
+ex:CompanyShape
+	a sh:NodeShape ;
+	sh:targetClass ex:Company ;
+	sh:property [
+		sh:path ex:name ;
+		sh:minCount 1 ;
+		sh:datatype xsd:string ;
+	] .
+						</div>
+						<div class="jsonld">
+							<pre class="jsonld">{
+	"@graph": [
+		{
+			"@id": "http://example.com/shapes/company",
+			"owl:versionIRI": {
+				"@id": "http://example.com/shapes/company/v2"
+			},
+			"owl:imports": {
+				"@id": "http://example.com/shapes/base"
+			}
+		},
+		{
+			"@id": "ex:CompanyShape",
+			"@type": "sh:NodeShape",
+			"sh:targetClass": { "@id": "ex:Company" },
+			"sh:property": {
+				"sh:path": { "@id": "ex:name" },
+				"sh:minCount": 1,
+				"sh:datatype": { "@id": "xsd:string" }
+			}
+		}
+	]
+}</pre>
+						</div>
+					</div>
+				</aside>
+
+				<p>
 					The resulting graph forms the input <a>shapes graph</a> for validation and MUST NOT be further modified during the validation process.
 				</p>
 				<p>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2089,6 +2089,12 @@ ex:SomeClass-alternativePathExample
 					Shapes graphs can be reusable validation modules that can be cross-referenced with the predicate <a data-cite="owl2-syntax/#Imports"><code>owl:imports</code></a>.
 					As a pre-validation step, SHACL processors SHOULD extend the originally provided <a>shapes graph</a> by transitively following and importing all referenced <a>shapes graphs</a>
 					through the <a data-cite="owl2-syntax/#Imports"><code>owl:imports</code></a> predicate.
+					When resolving an imported IRI, if the retrieved graph contains a triple with the imported IRI as the object of
+					<a data-cite="owl2-syntax/#Ontology_IRI_and_Version_IRI"><code>owl:versionIRI</code></a>,
+					the processor SHOULD treat the subject of that triple as the canonical identity of the imported graph
+					for the purpose of following further <code>owl:imports</code> statements.
+					Formally, processors SHOULD use the property path <code>^owl:versionIRI?/owl:imports</code> iteratively
+					to resolve imports, so that version IRIs can be used to import versioned shapes graphs.
 					The resulting graph forms the input <a>shapes graph</a> for validation and MUST NOT be further modified during the validation process.
 				</p>
 				<p>
@@ -2147,6 +2153,8 @@ ex:SomeClass-alternativePathExample
 				<p class="syntax">
 					A <a>data graph</a> can include triples used to suggest one or more graphs to a SHACL processor with the predicate <code>sh:shapesGraph</code>.
 					<span data-syntax-rule="shapesGraph-nodeKind">Every <a>value</a> of <code>sh:shapesGraph</code> is an <a>IRI</a></span> representing a graph that SHOULD be included into the <a>shapes graph</a> used to validate the <a>data graph</a>.
+					The value of <code>sh:shapesGraph</code> may be a value of <a data-cite="owl2-syntax/#Ontology_IRI_and_Version_IRI"><code>owl:versionIRI</code></a>,
+					so the same version IRI resolution strategy described for <a href="#shapes-graph">Shapes Graphs</a> applies here.
 				</p>
 				<p>
 					In the following example, a SHACL processor SHOULD use the union of <code>ex:graph-shapes1</code> and <code>ex:graph-shapes2</code> graphs (and their <code>owl:imports</code>) as the <a>shapes graph</a> when validating the given graph.

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2091,7 +2091,7 @@ ex:SomeClass-alternativePathExample
 					through the <a data-cite="owl2-syntax/#Imports"><code>owl:imports</code></a> predicate.
 					When resolving an imported IRI, if the retrieved graph contains a triple with the imported IRI as the object of
 					<a data-cite="owl2-syntax/#Ontology_IRI_and_Version_IRI"><code>owl:versionIRI</code></a>,
-					the processor SHOULD treat the subject of that triple as the canonical identity of the imported graph
+					the processor SHOULD treat the subject of that triple as the shapes graph IRI of the imported graph
 					for the purpose of following further <code>owl:imports</code> statements.
 					Formally, processors SHOULD use the property path <code>^owl:versionIRI?/owl:imports</code> iteratively
 					to resolve imports, so that version IRIs can be used to import versioned shapes graphs.

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -745,8 +745,11 @@ ex:
 					<p class="syntax">
 						<span data-syntax-rule="prefixes-nodeKind">The values of <code>sh:prefixes</code> are either <a>IRIs</a> or <a>blank nodes</a>.</span>
 						<span data-syntax-rule="prefixes-duplicates">A SHACL processor collects a set of prefix mappings as the union of all
-						individual prefix mappings that are <a>values</a> of the <a>SPARQL property path</a> <code>sh:prefixes/owl:imports*/sh:declare</code>
+						individual prefix mappings that are <a>values</a> of the <a>SPARQL property path</a> <code>sh:prefixes/(^owl:versionIRI?/owl:imports)*/sh:declare</code>
 						of the <a>SPARQL-based constraint</a> or <a>validator</a>.
+						The <code>^owl:versionIRI?</code> element supports graphs that are imported by
+						<a data-cite="owl2-syntax/#Ontology_IRI_and_Version_IRI"><code>owl:versionIRI</code></a>,
+						navigating from the version IRI to the ontology IRI before following further <code>owl:imports</code>.
 						If such a collection of prefix declarations contains multiple different namespaces for the same <a>value</a> of <code>sh:prefix</code>,
 						then the <a>shapes graph</a> is <a>ill-formed</a>.</span>
 						(Note that SHACL processors MAY ignore prefix declarations that are never reached).

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -749,7 +749,7 @@ ex:
 						of the <a>SPARQL-based constraint</a> or <a>validator</a>.
 						The <code>^owl:versionIRI?</code> element supports graphs that are imported by
 						<a data-cite="owl2-syntax/#Ontology_IRI_and_Version_IRI"><code>owl:versionIRI</code></a>,
-						navigating from the version IRI to the ontology IRI before following further <code>owl:imports</code>.
+						navigating from the version IRI to the shapes graph IRI before following further <code>owl:imports</code>.
 						If such a collection of prefix declarations contains multiple different namespaces for the same <a>value</a> of <code>sh:prefix</code>,
 						then the <a>shapes graph</a> is <a>ill-formed</a>.</span>
 						(Note that SHACL processors MAY ignore prefix declarations that are never reached).


### PR DESCRIPTION
This adds support for `owl:versionIRI` in shapes graph import resolution and SPARQL prefix declaration lookup. When a shapes graph is imported by its version IRI, processors should now navigate from the version IRI to the ontology IRI before following further `owl:imports` or `sh:declare` paths.

<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #830

* [See the Core document rendered online here](https://raw.githack.com/w3c/data-shapes/830-support-for-owlversioniri/shacl12-core/index.html)
* [See the SPARQL document rendered online here](https://raw.githack.com/w3c/data-shapes/830-support-for-owlversioniri/shacl12-sparql/index.html)
