### PR TITLE
Add Ariadne SHACL EARL report (121/121)

### DIFF
--- a/data-shapes-test-suite/reports/ariadne-shacl-earl.ttl
+++ b/data-shapes-test-suite/reports/ariadne-shacl-earl.ttl
@@ -14,6 +14,11 @@
   doap:description "Graph database in Common Lisp" ;
   doap:programming-language "Common Lisp" ;
   doap:homepage <https://sr.ht/~hajovonta/ariadne> ;
+  doap:release [
+    rdf:type doap:Version ;
+    doap:revision "0.1.0" ;
+    doap:created "2026-04-15"^^xsd:date ;
+  ] ;
 .
 [
   rdf:type earl:Assertion ;

--- a/data-shapes-test-suite/reports/ariadne-shacl-earl.ttl
+++ b/data-shapes-test-suite/reports/ariadne-shacl-earl.ttl
@@ -1,0 +1,1348 @@
+# baseURI: https://sr.ht/~hajovonta/ariadne/earl
+
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://sr.ht/~hajovonta/ariadne>
+  rdf:type doap:Project ;
+  rdf:type earl:Software ;
+  rdf:type earl:TestSubject ;
+  doap:name "Ariadne" ;
+  doap:description "Graph database in Common Lisp" ;
+  doap:programming-language "Common Lisp" ;
+  doap:homepage <https://sr.ht/~hajovonta/ariadne> ;
+.
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/complex/personexample> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/complex/shacl-shacl> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/misc/deactivated-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/misc/deactivated-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/misc/message-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/misc/severity-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/misc/severity-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/and-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/and-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/class-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/class-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/class-003> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/closed-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/closed-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/datatype-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/datatype-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/disjoint-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/equals-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/hasValue-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/in-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/languageIn-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/maxExclusive-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/maxInclusive-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/maxLength-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/minExclusive-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/minInclusive-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/minInclusive-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/minInclusive-003> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/minLength-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/node-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/nodeKind-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/not-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/not-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/or-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/pattern-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/pattern-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/qualified-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/xone-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/node/xone-duplicate> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/and-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/class-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/datatype-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/datatype-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/datatype-003> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/datatype-ill-formed> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/disjoint-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/equals-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/hasValue-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/in-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/languageIn-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/lessThan-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/lessThan-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/lessThanOrEquals-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/maxCount-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/maxCount-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/maxExclusive-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/maxInclusive-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/maxLength-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/minCount-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/minCount-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/minExclusive-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/minExclusive-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/minLength-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/node-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/node-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/nodeKind-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/not-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/or-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/or-datatypes-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/pattern-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/pattern-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/property-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/qualifiedMinCountDisjoint-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/qualifiedValueShape-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/qualifiedValueShapesDisjoint-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/uniqueLang-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/property/uniqueLang-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/path/path-alternative-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/path/path-complex-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/path/path-complex-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/path/path-inverse-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/path/path-oneOrMore-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/path/path-sequence-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/path/path-sequence-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/path/path-sequence-duplicate-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/path/path-strange-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/path/path-strange-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/path/path-unused-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/path/path-zeroOrMore-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/path/path-zeroOrOne-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/targets/multipleTargets-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/targets/targetClass-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/targets/targetClassImplicit-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/targets/targetNode-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/targets/targetObjectsOf-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/targets/targetSubjectsOf-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/targets/targetSubjectsOf-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/core/validation-reports/shared> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/component/nodeValidator-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/component/optional-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/component/propertyValidator-select-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/component/validator-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/node/prefixes-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/node/sparql-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/node/sparql-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/node/sparql-003> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/property/sparql-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/pre-binding/pre-binding-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/pre-binding/pre-binding-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/pre-binding/pre-binding-003> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/pre-binding/pre-binding-004> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/pre-binding/pre-binding-005> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/pre-binding/pre-binding-006> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/pre-binding/pre-binding-007> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/pre-binding/shapesGraph-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/pre-binding/unsupported-sparql-001> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/pre-binding/unsupported-sparql-002> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/pre-binding/unsupported-sparql-003> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/pre-binding/unsupported-sparql-004> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/pre-binding/unsupported-sparql-005> ;
+].
+[
+  rdf:type earl:Assertion ;
+  earl:assertedBy <https://sr.ht/~hajovonta> ;
+  earl:result [
+      rdf:type earl:TestResult ;
+      earl:mode earl:automatic ;
+      earl:outcome earl:passed ;
+    ] ;
+  earl:subject <https://sr.ht/~hajovonta/ariadne> ;
+  earl:test <urn:x-shacl-test:/sparql/pre-binding/unsupported-sparql-006> ;
+].


### PR DESCRIPTION
Ariadne is a graph database implemented in Common Lisp. This report covers all 121 tests in the SHACL test suite (98 Core + 23 SPARQL), all passing.
 
Homepage: https://sr.ht/~hajovonta/ariadne
