### PR TITLE
Handling of possible import closure incompatibilities due to owl:versionIRI

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -6423,6 +6423,7 @@ ex:NameGroup
 				<li>Added the new constraint component <a href="#SubsetOfConstraintComponent"><code>sh:subsetOf</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/786">Issue 786</a></li>
 				<li>Added the graph types <code>sh:DataGraph</code> and <code>sh:ShapesGraph</code>; see <a href="https://github.com/w3c/data-shapes/issues/169">Issue 169</a></li>
 				<li>Added the new constraint component <a href="#UniqueValuesForConstraintComponent"><code>sh:uniqueValuesFor</code></a>, see <a href="https://github.com/w3c/data-shapes/issues/661">Issue 661</a></li>
+				<li>Added support for <a data-cite="owl2-syntax/#Ontology_IRI_and_Version_IRI"><code>owl:versionIRI</code></a> in <a href="#shapes-graph">shapes graph</a> imports, and expanded the definition of <a>well-formed</a> shapes graphs to include import closure constraints from [[owl2-syntax]]; see <a href="https://github.com/w3c/data-shapes/issues/830">Issue 830</a></li>
 			</ul>
 		</section>
   </body>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -505,7 +505,7 @@
 					<li>It contains no <a>ill-formed</a> nodes (i.e., all nodes satisfy the syntax rules mentioned above).</li>
 					<li>Its import closure (as determined by transitively following
 						<a data-cite="owl2-syntax/#Imports"><code>owl:imports</code></a> statements)
-						satisfies the constraints defined by [[owl2-syntax]], namely that it does not contain two shapes graphs such that:
+						satisfies the constraints defined by [[owl2-syntax]], namely that it does not contain two shapes graphs where:
 						<ul>
 							<li>
 								they are different versions of the same series

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -497,7 +497,30 @@
 					The complete list of these rules can be found in the <a href="#syntax-rules">appendix</a>.
 					Nodes that violate any of these rules are called <dfn>ill-formed</dfn>.
 					Nodes that violate none of these rules are called <dfn>well-formed</dfn>.
-					A <a>shapes graph</a> is ill-formed if it contains at least one ill-formed node.
+				</p>
+				<p>
+					A <a>shapes graph</a> is <a>well-formed</a> if all of the following conditions hold:
+				</p>
+				<ol>
+					<li>It contains no <a>ill-formed</a> nodes (i.e., all nodes satisfy the syntax rules mentioned above).</li>
+					<li>Its import closure (as determined by transitively following
+						<a data-cite="owl2-syntax/#Imports"><code>owl:imports</code></a> statements)
+						satisfies the constraints defined by [[owl2-syntax]], namely that it does not contain two shapes graphs such that:
+						<ul>
+							<li>
+								they are different versions of the same series
+								(i.e., they share the same shapes graph IRI but have different
+								<a data-cite="owl2-syntax/#Ontology_IRI_and_Version_IRI"><code>owl:versionIRI</code></a> values), or
+							</li>
+							<li>
+								one contains an <code>owl:incompatibleWith</code> annotation whose value is equal to
+								either the shapes graph IRI or the <code>owl:versionIRI</code> of the other.
+							</li>
+						</ul>
+					</li>
+				</ol>
+				<p>
+					A <a>shapes graph</a> that is not <a>well-formed</a> is <a>ill-formed</a>.
 				</p>
 			</section>
 
@@ -2193,6 +2216,13 @@ ex:CompanyShape
 				<p>
 					The resulting graph forms the input <a>shapes graph</a> for validation and MUST NOT be further modified during the validation process.
 				</p>
+				<p class="note">
+					When using <code>owl:versionIRI</code> to import versioned shapes graphs, care should be taken to
+					avoid importing incompatible versions. In particular, the import closure of a shapes graph
+					SHOULD NOT contain two graphs that are different versions of the same series, or where one
+					declares <code>owl:incompatibleWith</code> the other. Such a shapes graph is considered
+					<a>ill-formed</a>. See the definition of <a>well-formed</a> shapes graphs for details.
+				</p>
 				<p>
 					In addition to shape declarations, the shapes graph may contain additional information for the SHACL processor such as <code>sh:entailment</code> statements.
 				</p>
@@ -2535,7 +2565,7 @@ ex:CompanyShape
 							consumer of the validation report about this fact.
 							If a SHACL instance of <code>sh:ValidationReport</code> in the results graph has <code>true</code> as the <a>value</a>
 							for <code>sh:shapesGraphWellFormed</code> then the <a>processor</a> was certain that the <a>shapes graph</a> that was used for the
-							<a>validation</a> process has passed all SHACL syntax rules (as summarized in <a href="#syntax-rules"></a>) during the validation process.
+							<a>validation</a> process is <a>well-formed</a>.
 						</p>
 					</section>
 				</section>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -505,7 +505,7 @@
 					<li>It contains no <a>ill-formed</a> nodes (i.e., all nodes satisfy the syntax rules mentioned above).</li>
 					<li>Its import closure (as determined by transitively following
 						<a data-cite="owl2-syntax/#Imports"><code>owl:imports</code></a> statements)
-						satisfies the constraints defined by [[owl2-syntax]], namely that it does not contain two shapes graphs where:
+						satisfies the constraints defined by the syntax specification of OWL 2 [[owl2-syntax]], namely that it does not contain two shapes graphs where:
 						<ul>
 							<li>
 								they are different versions of the same series

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -505,7 +505,7 @@
 					<li>It contains no <a>ill-formed</a> nodes (i.e., all nodes satisfy the syntax rules mentioned above).</li>
 					<li>Its import closure (as determined by transitively following
 						<a data-cite="owl2-syntax/#Imports"><code>owl:imports</code></a> statements)
-						satisfies the constraints defined by the syntax specification of OWL 2 [[owl2-syntax]], namely that it does not contain two shapes graphs where:
+						satisfies the constraints defined by <a data-cite="owl2-syntax/#Imports">Section 3.4</a> of the OWL 2 syntax specification [[owl2-syntax]], namely that it does not contain two shapes graphs where:
 						<ul>
 							<li>
 								they are different versions of the same series


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

[See this document rendered online here](https://raw.githack.com/w3c/data-shapes/owl-versionIRI-guidance/shacl12-core/index.html)

Since `owl:versionIRI` support was added for shapes graph imports in #842, it was proposed that the spec should address potential incompatibilities that can arise in the import closure. The [OWL 2 Imports specification](https://www.w3.org/TR/owl2-syntax/#Imports) defines constraints on import closures, specifically around conflicting versions and `owl:incompatibleWith` declarations. This is added as part of checking whether the shapes graph is "well-formed", which currently is not strictly required by the spec. Furthermore, the proposed checks are farily simple to perform on the shapes graph after closure is complete so the implementation overhead should not be significant.

This PR includes the following specific changes:


### 1. Expanded well-formed shapes graph definition

Restructured the well-formed/ill-formed definitions so that a shapes graph is well-formed if:
1. It contains no ill-formed nodes (the prior definition of a well-formed shapes graph), AND
2. Its import closure satisfies the constraints defined by OWL 2, namely that no two shapes graphs that are different versions of the same series or where one declares `owl:incompatibleWith` the other.

### 2. Informative note in the Shapes Graph section

Added a note near the `owl:versionIRI` import example warning that versioned imports may introduce incompatibilities.

### 3. Simplified `sh:shapesGraphWellFormed` description

Updated the description to defer to the `well-formed` definition rather than only referencing the syntax rules appendix.
