### PR TITLE
[UI] Outline UI concepts and patterns

### DIFF
--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1460,6 +1460,8 @@ ex:alice a ex:Person ;
         Some of the UI meetings have discussed using node expressions, dynamic SHACL, and SPARQL with the SERVICE clause.
       </p>
       <div class="issue" data-number="846"></div>
+      <h4>Fetching values from named graphs</h4>
+      <div class="issue" data-number="672"></div>
 
       <h3>Grouping, Ordering, and Layout Hints</h3>
       <p class="ednote">

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1480,7 +1480,7 @@ ex:alice a ex:Person ;
       </p>
       <div class="issue" data-number="855"></div>
 
-      <h3>Form error handling</h3>
+      <h3>Form Messages and Error Handling</h3>
       <p class="ednote">
         The pattern should describe how renderers may handle and display form errors, including validation errors and submission errors.
       </p>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -187,7 +187,7 @@
       <p>Content.</p>
     </section>
 
-    <section id="introduction" class="appendix informative">
+    <section id="introduction" class="informative">
       <h2>Introduction</h2>
       <p>
         RDF applications commonly provide user interfaces that allow users to view and edit RDF resources.
@@ -216,7 +216,7 @@
         shapes who wish to generate forms for their data.
       </p>
 
-      <section id="scope" class="appendix informative">
+      <section id="scope" class="informative">
         <h3>Scope</h3>
         <p>
           The scope of this specification is limited to form rendering for viewing and editing RDF resources

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -239,6 +239,7 @@
 
       <section id="terminology">
         <h3>Terminology</h3>
+        <p class="ednote">Link to definitions and concepts from other docs, such as SHACL Core, RDF 1.2, etc.</p>
         <p>
           Terminology used throughout this specification is taken from several
           sources:
@@ -455,45 +456,6 @@
             <a>shapes graph</a>, <a>data graph</a>, application environment, and user preferences, to determine the best label for UI presentation.
           </div>
         </div>
-        <div class="def">
-          <div class="term-def-header">Property UI Component</div>
-          <div>
-            A <dfn data-lt="property ui component">Property UI Component</dfn> is a combination of <a>constraints</a>
-            across multiple <a>property shapes</a> that share the same <a>focus node</a> and <a>property path</a>.
-          </div>
-        </div>
-        <div class="def">
-          <div class="term-def-header">Node UI Component</div>
-          <div>
-            A <dfn data-lt="node ui component">Node UI Component</dfn> is generated from a single <a>focus node</a>,
-            typically containing one or more <a>property UI components</a>. It is often derived from one or more
-            <a>node shapes</a> that apply to the <a>focus node</a>.
-          </div>
-        </div>
-        <div class="def">
-          <div class="term-def-header">SHACL Renderer</div>
-          <div>
-            A <dfn data-lt="shacl Renderer">SHACL Renderer</dfn> is software that processes SHACL
-            <a>shapes</a> and data and dynamically generates a user-interface using one
-            or more <a>node UI components</a>. Implementations may add supplementary UI elements, such as a submit
-            button to save changes, controls to toggle between edit and view modes, selectors for <a>focus node</a> and
-            <a>node shape</a>, or visualizations of <a>validation report</a> messages.
-
-            They may also provide:
-            <ul>
-              <li>State management for editing, viewing, and tracking data changes</li>
-              <li>Widget management, including widget selection strategies</li>
-              <li>Logic for determining the initial focus node (target) and the best suited node shape</li>
-              <li>An interface to interact with the data layer</li>
-            </ul>
-
-            A SHACL Renderer operates on a <a>data graph</a> and a <a>shapes graph</a>, and may also take a
-            <a>focus node</a> and a <a>node shape</a>. When all four inputs are provided, the renderer
-            operates in <strong>manual mode</strong>. When the focus node or node shape is not provided,
-            the renderer may operate in <strong>automatic mode</strong>, in which case the application determines
-            appropriate values for the missing inputs.
-          </div>
-        </div>
       </section>
 
       <section id="conventions">
@@ -652,39 +614,67 @@
       </section>
     </section>
 
-    <section id="getting-started">
-      <h2>Getting Started with SHACL UI</h2>
-      <p>TODO: provide an introduction, use cases, and examples on SHACL UI basics.</p>
+    <section id="shacl-ui" class="informative">
+      <h2 >SHACL UI</h2>
+      <p class="ednote">
+        TODO: provide an introduction, use cases, and examples on SHACL UI basics.
+      </p>
 
       <p class="note">Add conceptual model diagram and UI mockups to illustrate the concepts.</p>
 
-      <section id="use-cases">
-        <h3>Use Cases</h3>
-        <p>Content.</p>
-      </section>
-    </section>
-
-    <section id="concepts">
-      <h2>SHACL UI Concepts</h2>
       <p>This section explains the UI concepts and how they work together.</p>
 
       <section id="renderer">
         <h3>SHACL Renderer</h3>
-        <p>Content.</p>
+        <p>
+          A SHACL Renderer is software that processes SHACL
+            <a>shapes</a> and data and dynamically generates a user-interface using one
+            or more <a>node UI components</a>. Implementations may add supplementary UI elements, such as a submit
+            button to save changes, controls to toggle between edit and view modes, selectors for <a>focus node</a> and
+            <a>node shape</a>, or visualizations of <a>validation report</a> messages.
+
+            They may also provide:
+            <ul>
+              <li>State management for editing, viewing, and tracking data changes</li>
+              <li>Widget management, including widget selection strategies</li>
+              <li>Logic for determining the initial focus node (target) and the best suited node shape</li>
+              <li>An interface to interact with the data layer</li>
+            </ul>
+
+            A SHACL Renderer operates on a <a>data graph</a> and a <a>shapes graph</a>, and may also take a
+            <a>focus node</a> and a <a>node shape</a>. When all four inputs are provided, the renderer
+            operates in <strong>manual mode</strong>. When the focus node or node shape is not provided,
+            the renderer may operate in <strong>automatic mode</strong>, in which case the application determines
+            appropriate values for the missing inputs.
+        </p>
+
+        <p class="ednote">TODO: review SHACL Renderer definition, particularly the manual and automatic mode, now that we have the scoring system defined.</p>
+
+        <div class="issue" data-number="609"></div>
       </section>
 
       <section id="node-ui-component">
         <h3>Node UI Component</h3>
-        <p>Content.</p>
+
+        <div>
+          A Node UI Component is generated from a single <a>focus node</a>,
+          typically containing one or more <a>property UI components</a>. It is often derived from one or more
+          <a>node shapes</a> that apply to the <a>focus node</a>.
+        </div>
       </section>
 
       <section id="property-ui-component">
         <h3>Property UI Component</h3>
-        <p>Content.</p>
+
+        <div>
+            A Property UI Component is a combination of <a>constraints</a>
+            across multiple <a>property shapes</a> that share the same <a>focus node</a> and <a>property path</a>.
+          </div>
       </section>
 
-      <p class="note">Describe the constraint collection/aggregation behaviour here for both Node and Property UI Component.</p>
+      <p class="ednote">TODO: Describe the constraint collection/aggregation behaviour here for both Node and Property UI Component.</p>
     </section>
+
     <section id="scoring-system">
       <h2>Scoring System</h2>
 
@@ -1020,7 +1010,8 @@
 
     <section id="core-constraints">
       <h2>Core Constraints</h2>
-      <p>Content.</p>
+
+      <p class="ednote">TODO: This section may not be needed if we decide to fold in the use of different constraints for common form scenarios under the Patterns section.</p>
     </section>
 
     <section id="property-paths">
@@ -1447,6 +1438,60 @@ ex:alice a ex:Person ;
     <section id="patterns">
       <h2>Patterns</h2>
       <p class="note">Add common UI form patterns here, e.g., error handling and validation, conditional rendering, etc. For each section, clearly state whether it's normative or informative and describe its use case.</p>
+      <p class="ednote">TODO: consider removing the explicit "patterns" section and move these topics under <a href="#shacl-ui">SHACL UI</a></p>
+
+      <h3>Root Shapes and Entry-Point Forms</h3>
+      <p class="ednote">
+        TODO: Add a pattern describing how applications choose the initial node shape and focus node for rendering.
+        This pattern should explain that applications may nominate one or more root node shapes for entry-point forms.
+      </p>
+
+      <h3>Conditional Shape Selection</h3>
+      <p class="ednote">
+        Add a pattern for conditional or dynamic sub-forms. Consider how the following constraints would work here. sh:class, sh:node, sh:or, sh:qualifiedValueShape.
+      </p>
+
+      <h3>Enumerations, Select Lists, and Autocomplete</h3>
+      <p class="ednote">
+        Add a pattern for select widgets. This should cover common sources for option lists: sh:in, class-based instance selection,
+        SKOS concepts, node expressions, and implementation-provided query services. It should distinguish static enumerations from dynamic lookups.
+
+        Some of the UI meetings have discussed using node expressions, dynamic SHACL, and SPARQL with the SERVICE clause.
+      </p>
+      <div class="issue" data-number="846"></div>
+
+      <h3>Grouping, Ordering, and Layout Hints</h3>
+      <p class="ednote">
+        Add a pattern explaining how renderers can use sh:group, sh:order, and possibly implementation-specific layout annotations to organize property UI components.
+      </p>
+      <div class="issue" data-number="775"></div>
+      <div class="issue" data-number="824"></div>
+
+      <h3>Displaying Validation Results</h3>
+      <p class="ednote">
+        The pattern should describe how renderers may associate sh:ValidationResult entries with property UI components or node UI components,
+        using sh:focusNode, sh:resultPath, sh:value, sh:sourceShape, sh:resultSeverity, and sh:resultMessage. It should avoid defining when validation
+        runs or how submission is blocked.
+      </p>
+      <div class="issue" data-number="541"></div>
+
+      <h3>Role-Based Shapes</h3>
+      <p class="ednote">
+        The section should explain that a single shapes graph may contain shapes used for different purposes, and implementations may need to
+        distinguish validation shapes and UI rendering shapes.
+      </p>
+
+      <h3>Default Namespace and Local Name Generation</h3>
+      <p class="ednote">
+        We may need a more broader set of patterns documented for creating, updating, and deleting data via SHACL UI.
+      </p>
+      <div class="issue" data-number="855"></div>
+
+      <h3>Form error handling</h3>
+      <p class="ednote">
+        The pattern should describe how renderers may handle and display form errors, including validation errors and submission errors.
+      </p>
+      <div class="issue" data-number="823"></div>
     </section>
 
     <section id="builtin-widgets">

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1468,14 +1468,6 @@ ex:alice a ex:Person ;
       <div class="issue" data-number="775"></div>
       <div class="issue" data-number="824"></div>
 
-      <h3>Displaying Validation Results</h3>
-      <p class="ednote">
-        The pattern should describe how renderers may associate sh:ValidationResult entries with property UI components or node UI components,
-        using sh:focusNode, sh:resultPath, sh:value, sh:sourceShape, sh:resultSeverity, and sh:resultMessage. It should avoid defining when validation
-        runs or how submission is blocked.
-      </p>
-      <div class="issue" data-number="541"></div>
-
       <h3>Role-Based Shapes</h3>
       <p class="ednote">
         The section should explain that a single shapes graph may contain shapes used for different purposes, and implementations may need to
@@ -1493,6 +1485,17 @@ ex:alice a ex:Person ;
         The pattern should describe how renderers may handle and display form errors, including validation errors and submission errors.
       </p>
       <div class="issue" data-number="823"></div>
+      <div class="issue" data-number="541"></div>
+
+      <h4>Displaying Validation Results</h4>
+      <p class="ednote">
+        This sub-section should address the <em>"Mapping validation results to the form"</em> mentioned in <a href="https://github.com/w3c/data-shapes/issues/823">ISSUE 823</a>.
+      </p>
+      <p class="ednote">
+        The pattern should describe how renderers may associate sh:ValidationResult entries with property UI components or node UI components,
+        using sh:focusNode, sh:resultPath, sh:value, sh:sourceShape, sh:resultSeverity, and sh:resultMessage. It should avoid defining when validation
+        runs or how an applications prevents malformed submissions.
+      </p>
     </section>
 
     <section id="builtin-widgets">

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -627,7 +627,8 @@
       <section id="renderer">
         <h3>SHACL Renderer</h3>
         <p>
-          A SHACL Renderer is software that processes SHACL
+          A <dfn data-plurals="SHACL Renderers" id="dfn-shacl-renderer" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">SHACL Renderer</dfn>
+          is software that processes SHACL
             <a>shapes</a> and data and dynamically generates a user-interface using one
             or more <a>node UI components</a>. Implementations may add supplementary UI elements, such as a submit
             button to save changes, controls to toggle between edit and view modes, selectors for <a>focus node</a> and
@@ -657,7 +658,7 @@
         <h3>Node UI Component</h3>
 
         <div>
-          A Node UI Component is generated from a single <a>focus node</a>,
+          A <dfn data-plurals="Node UI Components" id="dfn-node-ui-component" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Node UI Component</dfn> is generated from a single <a>focus node</a>,
           typically containing one or more <a>property UI components</a>. It is often derived from one or more
           <a>node shapes</a> that apply to the <a>focus node</a>.
         </div>
@@ -667,7 +668,7 @@
         <h3>Property UI Component</h3>
 
         <div>
-            A Property UI Component is a combination of <a>constraints</a>
+            A <dfn data-plurals="Property UI Components" id="dfn-property-ui-component" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Property UI Component</dfn> is a combination of <a>constraints</a>
             across multiple <a>property shapes</a> that share the same <a>focus node</a> and <a>property path</a>.
           </div>
       </section>


### PR DESCRIPTION
Move the SHACL Renderer, Node UI Component, and Property UI Component material out of the terminology block and into a dedicated informative SHACL UI section.

Replace notes, placeholders and TODO with ednotes.

Link to relevant GitHub issues where applicable.

Sections touched are not complete yet. This is only scaffolding out the document structure.

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/ui/doc-scaffold/shacl12-ui/index.html)
