### PR TITLE
#878: Replaced "is informative" with "is non-normative", SHOULD->should, MAY->may in those sections

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -861,7 +861,6 @@ ex:Person
 
 		<section id="constraints-section">
 			<h2>Shapes and Constraints</h2>
-
 			<p><em>The following introduction is non-normative.</em></p>
 			<p>
 				The following informal diagram provides an overview of some of the key classes in the SHACL vocabulary.
@@ -1065,7 +1064,7 @@ ex:MultiplePatternsShape
 					<p>
 						An <a>RDF term</a> that is <a>validated</a> against a <a>shape</a> using the triples from a <a>data graph</a> is called a <dfn>focus node</dfn>.
 					</p>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The set of <a>focus nodes</a> for a <a>shape</a> may be identified as follows:
 					</p>
@@ -1101,7 +1100,7 @@ ex:MultiplePatternsShape
 						<li><a href="#targetWhere">where targets</a></li>
 						<li><a href="#explicit-shape-target">explicit shape targets</a></li>
 					</ul>
-					<p><em>The remainder of this introduction is informative.</em></p>
+					<p><em>The remainder of this introduction is non-normative.</em></p>
 					<p>
 						RDF terms produced by targets are not required to exist as nodes in the <a>data graph</a>.
 						Targets of a shape are ignored whenever a focus node is provided directly as input to the validation process for that shape.
@@ -1124,7 +1123,7 @@ ex:MultiplePatternsShape
 							then the <a>output nodes</a> of <code>evalExpr(expr, <a>data graph</a>, s, {})</code> are <a>targets</a>
 							for the data graph <code>DG</code> as <a>focus graph</a>.
 						</div>
-						<p><em>The remainder of this section is informative.</em></p>
+						<p><em>The remainder of this section is non-normative.</em></p>
 						<p>
 							With the example data below, only <code>ex:Alice</code> is the target of the provided shape:
 						</p>
@@ -1157,7 +1156,7 @@ ex:Bob a ex:Person .
 							<code>sh:targetClass</code> in <code>SG</code> then the set of <a>SHACL instances</a> of <code>c</code> in a data graph
 							<code>DG</code> is a <a>target</a> from <code>DG</code> for <code>s</code> in <code>SG</code>.
 						</div>
-						<p><em>The remainder of this section is informative.</em></p>
+						<p><em>The remainder of this section is non-normative.</em></p>
 						<aside class="example" title="An example of a class-based target">
 							<div class="shapes-graph">
 								<div class="turtle">
@@ -1230,7 +1229,7 @@ ex:House a ex:Nephrologist .
 							Please keep in mind that <code>sh:ShapeClass</code> may not be understood to be a subclass of <code>rdfs:Class</code> by some SHACL-unaware implementations.
 							It is therefore recommended (but not required) that graphs that use <code>sh:ShapeClass</code> include an <code>owl:imports sh:</code> statement.
 						</p>
-						<p><em>The remainder of this section is informative.</em></p>
+						<p><em>The remainder of this section is non-normative.</em></p>
 						<p>
 							In the following example, <code>ex:Alice</code> is a focus node, because it is a <a>SHACL instance</a> of
 							<code>ex:Person</code> which is both a class and a shape in the <a>shapes graph</a>.
@@ -1276,7 +1275,7 @@ ex:Person
 							data graph <code>DG</code> that are <a>subjects</a> of triples in <code>DG</code> with <a>predicate</a>
 							<code>p</code> is a <a>target</a> from <code>DG</code> for <code>s</code> in <code>SG</code>.
 						</div>
-						<p><em>The remainder of this section is informative.</em></p>
+						<p><em>The remainder of this section is non-normative.</em></p>
 						<aside class="example" title="An example of a subjects-of target">
 							<div class="shapes-graph">
 								<div class="turtle">
@@ -1311,7 +1310,7 @@ ex:Bob ex:livesIn ex:NewYork .
 							data graph <code>DG</code> that are <a>objects</a> of triples in <code>DG</code> with <a>predicate</a>
 							<code>p</code> is a <a>target</a> from <code>DG</code> for <code>s</code> in <code>SG</code>.
 						</div>
-						<p><em>The remainder of this section is informative.</em></p>
+						<p><em>The remainder of this section is non-normative.</em></p>
 						<aside class="example" title="An example of an objects-of target">
 							<div class="shapes-graph">
 								<div class="turtle">
@@ -1345,7 +1344,7 @@ ex:Bob ex:livesIn ex:NewYork .
 							<code>sh:targetWhere</code> in <code>SG</code> then the set of <a>nodes</a> in a data graph
 							<code>DG</code> that <a>conform</a> to <code>w</code> is a <a>target</a> from <code>DG</code> for <code>s</code> in <code>SG</code>.
 						</div>
-						<p><em>The remainder of this section is informative.</em></p>
+						<p><em>The remainder of this section is non-normative.</em></p>
 						<aside class="example" title="An example of a where target">
 							<div class="shapes-graph">
 								<div class="turtle">
@@ -1417,7 +1416,7 @@ ex:Alice a ex:Person .
 							If <code>n</code> has <a>value</a> <code>s</code> for <code>sh:shape</code> in the <a>data graph</a>,
 							then <code>n</code> is a <a>target</a> for <code>s</code>.
 						</div>
-						<p><em>The remainder of this section is informative.</em></p>
+						<p><em>The remainder of this section is non-normative.</em></p>
 						<p class="note">
 							<code>sh:shape</code> is different from <code>sh:targetNode</code>, although both can be used to
 							link individual nodes with shapes.
@@ -1498,10 +1497,10 @@ ex:Bob a ex:Person .
 							</tr>
 						</tbody>
 					</table>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The validation process handles the values of <code>sh:severity</code> according to <a>conformance checking</a>.
-						Additionally, user interface tools MAY use the values to categorize validation results.
+						Additionally, user interface tools may use the values to categorize validation results.
 						The values of <code>sh:severity</code> are used by SHACL processors to populate the <code>sh:resultSeverity</code> field of
 						validation results, see <a href="#results-severity">section on severity in validation results</a>.
 						Any IRI can be used as a severity.
@@ -1629,7 +1628,7 @@ ex:MyShape-myProperty2
 						A <a>shapes graph</a> can specify at most one <a>value</a> for the property <code>sh:message</code>
 						in the <a>reifiers</a> of the <a>triples</a> in <code>T</code>.
 					</span></p>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						See the <a href="#results-message">section on <code>sh:resultMessage</code> in the validation results</a>
 						on further details on how the values of <code>sh:resultMessage</code> are populated.
@@ -1689,7 +1688,7 @@ ex:MyShape-myProperty
 						<a>output node</a>, the constraints that use the <a>triple</a> are called <dfn data-lt="deactivated constraint">deactivated constraints</dfn>.
 						Deactivated constraints are ignored during validation.
 					</p>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						In SHACL Core, the only valid values for <code>sh:deactivated</code> are the
 						<a href="#LiteralExpression">constant literal node expressions</a>
@@ -2089,16 +2088,16 @@ ex:SomeClass-alternativePathExample
 					<span data-syntax-rule="ShapesGraph">The <code>sh:ShapesGraph</code> class MAY be used as an <code>rdf:type</code>
 					of the <a>IRI</a> of a graph that is typically used as a <a>shapes graph</a>.</span>
 				</p>
-				<p><em>The remainder of this section is informative.</em></p>
+				<p><em>The remainder of this section is non-normative.</em></p>
 				<p>
 					Shapes graphs can be reusable validation modules that can be cross-referenced with the predicate <a data-cite="owl2-syntax/#Imports"><code>owl:imports</code></a>.
-					As a pre-validation step, SHACL processors SHOULD extend the originally provided <a>shapes graph</a> by transitively following and importing all referenced <a>shapes graphs</a>
+					As a pre-validation step, SHACL processors should extend the originally provided <a>shapes graph</a> by transitively following and importing all referenced <a>shapes graphs</a>
 					through the <a data-cite="owl2-syntax/#Imports"><code>owl:imports</code></a> predicate.
 					When resolving an imported IRI, if the retrieved graph contains a triple with the imported IRI as the object of
 					<a data-cite="owl2-syntax/#Ontology_IRI_and_Version_IRI"><code>owl:versionIRI</code></a>,
-					the processor SHOULD treat the subject of that triple as the shapes graph IRI of the imported graph
+					the processor should treat the subject of that triple as the shapes graph IRI of the imported graph
 					for the purpose of following further <code>owl:imports</code> statements.
-					Formally, processors SHOULD use the property path <code>^owl:versionIRI?/owl:imports</code> iteratively
+					Formally, processors should use the property path <code>^owl:versionIRI?/owl:imports</code> iteratively
 					to resolve imports, so that version IRIs can be used to import versioned shapes graphs.
 				</p>
 				<p>
@@ -2209,7 +2208,7 @@ ex:CompanyShape
 					Note, however, that a <a>shapes graph</a> MAY also play the role of a <a>data graph</a>; for example,
 					when the shapes themselves will be validated.
 				</p>
-				<p><em>The remainder of this section is informative.</em></p>
+				<p><em>The remainder of this section is non-normative.</em></p>
 				<p>
 					A data graph is one of the inputs to the SHACL processor for <a>validation</a>.
 					SHACL processors treat it as a general RDF graph and makes no assumption about its nature.
@@ -2233,7 +2232,7 @@ ex:CompanyShape
 					presence of <code>X a owl:Ontology .</code> such that <code>X owl:imports Y .</code> will process the <code>owl:imports</code> statement as a
 					directive to load <code>Y</code>.  See <a data-cite="owl2-mapping-to-rdf/#Resolving_Included_RDF_Graphs">OWL 2 Web Ontology Language Mapping
 					to RDF Graphs, Section 3.1.1</a> for further detail.  Hence, when using statements of the form `X a sh:DataGraph .`, `X a owl:Ontology .`
-					SHOULD also be included.
+					should also be included.
 				</p>
 			</section>
 
@@ -2382,7 +2381,7 @@ ex:CompanyShape
 						The <a>validation</a> with <a>recursive</a> shapes is not defined in SHACL and is left to SHACL processor implementations.
 						For example, SHACL processors may support recursion scenarios or produce a failure when they detect recursion.
 					</p>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The recursion policy above has been selected to support a large variety of implementation strategies.
 						By leaving recursion undefined, implementations may choose to not support recursion so that they
@@ -2697,7 +2696,7 @@ ex:CompanyShape
 				Furthermore, the validators always produce <em>new</em> result nodes, i.e. when the textual definition states that
 				"...there is a validation result..." then this refers to a distinct new node in a results graph.
 			</p>
-			<p><em>The remainder of this section is informative.</em></p>
+			<p><em>The remainder of this section is non-normative.</em></p>
 			<p>
 				The choice of constraint components that were included into the SHACL Core was made based on
 				the requirements collected by the [[shacl-ucr]] document.
@@ -2760,7 +2759,7 @@ ex:CompanyShape
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that multiple values for <code>sh:class</code> are interpreted as a conjunction,
 						i.e., the values need to be SHACL instances of all of them.
@@ -2866,7 +2865,7 @@ ex:Alice a ex:Person ; ex:pet ex:Tessie, ex:Rusty .
 							and, for the datatypes supported by SPARQL 1.2, is not an <a data-cite="rdf12-concepts#section-Graph-Literal">ill-typed</a> literal.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The values of <code>sh:datatype</code> are typically <a>datatypes</a>, such as <code>xsd:string</code>.
 					</p>
@@ -2975,7 +2974,7 @@ ex:Estonia rdfs:label "Estonia", "Estland"@de .
 							Any <a>triple term</a> matches only <code>sh:TripleTerm</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The following example states that all values of <code>ex:knows</code> need to be IRIs, at any subject.
 					</p>
@@ -3062,7 +3061,7 @@ ex:Alice ex:knows <span class="focus-node-error">"Bob"</span> .
 							there is a <a>validation result</a>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<aside class="example" title="Example of the use of sh:minCount">
 						<div class="shapes-graph">
 							<div class="turtle">
@@ -3119,7 +3118,7 @@ ex:Alice ex:name "Alice" .
 							there is a <a>validation result</a>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<aside class="example" title="Example of the use of sh:maxCount">
 						<div class="shapes-graph">
 							<div class="turtle">
@@ -3210,7 +3209,7 @@ ex:Bob ex:age 23 .
 							there is a <a>validation result</a> with <code>v</code> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						There is a validation result if the value node cannot be compared to the specified range,
 						for example when someone compares a string with an integer.
@@ -3369,7 +3368,7 @@ ex:Bob ex:age 23 .
 							there is a <a>validation result</a> with <code>v</code> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that if the value of <code>sh:minLength</code> is 0 then there is no restriction on the
 						string length but the constraint is still violated if the value node is a blank node.
@@ -3416,7 +3415,7 @@ ex:Bob ex:age 23 .
 							there is a <a>validation result</a> with <code>v</code> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<aside class="example" title="Example of the use of sh:minLength and sh:maxLength">
 						<div class="shapes-graph">
 							<div class="turtle">
@@ -3490,7 +3489,7 @@ ex:Bob ex:password "123456789" .
 							If <code>$flags</code> has a value then the matching MUST follow the definition of the 3-argument variant of the SPARQL REGEX function, using <code>$flags</code> as third argument.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<aside class="example" title="Example of the use of sh:pattern and sh:flags">
 						<div class="shapes-graph">
 							<div class="turtle">
@@ -3559,7 +3558,7 @@ ex:Alice ex:bCode "B102" .
 							regular expression (as defined by the <a data-cite="sparql12-query#func-regex">SPARQL REGEX function</a>) <code>[\f\r\n\v]</code>, there is a validation result.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<aside class="example" title="Example of the use of sh:singleLine">
 						<p>
 							In this example, the valid target nodes of the shape can only contain single-lined values for <code>rdfs:label</code>.
@@ -3630,7 +3629,7 @@ ex:SingleLineExampleShape-comment
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The following example shape states that all values of <code>ex:prefLabel</code>
 						can be either in English or Māori.
@@ -3712,7 +3711,7 @@ ex:Mountain
 							as is the pair <code>"1"@ar--rtl</code> and <code>"1"@ar</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<aside class="example" title="Example of the use of sh:uniqueLang">
 						<div class="shapes-graph">
 							<div class="turtle">
@@ -3786,7 +3785,7 @@ ex:Alice
 							If any member <code>m</code> of the <a href="#syntax-rule-SHACL-list">SHACL list</a> <code>v</code> does not <a>conform</a> to <code>$memberShape</code>, there is a <a>validation result</a>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Each member <code>m</code> of a value node <code>v</code> that does not conform to the <code>$memberShape</code> should be reported as a separate <code>sh:detail</code> in the <a>validation result</a> for <code>v</code>.
 						If <code>v</code> is not a valid <a href="#syntax-rule-SHACL-list">SHACL list</a>, this should be reported as a top-level <a>validation result</a> and validation of individual members should not be attempted.
@@ -3863,7 +3862,7 @@ ex:agenda1 a ex:Agenda ;
 							there is a <a>validation result</a>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						In the following example, all values of the property <code>ex:skills</code> must be SHACL lists with at least 1 member.
 						Additional test cases for <code>sh:minListLength</code> can be found in the SHACL test suite: <a href="../shacl12-test-suite/tests/core/node/minListLength-001.ttl">minListLength-001.ttl</a>.
@@ -3932,7 +3931,7 @@ ex:person1 a ex:Person ;
 							there is a <a>validation result</a>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						In the following example, all values of the property <code>ex:hobbies</code> must be SHACL lists with at most 2 members.
 						Additional test cases for <code>sh:maxListLength</code> can be found in the SHACL test suite: <a href="../shacl12-test-suite/tests/core/node/maxListLength-001.ttl">maxListLength-001.ttl</a>.
@@ -4000,7 +3999,7 @@ ex:person1 a ex:Person ;
 							there is a <a>validation result</a>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Each duplicate member <code>m</code> of a list <code>v</code> should be reported as a separate <code>sh:detail</code> in the <a>validation result</a> for <code>v</code>. If the list <code>v</code> is not a valid <a href="#syntax-rule-SHACL-list">SHACL list</a>, this should be reported as a top-level <a>validation result</a> and validation of unique membership should not be attempted.
 					</p>
@@ -4087,7 +4086,7 @@ ex:person1 a ex:Person ;
 							there is a <a>validation result</a> with the <a>value</a> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The following example illustrates the use of <code>sh:equals</code> in a shape to specify
 						that certain focus nodes need to have the same set of values for <code>ex:firstName</code> and <code>ex:givenName</code>.
@@ -4199,7 +4198,7 @@ ex:BobsTattoo
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The following example illustrates the use of <code>sh:disjoint</code> in a shape to specify
 						that certain focus nodes cannot share any values for <code>ex:prefLabel</code> and <code>ex:altLabel</code>.
@@ -4271,7 +4270,7 @@ ex:USA
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The following example illustrates the use of <code>sh:subsetOf</code> in a shape to specify
 						that the favorite child of a person must be among the actual children.
@@ -4344,7 +4343,7 @@ ex:Bob
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The following example illustrates the use of <code>sh:lessThan</code> in a shape to specify
 						that all values of <code>ex:startDate</code> are "before" the values of <code>ex:endDate</code>.
@@ -4456,7 +4455,7 @@ ex:LessThanExampleShape-startDate
 							there is <a>validation result</a> with <code>v</code> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The following example illustrates the use of <code>sh:not</code> in a shape to specify the condition
 						that certain focus nodes cannot have any value of <code>ex:property</code>.
@@ -4521,7 +4520,7 @@ ex:NotExampleShape
 							there is a <a>validation result</a> with <code>v</code> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that although <code>sh:and</code> has a <a>SHACL list</a> of shapes as its value,
 						the order of those shapes does not impact the validation results.
@@ -4611,7 +4610,7 @@ ex:ValidInstance
 							there is a <a>validation result</a> with <code>v</code> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that although <code>sh:or</code> has a <a>SHACL list</a> of shapes as its value,
 						the order of those shapes does not impact the validation results.
@@ -4743,7 +4742,7 @@ ex:shapeRoot a sh:NodeShape;
 							there is a <a>validation result</a> with <code>v</code> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that although <code>sh:xone</code> has a <a>SHACL list</a> of shapes as its value,
 						the order of those shapes does not impact the validation results.
@@ -4842,7 +4841,7 @@ ex:Carla a ex:Person ;
 							there is a <a>validation result</a> with <code>v</code> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The following example illustrates the use of <code>sh:node</code> in property shapes.
 						All values of the property <code>ex:address</code> must fulfill the
@@ -4994,7 +4993,7 @@ ex:USZipCode
 							Otherwise, the validation results are the results of <a>validating</a> <code>v</code> as <a>focus node</a> against the property shape <code>$property</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that there is an important difference between <code>sh:property</code> and <code>sh:node</code>:
 						If a value node is violating the constraint, then there is only a single validation result for <code>sh:node</code> for this value node,
@@ -5047,7 +5046,7 @@ ex:USZipCode
 							there is a <a>validation result</a>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that implementations may stop processing value nodes once one of the value nodes has conformed.
 						Since the order of nodes in the set of value nodes is undefined, there is no guarantee that any node is
@@ -5177,7 +5176,7 @@ ex:DuckFarmerShape-tendsAnimal
 						</div>
 					</div>
 
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						In the following example shape can be used to specify the condition that the property <code>ex:parent</code> has exactly two values,
 						and at least one of them is female.
@@ -5309,7 +5308,7 @@ ex:HandShape
 						</div>
 					</div>
 
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<aside class="example" title="Example of sh:reifierShape and sh:reificationRequired">
 						<div class="shapes-graph">
 							<div class="turtle">
@@ -5458,7 +5457,7 @@ for each rdf:type T of the value node in the data graph
 							it from visiting the same `S` twice.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The following example illustrates the use of <code>sh:closed</code> in a shape to specify the condition
 						that certain focus nodes only have values for <code>ex:firstName</code> and <code>ex:lastName</code>.
@@ -5537,7 +5536,7 @@ ex:Alice
 							there is a <a>validation result</a>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<aside class="example" title="Example of the use of sh:hasValue">
 						<div class="shapes-graph">
 							<div class="turtle">
@@ -5601,7 +5600,7 @@ ex:Alice
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that matching of literals needs to be exact, e.g. <code>"04"^^xsd:byte</code> does not match <code>"4"^^xsd:integer</code>.
 					</p>
@@ -5674,7 +5673,7 @@ ex:RainbowPony ex:color ex:Pink .
 							there is a <a>validation result</a> with the <a>value node</a> as <code>sh:value</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The <code>sh:rootClass</code> constraint is typically used with property shapes
 						that can have classes as their values (e.g., via <code>sh:class rdfs:Class</code>)
@@ -5756,7 +5755,7 @@ ex:Zoo
 							No result is produced if <code>V</code> has no <a>values</a> for any of the properties in <code>$properties</code>.
 						</div>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that matching of literals needs to be exact, e.g. <code>"04"^^xsd:byte</code> does not match <code>"4"^^xsd:integer</code>.
 						Also note that <code>sh:uniqueValuesFor</code> does not prescribe the existence of these values, and is therefore
@@ -5849,17 +5848,17 @@ ex:Concept2
 				this section covers properties that are ignored by SHACL processors.
 				The use of these so-called <dfn data-lt="non-validating property">non-validating properties</dfn>
 				is entirely optional and is not subject to formal interpretation contracts.
-				They MAY be used for purposes such as form building, code generation or predictable printing of RDF files.
+				They may be used for purposes such as form building, code generation or predictable printing of RDF files.
 			</p>
 			<section id="name">
 				<h3>sh:name and sh:description</h3>
 				<p>
 					Property shapes may have one or more <a>values</a> for <code>sh:name</code>
 					to provide human-readable labels for the property in the target where it appears.
-					If present, tools SHOULD prefer such locally specified labels
+					If present, tools should prefer such locally specified labels
 					over globally specified labels at the <code>rdf:Property</code> itself.
 					For example, if a form displays a node that is in the target of a given property shape
-					with an <code>sh:name</code>, then the tool SHOULD use the provided name.
+					with an <code>sh:name</code>, then the tool should use the provided name.
 					The <a>values</a> of <code>sh:name</code> must be <a>literals</a> with <a>datatype</a>
 					<code>xsd:string</code>, <code>rdf:dirLangString</code>, or <code>rdf:langString</code>.
 				</p>
@@ -5874,7 +5873,7 @@ ex:Concept2
 					multiple <a>values</a>, but should only have one <a>value</a> per language tag.
 				</p>
 				<p>
-					Note that <code>sh:name</code> and <code>sh:description</code> SHOULD NOT be used for <a>node shapes</a>.
+					Note that <code>sh:name</code> and <code>sh:description</code> should NOT be used for <a>node shapes</a>.
 					For those, the properties <code>rdfs:label</code> and <code>rdfs:comment</code> are well-established
 					and already used for class definitions.
 				</p>
@@ -5896,8 +5895,8 @@ ex:Concept2
 					the intended semantics of a shape.
 				</p>
 				<p>
-					Multiple values of <code>sh:intent</code> MAY be provided to represent distinct intended rules.
-					Some of these rules MAY overlap with constraints that are already expressed formally using SHACL constraint components.
+					Multiple values of <code>sh:intent</code> may be provided to represent distinct intended rules.
+					Some of these rules may overlap with constraints that are already expressed formally using SHACL constraint components.
 					When a value of <code>sh:intent</code> represents semantics that are also represented formally in the same
 					shapes graph, the <a>triple</a> of the <code>sh:intent</code> statement can be reified with the property value
 					<code>sh:formalized true</code>.
@@ -6198,7 +6197,7 @@ ex:AddressGroup
 					</div>
 				</aside>
 				<p>
-					A form building application MAY use the information above to display information as follows:
+					A form building application may use the information above to display information as follows:
 				</p>
 				<div class="ui-form">
 					<div class="ui-form-header">Name</div>
@@ -6291,7 +6290,7 @@ ex:NameGroup
 				</aside>
 			</section>
 			<div class="note">
-				For predicates that accept literals of type <code>xsd:string</code>, <code>rdf:langString</code>, <code>rdf:dirLangString</code>, or <code>rdf:HTML</code>, users SHOULD avoid <code>xsd:string</code> in favor of <code>rdf:langString</code> or <code>rdf:dirLangString</code>. Using language tags and, where appropriate, directionality markers is recommended to support internationalization and correctly handle bidirectional text.
+				For predicates that accept literals of type <code>xsd:string</code>, <code>rdf:langString</code>, <code>rdf:dirLangString</code>, or <code>rdf:HTML</code>, users should avoid <code>xsd:string</code> in favor of <code>rdf:langString</code> or <code>rdf:dirLangString</code>. Using language tags and, where appropriate, directionality markers is recommended to support internationalization and correctly handle bidirectional text.
 			</div>
 		</section>
 

--- a/shacl12-node-expr/index.html
+++ b/shacl12-node-expr/index.html
@@ -858,7 +858,7 @@ ex:Company-employeeCount
 						and then produce a different list of <a>nodes</a>
 						as <a>output nodes</a>.
 					</p>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						This document includes many examples of <a>named parameter functions</a>, such as
 						the <a href="#EstonianCompanyShapeExample">Estonian Company Shape example</a>.
@@ -912,7 +912,7 @@ ex:Company-employeeCount
 						An <a>evaluation failure</a> must be produced if there is more than one <a>output node</a>.
 						This is different from <a>named parameter functions</a>, where arguments may produce lists of multiple nodes.
 					</p>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that some <a>named parameter functions</a> &mdash; such as <code>shnex:IntersectionExpression</code> &mdash;
 						also use a <a>SHACL list</a> as an object of the <a>key parameter</a>, similar to <a>list parameter functions</a> which always have a <a>SHACL list</a> as the object of their <a>list parameter property</a>.
@@ -965,7 +965,7 @@ ex:Person-displayName
 					In general, if any such nested expressions produce a <a>failure</a> then the surrounding
 					expression also produces the same <a>failure</a>.
 				</p>
-				<p><em>The remainder of this section is informative.</em></p>
+				<p><em>The remainder of this section is non-normative.</em></p>
 				<p>
 					Note that this policy impacts the evaluation order of node expressions.
 					For example, <code>shnex:if</code> expressions are evaluated first and <code>shnex:then</code>
@@ -1009,7 +1009,7 @@ ex:Person-displayName
 							An <a>empty expression</a> has the empty list <code>[]</code> as its <a>output nodes</a>.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						This node expression function is written in Turtle as <code>[]</code> and must not be confused with
 						the empty SHACL list <code>()</code> which is the <a>IRI</a> <code>rdf:nil</code>.
@@ -1057,7 +1057,7 @@ ex:Person-displayName
 							<li>otherwise <code>evalExpr(expr, focusGraph, focusNode, scope) -> []</code></li>
 						</ol>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The following example illustrates the use of a <a>var expression</a> pointing at the current <a>focus node</a>
 						to state that the default value of the <code>ex:loves</code> relationship is the current instance of <code>ex:Person</code>,
@@ -1126,7 +1126,7 @@ ex:Person-loves
 							in the same order as in the list.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that <code>rdf:nil</code> itself is not a <a>list expression</a> because it will be interpreted
 						as a <a>IRI expression</a>.
@@ -1224,7 +1224,7 @@ ex:ClassShape-superClassesExceptRoots
 						</ul>
 						<p>For example, <code>sh:path ex:name</code> in a property shape constrains the values of the <code>ex:name</code> property, while <code>shnex:pathValues ex:name</code> in a node expression generates a sequence containing all values of the <code>ex:name</code> property.</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that by definition, the <a>value nodes</a> of a property shape may be derived properties,
 						based on <code>sh:values</code> or <code>sh:defaultValue</code> expressions.
@@ -1321,7 +1321,7 @@ ex:DirectInstancesOfConceptShape
 							<code>N</code> has at least one member; otherwise, the output nodes are <code>( false )</code>.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The <a href="#IfExpressionExample">Example for <code>shnex:if</code></a> uses <code>shnex:exists</code>.
 					</p>
@@ -1390,7 +1390,7 @@ ex:DirectInstancesOfConceptShape
 							<code>shnex:else</code> branches are only evaluated when necessary.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p id="IfExpressionExample">
 						The following example illustrates the use of <code>shnex:if</code> to compute the
 						values of a derived property <code>ex:fillColor</code> that may be queried to
@@ -1468,7 +1468,7 @@ ex:City-fillColor
 							Nodes are compared using <a>term equality</a>, i.e. <code>"01"^^xsd:integer</code> is distinct from <code>"1"^^xsd:integer</code>.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p id="DistinctExpressionExample">
 						The following example declares a derived property <code>ex:superClassesIncludingRoot</code>
 						that is computed as the <a href="#ConcatExpression">concat</a> of the (transitive) values of <code>rdfs:subClassOf</code>
@@ -1544,7 +1544,7 @@ ex:ClassShape-superClassesIncludingRoot
 							The intersection does not include duplicates and the order is undefined.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p id="IntersectionExpressionExample">
 						The following example uses <code>shnex:intersection</code> as a <code>sh:targetNode</code> node expression.
 						This shape will target all nodes that are <a>SHACL instances</a> of <code>ex:Australian</code> and
@@ -1630,7 +1630,7 @@ ex:DualCitizenShape
 							The order is preserved, evaluating the <code>members</code> from left to right and keeping the order of each list of output nodes.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that a <a>concat expression</a> may produce duplicate <a>output nodes</a> if the individual output nodes overlap.
 						Use <a href="#DistinctExpression">shnex:distinct</a> to eliminate duplicates.
@@ -1742,7 +1742,7 @@ ex:PersonShape-allRelatives
 							Nodes must be equal using <a>term equality</a>, i.e., <code>"01"^^xsd:integer</code> is distinct from <code>"1"^^xsd:integer</code>.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The following example declares a derived property, <code>ex:availableAuthors</code>,
 						that returns all persons who are authors, except those who are currently on leave.
@@ -1845,7 +1845,7 @@ ex:PublisherShape-availableAuthors
 							the <a>shape</a> <code>filterShape</code>, preserving the order in the list.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The following example illustrates the use of <code>shnex:filterShape</code> to return a subset
 						of values of the <code>ex:child</code> property where the <code>ex:gender</code> property
@@ -1927,7 +1927,7 @@ ex:Person-maleChildren
 							from left to right, in the same order.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p id="LimitExpressionExample">
 						The following example illustrates the use of <code>shnex:limit</code> to compute the
 						values of a derived property <code>ex:oldestChildren</code> to be a sub-list of
@@ -2013,7 +2013,7 @@ ex:PersonShape-oldestTwoChildren
 							except for the first <code>offset</code> nodes from left to right, in the same order.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p id="OffsetExpressionExample">
 						The following example illustrates the use of <code>shnex:offset</code> to compute the
 						values of a derived property <code>ex:remainingChildren</code> to be a sub-list of
@@ -2113,7 +2113,7 @@ ex:PersonShape-remainingChildren
 							If <code>desc</code> is <code>true</code> then the <a>output nodes</a> are returned in the reverse order.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The <a href="#LimitExpressionExample">Example of <code>shnex:limit</code></a> also illustrates <code>shnex:orderBy</code>.
 					</p>
@@ -2182,7 +2182,7 @@ ex:PersonShape-remainingChildren
 							<code>M<sub>n</sub></code> in the order of the corresponding nodes <code>n</code> in <code>N</code>.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The <code>shnex:flatMap</code> operation applies an expression to each input node and flattens the results
 						into a single sequence. This is particularly useful when combining results from multiple path traversals
@@ -2339,7 +2339,7 @@ ex:Employee3
 							or an empty sequence if no such node exists.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The <code>shnex:findFirst</code> operation finds the first node in a sequence that conforms to a given shape.
 					</p>
@@ -2431,7 +2431,7 @@ ex:SeniorEmployeeShape
 							otherwise the output nodes are <code>( false )</code>.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The <code>shnex:matchAll</code> operation returns <code>true</code> if all nodes in a sequence conform to a given shape,
 						<code>false</code> otherwise.
@@ -2515,7 +2515,7 @@ ex:ActiveEmployeeShape
 							<code>xsd:integer</code> <a>literal</a> that is computed as the length of <code>N</code>.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The following example illustrates the use of <code>shnex:count</code> to derive a property
 						<code>ex:topConceptCount</code> as the number of values of the <code>skos:hasTopConcept</code>
@@ -2583,7 +2583,7 @@ skos:ConceptScheme-topConceptCount
 							see <dfn data-cite="sparql12-query#aggMin">SPARQL MIN</dfn>.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p id="MinExpressionExample">
 						The following example illustrates the use of <code>shnex:min</code> to derive a property
 						<code>ex:minStartDate</code> as the smallest value of the values that can be reached using the
@@ -2653,7 +2653,7 @@ ex:CompanyShape-minStartDate
 							see <dfn data-cite="sparql12-query#aggMax">SPARQL MAX</dfn>.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						The <a href="#MinExpressionExample">Example for <code>shnex:min</code></a> can be easily adapted
 						for <code>shnex:max</code>.
@@ -2698,7 +2698,7 @@ ex:CompanyShape-minStartDate
 							see <dfn data-cite="sparql12-query#aggSum">SPARQL SUM</dfn>.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that <code>shnex:sum</code> needs to be used with care and may be misunderstood,
 						when used with property paths.
@@ -2803,7 +2803,7 @@ ex:MyCompany
 							of <code>type</code> in the <a>focus graph</a>.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Note that the definition of <code>SHACL instance</code> includes instances of subclasses of the given class.
 						So if the <a>focus graph</a> contains <code>ex:SubClass rdfs:subClassOf ex:SuperClass</code> and <code>ex:SubInstance a ex:SubClass</code>
@@ -2857,7 +2857,7 @@ ex:MyCompany
 							that <a>conform</a> to <code>shape</code>.
 						</p>
 					</div>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 						Users of this node expression function should be aware that the list of output nodes may be very large
 						and that some implementations may not be able to efficiently process it.
@@ -2975,7 +2975,7 @@ ex:LargeCompanyShape
 						<code>evalExpr(expr, focusGraph, focusNode, scope) -> evalExpr(body, focusGraph, focusNode, argScope)</code>
 					</p>
 				</div>
-				<p><em>The remainder of this section is informative.</em></p>
+				<p><em>The remainder of this section is non-normative.</em></p>
 				<p>
 					The following example defines a new <a>node expression function</a> <code>ex:AverageExpression</code>
 					that takes another node expression as input using the <a>key parameter</a> <code>ex:average</code>
@@ -3072,7 +3072,7 @@ ex:CompanyShape-averageIncome
 						where an <a>evaluation failure</a> is reported when there is more than 1 output node.
 					</p>
 				</div>
-				<p><em>The remainder of this section is informative.</em></p>
+				<p><em>The remainder of this section is non-normative.</em></p>
 				<p>
 					The following example defines a new <a>node expression function</a> <code>ex:spacedConcat</code>
 					that takes two nodes as input and returns a string concatenating the two nodes with a space in between.
@@ -3165,7 +3165,7 @@ ex:Person-fullName
 						<li>otherwise <code>evalExpr(expr, focusGraph, focusNode, scope) -> []</code></li>
 					</ol>
 				</div>
-				<p><em>The remainder of this section is informative.</em></p>
+				<p><em>The remainder of this section is non-normative.</em></p>
 				<p>
 					Both <code>shnex:arg</code> and <code>shnex:var</code> access values from the scope.
 					The difference is that <code>shnex:arg</code> interprets the values as node expressions, while
@@ -3229,7 +3229,7 @@ ex:Person-fullName
 						and a <a>deep copy</a> of <code>$expr</code> in the results graph as its <code>sh:sourceConstraint</code>.
 					</div>
 				</div>
-				<p><em>The remainder of this section is informative.</em></p>
+				<p><em>The remainder of this section is non-normative.</em></p>
 				<p>
 					Note that the <code>scope</code> in the evaluation of expression constraints maps
 					<code>value</code> to the current <a>value node</a>.
@@ -3335,7 +3335,7 @@ ex:Germany
 						<code>s</code> as <code>sh:sourceConstraint</code>.
 					</div>
 				</div>
-				<p><em>The remainder of this section is informative.</em></p>
+				<p><em>The remainder of this section is non-normative.</em></p>
 				<p>
 					<code>sh:nodeByExpression</code> functions similarly to <code>sh:node</code>, but instead of referencing a fixed <a>node shape</a>,
 					a referenced <a>node expression</a> is used to dynamically compute the set of <a>node shapes</a> to which each <a>value node</a> must conform.

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -1021,12 +1021,12 @@ ex:hasPattern
 						<span data-syntax-rule="labelTemplate-datatype">The values of <code>sh:labelTemplate</code> are strings (possibly with language tag)</span> and
 						are called <dfn data-lt="label template">label templates</dfn>.
 					</p>
-					<p><em>The remainder of this section is informative.</em></p>
+					<p><em>The remainder of this section is non-normative.</em></p>
 					<p>
 					 	<a>Label templates</a> can include the names of the parameters that are declared for the constraint component
 					 	using the syntaxes <code>{?varName}</code> or <code>{$varName}</code>,
 						where <code>varName</code> is the name of the <a>parameter name</a>.
-						At display time, these <code>{?varName}</code> and <code>{$varName}</code> blocks SHOULD be replaced with the actual parameter values.
+						At display time, these <code>{?varName}</code> and <code>{$varName}</code> blocks should be replaced with the actual parameter values.
 						There may be multiple label templates for the same subject, but they should not have the same language tags
 						and there should not be more than one template with datatype `xsd:string`.
 					</p>
@@ -1061,7 +1061,7 @@ ex:hasPattern
 							The value of <code>sh:select</code> is a valid SPARQL SELECT query using the aforementioned <a href="#sparql-prefixes">prefix handling rules</a>.
 							The SPARQL query derived from the value of <code>sh:select</code> <a data-cite="sparql12-query/#selectproject">projects</a> the variable <code>this</code> in its SELECT clause.
 						</p>
-						<p><em>The remainder of this section is informative.</em></p>
+						<p><em>The remainder of this section is non-normative.</em></p>
 						<p>
 							The following example illustrates the declaration of a constraint component based on a SPARQL SELECT query.
 							It is a generalized variation of the example from <a href="#sparql-constraints-example"></a>.
@@ -1188,7 +1188,7 @@ ex:LanguageExampleShape
 							<span data-syntax-rule="ask-datatype">The value of <code>sh:ask</code> must be a literal with datatype <code>xsd:string</code>.</span>
 							<span data-syntax-rule="ask-sparql">The value of <code>sh:ask</code> must be a valid SPARQL ASK query using the aforementioned <a href="#sparql-prefixes">prefix handling rules</a>.</span>
 						</p>
-						<p><em>The remainder of this section is informative.</em></p>
+						<p><em>The remainder of this section is non-normative.</em></p>
 						<p>
 							The ASK queries return <code>true</code> if and only if a given <a>value node</a>
 							(represented by the pre-bound variable <code>value</code>) conforms to the constraint.
@@ -1449,7 +1449,7 @@ ex:AnnotationExample
 						<code>evalExpr(expr, focusGraph, focusNode, scope) -> resultNodes</code>
 					</p>
 				</div>
-				<p><em>The remainder of this section is informative.</em></p>
+				<p><em>The remainder of this section is non-normative.</em></p>
 				<aside class="example" title="A dynamically computed property using a node expression based on a SPARQL query">
 					<p>
 						Here is an example use of a <a>select expression</a>, computing the values of a property shape for the property
@@ -1634,7 +1634,7 @@ ex:Bernd
 						<code>evalExpr(expr, focusGraph, focusNode, scope) -> resultNodes</code>
 					</p>
 				</div>
-				<p><em>The remainder of this section is informative.</em></p>
+				<p><em>The remainder of this section is non-normative.</em></p>
 				<aside class="example" title="A dynamically computed property using a SPARQL expr expression">
 					<p>
 						Here is an example use of an <a>SPARQL expr expression</a>, computing the values of a property shape for the property


### PR DESCRIPTION
Closes #878

* [See the Core document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-878/shacl12-core/index.html)

* [See the SPARQL document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-878/shacl12-sparql/index.html)

* [See the NodeExpr document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-878/shacl12-node-expr/index.html)
