### PR TITLE
Shapes Rules Language grammar and other document work.

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -7,8 +7,6 @@
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
       var respecConfig = {
-        localBiblio: {},
-
         specStatus: "ED",
         group: "wg/data-shapes",
         github: "w3c/data-shapes",
@@ -18,7 +16,6 @@
         copyrightStart: "2025",
         // Can remove SHACL12-*?
         xref: ["RDF12-CONCEPTS", "SPARQL12-QUERY", "SHACL12-CORE", "SHACL12-SPARQL", "SHACL12-NODE-EXPR" ] ,
-        lint: { "no-unused-dfns": false },
 //        maxTocLevel: 2,
 
         editors: [
@@ -139,7 +136,6 @@
           padding-left: 0.4em;
       }
 
-
       .algorithm {
           /* <pre> written as CSS
           font-family: monospace;
@@ -147,6 +143,25 @@
           */
           color: #444;
       }
+
+      .grammarTable {
+          font-size: 12px;
+      }
+
+      /* CSS from Turtle*/
+
+      table.cp-definitions { border-collapse:collapse; background-color: #DDDDFF}
+      body.darkmode table.cp-definitions { background-color: black}
+
+      table.cp-definitions,
+      table.cp-definitions th,
+      table.cp-definitions td { border:0px solid black; padding:0.2em; }
+      table.cp-definitions td:nth-child(2) { text-align: center; }
+      
+      .term2escape-yes { background-color: lightgreen; }
+      .darkmode .term2escape-yes { background-color: darkgreen; }
+
+      
     </style>
 
   </head>
@@ -296,13 +311,29 @@
         </p>
         -->
       </section>
+    </section>
 
-      <section id="conformance">
+    <section id="conformance">
+      <!-- RFC 2119 boilerplate added automatically -->
+      <p class="todo">@@Needs adjusting and links</p>
+      <p>This specification defines conformance criteria for:</p>
+      <ul>
+        <li><a href="#rule-set-evaluation">SHACL Rule Set evaluation</a></li>
+        <li><a href="#shape-rules-syntax">Shapes Rule Language</a></li>
+      </ul>
 
-        <h3>Conformance</h3>
-        <p class="ednote">RFC 2119 language should be automatically inserted here.</p>
+      <p>A conforming 
+        <dfn 
+          data-lt="shapes rules language document|shapes rules document|ruleset document"
+          >Shapes Rules Language Document</dfn> is an
+        <a data-cite="RDF12-CONCEPTS#dfn-rdf-string">RDF string</a> that
+        conforms to the grammar, starting with the
+        <a href="#rRuleSet"><code>RuleSet</code></a>
+        production, and conforming to the additional constraints defined in
+        <a href="#shapes-rules-grammar" class="sectionRef"></a>
+      </p>
 
-      </section>
+      <p class="note">This specification does not define how SHACL Rules processors handle non-conforming input documents.</p>
     </section>
 
     <section id="overview" class="informative">
@@ -1677,7 +1708,7 @@ merge(S1, S2) = { <var>μ</var> |
             @@Walk imports - visit only once@@
           </p>
           <p class="ednote">
-            @@TODO: consider defining a rule set as having two components and a
+            <span class="todo">@@ TODO</span>: consider defining a rule set as having two components and a
             separate set of imports. i.e. imports are in the parsing and sorted out 
             to give a usable "rule set" of "rules + data"
           </p>
@@ -1900,976 +1931,335 @@ the result is GI
     <section id="shapes-rules-grammar">
       <h2>Shapes Rules Language Grammar</h2>
 
-      <!-- GRAMMAR -->
-      <div class="grammarTable">
-        <table><tbody>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[1]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rRuleSet">RuleSet</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rRuleOrDataBlock">RuleOrDataBlock</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[2]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rRuleOrDataBlock">RuleOrDataBlock</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPrologue">Prologue</a> ( <a href="#rRuleOrData">RuleOrData</a>+ ( <a href="#rPrologue1">Prologue1</a> <a href="#rRuleOrData">RuleOrData</a>? )* )?</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[3]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rRuleOrData">RuleOrData</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rRule">Rule</a> | <a href="#rData">Data</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[4]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPrologue">Prologue</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPrologue1">Prologue1</a>*</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[5]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPrologue1">Prologue1</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rBaseDecl">BaseDecl</a> | <a href="#rPrefixDecl">PrefixDecl</a> | <a href="#rVersionDecl">VersionDecl</a> | <a href="#rImportsDecl">ImportsDecl</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[6]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBaseDecl">BaseDecl</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'BASE'</span> <a href="#rIRIREF">IRIREF</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[7]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPrefixDecl">PrefixDecl</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'PREFIX'</span> <a href="#rPNAME_NS">PNAME_NS</a> <a href="#rIRIREF">IRIREF</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[8]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVersionDecl">VersionDecl</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'VERSION'</span> <a href="#rVersionSpecifier">VersionSpecifier</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[9]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVersionSpecifier">VersionSpecifier</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rSTRING_LITERAL1">STRING_LITERAL1</a> | <a href="#rSTRING_LITERAL2">STRING_LITERAL2</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[10]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rImportsDecl">ImportsDecl</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'IMPORTS'</span> <a href="#riri">iri</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[11]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rRule">Rule</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rRule1">Rule1</a> | <a href="#rRule2">Rule2</a> | <a href="#rDeclaration">Declaration</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[12]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rRule1">Rule1</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'RULE'</span> <a href="#rHeadTemplate">HeadTemplate</a> <span class="token">'WHERE'</span> <a href="#rBodyPattern">BodyPattern</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[13]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rRule2">Rule2</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'IF'</span> <a href="#rBodyPattern">BodyPattern</a> <span class="token">'THEN'</span> <a href="#rHeadTemplate">HeadTemplate</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[14]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDeclaration">Declaration</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">( <span class="token">'TRANSITIVE'</span> <span class="token">'('</span> <a href="#riri">iri</a> <span class="token">')'</span> | <span class="token">'SYMMETRIC'</span> <span class="token">'('</span> <a href="#riri">iri</a> <span class="token">')'</span> | <span class="token">'INVERSE'</span> <span class="token">'('</span> <a href="#riri">iri</a> <span class="token">','</span> <a href="#riri">iri</a> <span class="token">')'</span> )</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[15]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rData">Data</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'DATA'</span> <span class="token">'{'</span> <a href="#rTriplesDataBlock">TriplesDataBlock</a>? <span class="token">'}'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[16]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTriplesDataBlock">TriplesDataBlock</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rTriplesSameSubject">TriplesSameSubject</a> ( <span class="token">'.'</span> <a href="#rTriplesDataBlock">TriplesDataBlock</a>? )?</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[17]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rHeadTemplate">HeadTemplate</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rHeadTemplateBlock">HeadTemplateBlock</a>? <span class="token">'}'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[18]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBodyPattern">BodyPattern</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rBodyTriplesBlock">BodyTriplesBlock</a>? ( <a href="#rBodyNotTriples">BodyNotTriples</a> <a href="#rBodyTriplesBlock">BodyTriplesBlock</a>? )* <span class="token">'}'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[19]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBodyNotTriples">BodyNotTriples</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rFilter">Filter</a> | <a href="#rNegation">Negation</a> | <a href="#rAssignment">Assignment</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[20]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBodyTriplesBlock">BodyTriplesBlock</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rTriplesBlock">TriplesBlock</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[21]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNegation">Negation</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'NOT'</span> <span class="token">'{'</span> <a href="#rBodyBasic">BodyBasic</a> <span class="token">'}'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[22]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBodyBasic">BodyBasic</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rBodyTriplesBlock">BodyTriplesBlock</a>? ( <a href="#rFilter">Filter</a> <a href="#rBodyTriplesBlock">BodyTriplesBlock</a>? )*</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[23]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rHeadTemplateBlock">HeadTemplateBlock</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rTriplesBlock">TriplesBlock</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[24]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTriplesBlock">TriplesBlock</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rTriplesSameSubjectPath">TriplesSameSubjectPath</a> ( <span class="token">'.'</span> <a href="#rTriplesBlock">TriplesBlock</a>? )?</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[25]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rReifiedTripleBlock">ReifiedTripleBlock</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rReifiedTriple">ReifiedTriple</a> <a href="#rPropertyList">PropertyList</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[26]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rReifiedTripleBlockPath">ReifiedTripleBlockPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rReifiedTriple">ReifiedTriple</a> <a href="#rPropertyListPath">PropertyListPath</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[27]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rAssignment">Assignment</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'SET'</span> <span class="token">'('</span> <a href="#rVar">Var</a> <span class="token">':='</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[28]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rReifier">Reifier</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'~'</span> <a href="#rVarOrReifierId">VarOrReifierId</a>?</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[29]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVarOrReifierId">VarOrReifierId</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rBlankNode">BlankNode</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[30]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rFilter">Filter</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'FILTER'</span> <a href="#rConstraint">Constraint</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[31]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rConstraint">Constraint</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#rFunctionCall">FunctionCall</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[32]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rFunctionCall">FunctionCall</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#riri">iri</a> <a href="#rArgList">ArgList</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[33]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rArgList">ArgList</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rNIL">NIL</a> | <span class="token">'('</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )* <span class="token">')'</span> </code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[34]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rExpressionList">ExpressionList</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rNIL">NIL</a> | <span class="token">'('</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )* <span class="token">')'</span> </code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[35]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTriplesSameSubject">TriplesSameSubject</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> | <a href="#rTriplesNode">TriplesNode</a> <a href="#rPropertyList">PropertyList</a> | <a href="#rReifiedTripleBlock">ReifiedTripleBlock</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[36]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPropertyList">PropertyList</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a>?</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[37]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPropertyListNotEmpty">PropertyListNotEmpty</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVerb">Verb</a> <a href="#rObjectList">ObjectList</a> ( <span class="token">';'</span> ( <a href="#rVerb">Verb</a> <a href="#rObjectList">ObjectList</a> )? )*</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[38]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVerb">Verb</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVarOrIri">VarOrIri</a> | <span class="token">'a'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[39]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rObjectList">ObjectList</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rObject">Object</a> ( <span class="token">','</span> <a href="#rObject">Object</a> )*</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[40]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rObject">Object</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rGraphNode">GraphNode</a> <a href="#rAnnotation">Annotation</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[41]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTriplesSameSubjectPath">TriplesSameSubjectPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> | <a href="#rTriplesNodePath">TriplesNodePath</a> <a href="#rPropertyListPath">PropertyListPath</a> | <a href="#rReifiedTripleBlockPath">ReifiedTripleBlockPath</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[42]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPropertyListPath">PropertyListPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a>?</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[43]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPropertyListPathNotEmpty">PropertyListPathNotEmpty</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> ( <span class="token">';'</span> ( ( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> )? )*</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[44]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVerbPath">VerbPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPath">Path</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[45]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVerbSimple">VerbSimple</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVar">Var</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[46]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rObjectListPath">ObjectListPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rObjectPath">ObjectPath</a> ( <span class="token">','</span> <a href="#rObjectPath">ObjectPath</a> )*</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[47]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rObjectPath">ObjectPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rGraphNodePath">GraphNodePath</a> <a href="#rAnnotationPath">AnnotationPath</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[48]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPath">Path</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPathSequence">PathSequence</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[49]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPathSequence">PathSequence</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPathEltOrInverse">PathEltOrInverse</a> ( <span class="token">'/'</span> <a href="#rPathEltOrInverse">PathEltOrInverse</a> )*</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[50]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPathEltOrInverse">PathEltOrInverse</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPathElt">PathElt</a> | <span class="token">'^'</span> <a href="#rPathElt">PathElt</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[51]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPathElt">PathElt</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPathPrimary">PathPrimary</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[52]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPathPrimary">PathPrimary</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#riri">iri</a> | <span class="token">'a'</span> | <span class="token">'('</span> <a href="#rPath">Path</a> <span class="token">')'</span> </code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[53]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTriplesNode">TriplesNode</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rCollection">Collection</a> | <a href="#rBlankNodePropertyList">BlankNodePropertyList</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[54]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBlankNodePropertyList">BlankNodePropertyList</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'['</span> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> <span class="token">']'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[55]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTriplesNodePath">TriplesNodePath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rCollectionPath">CollectionPath</a> | <a href="#rBlankNodePropertyListPath">BlankNodePropertyListPath</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[56]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBlankNodePropertyListPath">BlankNodePropertyListPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'['</span> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> <span class="token">']'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[57]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rCollection">Collection</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rGraphNode">GraphNode</a>+ <span class="token">')'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[58]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rCollectionPath">CollectionPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rGraphNodePath">GraphNodePath</a>+ <span class="token">')'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[59]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rAnnotationPath">AnnotationPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">( <a href="#rReifier">Reifier</a> | <a href="#rAnnotationBlockPath">AnnotationBlockPath</a> )*</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[60]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rAnnotationBlockPath">AnnotationBlockPath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'{|'</span> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> <span class="token">'|}'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[61]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rAnnotation">Annotation</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">( <a href="#rReifier">Reifier</a> | <a href="#rAnnotationBlock">AnnotationBlock</a> )*</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[62]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rAnnotationBlock">AnnotationBlock</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'{|'</span> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> <span class="token">'|}'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[63]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGraphNode">GraphNode</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> | <a href="#rTriplesNode">TriplesNode</a> | <a href="#rReifiedTriple">ReifiedTriple</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[64]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rGraphNodePath">GraphNodePath</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> | <a href="#rTriplesNodePath">TriplesNodePath</a> | <a href="#rReifiedTriple">ReifiedTriple</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[65]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVarOrTerm">VarOrTerm</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#rRDFTerm">RDFTerm</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[66]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rRDFTerm">RDFTerm</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rNIL">NIL</a> | <a href="#rTripleTerm">TripleTerm</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[67]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rReifiedTriple">ReifiedTriple</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rReifiedTripleSubject">ReifiedTripleSubject</a> <a href="#rVerb">Verb</a> <a href="#rReifiedTripleObject">ReifiedTripleObject</a> <a href="#rReifier">Reifier</a>? <span class="token">'&gt;&gt;'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[68]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rReifiedTripleSubject">ReifiedTripleSubject</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rReifiedTriple">ReifiedTriple</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[69]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rReifiedTripleObject">ReifiedTripleObject</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rReifiedTriple">ReifiedTriple</a> | <a href="#rTripleTerm">TripleTerm</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[70]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTripleTerm">TripleTerm</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'&lt;&lt;('</span> <a href="#rTripleTermSubject">TripleTermSubject</a> <a href="#rVerb">Verb</a> <a href="#rTripleTermObject">TripleTermObject</a> <span class="token">')&gt;&gt;'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[71]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTripleTermSubject">TripleTermSubject</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[72]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTripleTermObject">TripleTermObject</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rTripleTerm">TripleTerm</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[73]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTripleTermData">TripleTermData</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'&lt;&lt;('</span> <a href="#rTripleTermDataSubject">TripleTermDataSubject</a> ( <a href="#riri">iri</a> | <span class="token">'a'</span> ) <a href="#rTripleTermDataObject">TripleTermDataObject</a> <span class="token">')&gt;&gt;'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[74]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTripleTermDataSubject">TripleTermDataSubject</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[75]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rTripleTermDataObject">TripleTermDataObject</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rTripleTermData">TripleTermData</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[76]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVarOrIri">VarOrIri</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[77]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVar">Var</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rVAR1">VAR1</a> | <a href="#rVAR2">VAR2</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[78]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rExpression">Expression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rConditionalOrExpression">ConditionalOrExpression</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[79]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rConditionalOrExpression">ConditionalOrExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rConditionalAndExpression">ConditionalAndExpression</a> ( <span class="token">'||'</span> <a href="#rConditionalAndExpression">ConditionalAndExpression</a> )*</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[80]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rConditionalAndExpression">ConditionalAndExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rValueLogical">ValueLogical</a> ( <span class="token">'&amp;&amp;'</span> <a href="#rValueLogical">ValueLogical</a> )*</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[81]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rValueLogical">ValueLogical</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rRelationalExpression">RelationalExpression</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[82]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rRelationalExpression">RelationalExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rNumericExpression">NumericExpression</a> ( <span class="token">'='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'!='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> | <span class="token">'NOT'</span> <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> )?</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[83]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNumericExpression">NumericExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rAdditiveExpression">AdditiveExpression</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[84]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rAdditiveExpression">AdditiveExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rMultiplicativeExpression">MultiplicativeExpression</a> ( <span class="token">'+'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | <span class="token">'-'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | ( <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a> ) ( ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) | ( <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) )* )*</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[85]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rMultiplicativeExpression">MultiplicativeExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rUnaryExpression">UnaryExpression</a> ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> | <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> )*</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[86]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rUnaryExpression">UnaryExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'!'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>| <span class="token">'+'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>| <span class="token">'-'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>| <a href="#rPrimaryExpression">PrimaryExpression</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[87]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPrimaryExpression">PrimaryExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#ririOrFunction">iriOrFunction</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprTripleTerm">ExprTripleTerm</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[88]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rExprTripleTerm">ExprTripleTerm</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'&lt;&lt;('</span> <a href="#rExprTripleTermSubject">ExprTripleTermSubject</a> <a href="#rVerb">Verb</a> <a href="#rExprTripleTermObject">ExprTripleTermObject</a> <span class="token">')&gt;&gt;'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[89]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rExprTripleTermSubject">ExprTripleTermSubject</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[90]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rExprTripleTermObject">ExprTripleTermObject</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprTripleTerm">ExprTripleTerm</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[91]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBrackettedExpression">BrackettedExpression</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[92]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBuiltInCall">BuiltInCall</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'STR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'LANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'LANGMATCHES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'LANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'DATATYPE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'IRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'BNODE'</span> ( <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> | <a href="#rNIL">NIL</a> ) <br/>| <span class="token">'ABS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'CEIL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'FLOOR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'ROUND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'CONCAT'</span> <a href="#rExpressionList">ExpressionList</a> <br/>| <span class="token">'SUBSTR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span> <br/>| <span class="token">'STRLEN'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'REPLACE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span> <br/>| <span class="token">'UCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'LCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'ENCODE_FOR_URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'CONTAINS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRSTARTS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRENDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRBEFORE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRAFTER'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'YEAR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'MONTH'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'DAY'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'HOURS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'MINUTES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'SECONDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'TIMEZONE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'TZ'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'NOW'</span> <a href="#rNIL">NIL</a> <br/>| <span class="token">'UUID'</span> <a href="#rNIL">NIL</a> <br/>| <span class="token">'STRUUID'</span> <a href="#rNIL">NIL</a> <br/>| <span class="token">'IF'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRLANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRDT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'sameTerm'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isIRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isURI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isBLANK'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isLITERAL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isNUMERIC'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'hasLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'hasLANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'REGEX'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span> <br/>| <span class="token">'isTRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'TRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'SUBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'PREDICATE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'OBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[93]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="ririOrFunction">iriOrFunction</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#riri">iri</a> <a href="#rArgList">ArgList</a>?</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[94]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rRDFLiteral">RDFLiteral</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rString">String</a> ( <a href="#rLANG_DIR">LANG_DIR</a> | <span class="token">'^^'</span> <a href="#riri">iri</a> )?</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[95]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNumericLiteral">NumericLiteral</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rNumericLiteralUnsigned">NumericLiteralUnsigned</a> | <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[96]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNumericLiteralUnsigned">NumericLiteralUnsigned</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rINTEGER">INTEGER</a> | <a href="#rDECIMAL">DECIMAL</a> | <a href="#rDOUBLE">DOUBLE</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[97]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNumericLiteralPositive">NumericLiteralPositive</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rINTEGER_POSITIVE">INTEGER_POSITIVE</a> | <a href="#rDECIMAL_POSITIVE">DECIMAL_POSITIVE</a> | <a href="#rDOUBLE_POSITIVE">DOUBLE_POSITIVE</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[98]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNumericLiteralNegative">NumericLiteralNegative</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rINTEGER_NEGATIVE">INTEGER_NEGATIVE</a> | <a href="#rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</a> | <a href="#rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[99]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBooleanLiteral">BooleanLiteral</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'true'</span> | <span class="token">'false'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[100]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rString">String</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rSTRING_LITERAL1">STRING_LITERAL1</a> | <a href="#rSTRING_LITERAL2">STRING_LITERAL2</a> | <a href="#rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</a> | <a href="#rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[101]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="riri">iri</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rIRIREF">IRIREF</a> | <a href="#rPrefixedName">PrefixedName</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[102]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPrefixedName">PrefixedName</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPNAME_LN">PNAME_LN</a> | <a href="#rPNAME_NS">PNAME_NS</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[103]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBlankNode">BlankNode</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rBLANK_NODE_LABEL">BLANK_NODE_LABEL</a> | <a href="#rANON">ANON</a></code></td>
-              </tr>
-        </tbody></table>
-      </div>
-      <p>Productions for terminals:</p>
-      <div class="grammarTable">
-        <table><tbody>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[104]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rIRIREF">IRIREF</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'&lt;' ([^&lt;&gt;"{}|^`\]-[#x00-#x20])* '&gt;'</span></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[105]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPNAME_NS">PNAME_NS</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPN_PREFIX">PN_PREFIX</a>? ':'</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[106]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPNAME_LN">PNAME_LN</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPNAME_NS">PNAME_NS</a> <a href="#rPN_LOCAL">PN_LOCAL</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[107]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rBLANK_NODE_LABEL">BLANK_NODE_LABEL</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">'_:' ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] ) ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[108]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVAR1">VAR1</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">'?' <a href="#rVARNAME">VARNAME</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[109]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVAR2">VAR2</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">'$' <a href="#rVARNAME">VARNAME</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[110]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rLANG_DIR">LANG_DIR</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">'@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)* ('--' [a-zA-Z]+)?</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[111]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rINTEGER">INTEGER</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">[0-9]+</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[112]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDECIMAL">DECIMAL</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">[0-9]* '.' [0-9]+</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[113]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDOUBLE">DOUBLE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">( ([0-9]+ ('.'[0-9]*)? ) | ( '.' ([0-9])+ ) ) [eE][+-]?[0-9]+</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[114]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rINTEGER_POSITIVE">INTEGER_POSITIVE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rINTEGER">INTEGER</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[115]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDECIMAL_POSITIVE">DECIMAL_POSITIVE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[116]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDOUBLE_POSITIVE">DOUBLE_POSITIVE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[117]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rINTEGER_NEGATIVE">INTEGER_NEGATIVE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rINTEGER">INTEGER</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[118]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[119]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[120]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rSTRING_LITERAL1">STRING_LITERAL1</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">"'" ( ([^#x27#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* "'"</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[121]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rSTRING_LITERAL2">STRING_LITERAL2</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">'"' ( ([^#x22#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> )* '"'</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[122]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">"'''" ( ( "'" | "''" )? ( [^'\] | <a href="#rECHAR">ECHAR</a> ) )* "'''"</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[123]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">'"""' ( ( '"' | '""' )? ( [^"\] | <a href="#rECHAR">ECHAR</a> ) )* '"""'</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[124]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rECHAR">ECHAR</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">'\' [tbnrf\"']</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[125]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rNIL">NIL</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">'(' <a href="#rWS">WS</a>* ')'</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[126]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rWS">WS</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">#x20 | #x9 | #xD | #xA</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[127]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rANON">ANON</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">'['  <a href="#rWS">WS</a>* ']'</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[128]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPN_CHARS_BASE">PN_CHARS_BASE</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">[A-Z] | [a-z] | [#x00C0-#x00D6] | [#x00D8-#x00F6] | [#x00F8-#x02FF] | [#x0370-#x037D] | [#x037F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[129]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPN_CHARS_U">PN_CHARS_U</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> | '_'</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[130]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rVARNAME">VARNAME</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">( <a href="#rPN_CHARS_U">PN_CHARS_U</a>  | [0-9] ) ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040] )*</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[131]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPN_CHARS">PN_CHARS</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPN_CHARS_U">PN_CHARS_U</a> | '-' | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040]</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[132]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPN_PREFIX">PN_PREFIX</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[133]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPN_LOCAL">PN_LOCAL</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">(<a href="#rPN_CHARS_U">PN_CHARS_U</a> | ':' | [0-9] | <a href="#rPLX">PLX</a> ) ((<a href="#rPN_CHARS">PN_CHARS</a> | '.' | ':' | <a href="#rPLX">PLX</a>)* (<a href="#rPN_CHARS">PN_CHARS</a> | ':' | <a href="#rPLX">PLX</a>) )?</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[134]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPLX">PLX</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody"><a href="#rPERCENT">PERCENT</a> | <a href="#rPN_LOCAL_ESC">PN_LOCAL_ESC</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[135]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPERCENT">PERCENT</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">'%' <a href="#rHEX">HEX</a> <a href="#rHEX">HEX</a></code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[136]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rHEX">HEX</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">[0-9] | [A-F] | [a-f]</code></td>
-              </tr>
-
-              <tr style="vertical-align: baseline">
-                <td><code>[137]&nbsp;&nbsp;</code></td>
-                <td><code><span class="doc-ref" id="rPN_LOCAL_ESC">PN_LOCAL_ESC</span></code></td>
-                <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
-                <td><code class="gRuleBody">'\' ( '_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | "'" | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%' )</code></td>
-              </tr>
-        </tbody></table>
-      </div>
-      <!-- GRAMMAR -->
+      <p>A <a>Shapes Rules Language document</a> is an <a data-cite="RDF12-CONCEPTS#dfn-rdf-string">RDF string</a>
+        encoded in UTF-8 [[!RFC3629]].
+        Only <a data-cite="I18N-GLOSSARY#dfn-scalar-value" class="lint-ignore">Unicode scalar values</a>,
+        in the ranges <code class="codepoint">U+0000</code> to <code class="codepoint">U+D7FF</code> 
+        and <code class="codepoint">U+E000</code> to <code class="codepoint">U+10FFFF</code>,
+        are allowed. This excludes 
+        <a data-cite="I18N-GLOSSARY#dfn-surrogate" class="lint-ignore">surrogate code points</a>,
+        range <code class="codepoint">U+D800</code> to <code class="codepoint">U+DFFF</code>.
+      </p>
+
+      <section id="grammar-ws">
+        <h3>White Space</h3>
+
+        <p>
+          White space
+          (production <a href="#rWS"><code>WS</code></a>) is used
+          to separate two terminals which would otherwise be (mis-)recognized as one
+          terminal. Rule names below in capitals indicate where white space is
+          significant; these form a possible choice of terminals for constructing a
+          Shapes Rules Language parser.
+        </p>
+
+        <p>
+          White space is significant in the production 
+          <a href="#rString"><code>String</code></a>.
+        </p>
+      </section>
+
+      <section id="grammar-comments">
+        <h3>Comments</h3>
+
+        <p>
+          Comments start with a <a href="#cp-number-sign"><code title="number sign">#</code></a> outside an
+          <a href="#rIRIREF"                     ><code>IRIREF</code></a>,
+          <a href="#rSTRING_LITERAL1"            ><code>STRING_LITERAL1</code></a>,
+          <a href="#rSTRING_LITERAL2"            ><code>STRING_LITERAL2</code></a>,
+          <a href="#rSTRING_LITERAL_LONG1"       ><code>STRING_LITERAL_LONG1</code></a>, or
+          <a href="#rSTRING_LITERAL_LONG2"       ><code>STRING_LITERAL_LONG2</code></a>,
+          and continue to the end of line (marked by
+          <a href="#cp-line-feed"><code title="line feed">LF</code></a>, or
+          <a href="#cp-carriage-return"><code title="carriage return">CR</code></a>),
+          or end of file if there is no end of line after the comment marker.
+          Comments are treated as white space.</p>
+      </section>
+
+      <section id="iri-references">
+        <h3>IRI References</h3>
+        <p>
+          <a data-cite="RDF12-CONCEPTS#dfn-relative-iri">Relative IRI references</a> are resolved with base IRIs
+          as per [[[RFC3986]]] [[RFC3986]] using only the basic algorithm in section 5.2.
+          Neither Syntax-Based Normalization nor Scheme-Based Normalization
+          (described in sections 6.2.2 and 6.2.3 of RFC3986) are performed.
+          Characters additionally allowed in IRI references are treated in the same way that
+          unreserved characters are treated in URI references, per section 6.5 of [[[RFC3987]]] [[RFC3987]].
+        </p>
+        <p>
+          The <a href="#rBaseDecl"><code>BASE</code></a>
+          directive defines the Base IRI used to
+          resolve <a data-cite="RDF12-CONCEPTS#dfn-relative-iri">relative IRI
+          references</a> per [[RFC3986]] 
+          <a data-cite="RFC3986#section-5.1.1">section 5.1.1, "Base URI Embedded in Content"</a>.
+          <a data-cite="RFC3986#section-5.1.2">Section 5.1.2, "Base URI from the Encapsulating Entity"</a>
+          defines how the In-Scope Base IRI may come from an encapsulating document,
+          such as a SOAP envelope with an `xml:base` directive or a MIME multipart document with a
+          `Content-Location` header.
+          The "Retrieval URI" identified in <a data-cite="RFC3986#section-5.1.3">5.1.3, Base "URI from the Retrieval URI"</a>,
+          is the URL from which a particular <a>Shapes Rules Language document</a> was retrieved.
+          If none of the above specifies the Base URI, the default
+          Base URI (<a data-cite="RFC3986#section-5.1.4">section 5.1.4, "Default Base URI"</a>) is used.
+          Each <a href="#rBaseDecl"><code>BASE</code></a> directive sets a new In-Scope Base URI,
+          relative to the previous one.
+        </p>
+      </section>
+
+      <section id="escapes">
+        <h3>Escape Sequences</h3>
+
+        <p>There are three forms of escapes used in <a>Shapes Rules documents</a>:</p>
+
+        <ul>
+          <li>
+            <p>
+              A <dfn>numeric escape sequence</dfn> represents the value of
+              a <a data-cite="I18N-GLOSSARY#dfn-code-point">Unicode code point</a>.
+            </p>
+            <p>
+              A <a>numeric escape sequence</a> MUST NOT produce a code point value
+              in the range <code class="codepoint">U+D800</code> to <code class="codepoint">U+DFFF</code>,
+              which is the range for 
+              Unicode <a data-cite="I18N-GLOSSARY#dfn-surrogate" class="lint-ignore">surrogates</a>.
+            </p>
+            <table id="tab-uchar" class="separated">
+              <thead>
+                <tr>
+                  <th>Escape sequence</th>
+                  <th>Unicode code point</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>\u</code> <a href="#rHEX"><code>hex</code></a>
+                    <a href="#rHEX"><code>hex</code></a>
+                    <a href="#rHEX"><code>hex</code></a>
+                    <a href="#rHEX"><code>hex</code></a></td>
+                  <td>A <a data-cite="I18N-GLOSSARY#dfn-code-point">Unicode code point</a>
+                    in the ranges <code class="codepoint">U+0000</code> to <code class="codepoint">U+D7FF</code>
+                    and <code class="codepoint">U+E000</code> to <code class="codepoint">U+FFFF</code>,
+                    corresponding to the value encoded by the four hexadecimal digits interpreted
+                    from most significant to least significant digit.</td>
+                </tr>
+                <tr>
+                  <td><code>\U</code> <a href="#rHEX"><code>hex</code></a>
+                    <a href="#rHEX"><code>hex</code></a>
+                    <a href="#rHEX"><code>hex</code></a>
+                    <a href="#rHEX"><code>hex</code></a>
+                    <a href="#rHEX"><code>hex</code></a>
+                    <a href="#rHEX"><code>hex</code></a>
+                    <a href="#rHEX"><code>hex</code></a>
+                    <a href="#rHEX"><code>hex</code></a></td>
+                  <td>A <a data-cite="I18N-GLOSSARY#dfn-code-point">Unicode code point</a>
+                    in the ranges <code class="codepoint">U+0000</code> to
+                    <code class="codepoint">U+D7FF</code>
+                    and <code class="codepoint">U+E000</code> to <code class="codepoint">U+10FFFF</code>,
+                    corresponding to the value encoded by the eight hexadecimal digits
+                    interpreted from most significant to least significant digit.</td>
+                </tr>
+              </tbody>
+            </table>
+            <p>where <a href="#rHEX"><code>hex</code></a> is a hexadecimal character</p>
+            <p style="margin-left: 2em"><code><a href="#rHEX"><code>HEX</code></a> ::= [0-9] | [A-F] | [a-f]</code></p>
+          </li>
+
+          <li>
+            <p>
+              A <dfn>string escape sequence</dfn> represents a character traditionally escaped in string literals:
+            </p>
+            <table id="tab-echar" class="separated">
+              <thead>
+                <tr>
+                  <th>Escape sequence</th>
+                  <th>Unicode code point</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>\t</code></td>
+                  <td><code class="codepoint">U+0009</code></td>
+                </tr>
+
+                <tr>
+                  <td><code>\b</code></td>
+                  <td><code class="codepoint">U+0008</code></td>
+                </tr>
+
+                <tr>
+                  <td><code>\n</code></td>
+                  <td><code class="codepoint">U+000A</code></td>
+                </tr>
+
+                <tr>
+                  <td><code>\r</code></td>
+                  <td><code class="codepoint">U+000D</code></td>
+                </tr>
+
+                <tr>
+                  <td><code>\f</code></td>
+                  <td><code class="codepoint">U+000C</code></td>
+                </tr>
+
+                <tr>
+                  <td><code>\"</code></td>
+                  <td><code class="codepoint">U+0022</code></td>
+                </tr>
+
+                <tr>
+                  <td><code>\'</code></td>
+                  <td><code class="codepoint">U+0027</code></td>
+                </tr>
+
+                <tr>
+                  <td><code>\\</code></td>
+                  <td><code class="codepoint">U+005C</code></td>
+                </tr>
+              </tbody>
+            </table>
+          </li>
+
+          <li> 
+            <p>
+              A <dfn>reserved character escape sequence</dfn> consists of a
+              <a href="#cp-backslash"><code title="backslash">\</code></a> followed by
+              one of these characters <code>~.-!$&amp;'()*+,;=/?#@%_</code>, and
+              represents the character to the right of
+              the <a href="#cp-backslash"><code title="backslash">\</code></a>.
+            </p>
+          </li>
+        </ul>
+
+        <table id="term2escape" class="separated last-center">
+          <caption>Context where each kind of escape sequence can be used</caption>
+          <thead>
+            <tr>
+              <th></th>
+              <th><a data-lt="numeric escape sequence">numeric<br/>escapes</a></th>
+              <th><a data-lt="string escape sequence">string<br/>escapes</a></th>
+              <th><a data-lt="reserved character escape sequence">reserved character<br/>escapes</a></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="r"><span style="font-weight:bold;">IRI</span>s,
+                used as <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF terms</a>
+                <a href="#rPrefixDecl"><code>PREFIX</code></a>,
+                or <a href="#rBaseDecl"><code>BASE</code></a> declarations</td>
+              <td class="term2escape-yes">yes</td>
+              <td>no</td>
+              <td>no</td>
+            </tr>
+            <tr>
+              <td class="r"><a href="#rPN_LOCAL"><span style="font-weight:bold;">local name</span>s</a></td>
+              <td>no</td>
+              <td>no</td>
+              <td class="term2escape-yes">yes</td>
+            </tr>
+            <tr>
+              <td class="r"><span style="font-weight:bold;">String</span>s</td>
+              <td class="term2escape-yes">yes</td>
+              <td class="term2escape-yes">yes</td>
+              <td>no</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p class="note">%-encoded sequences are in the
+          <a href="#rIRIREF">character range for IRIs</a>
+          and are <a href="#rPERCENT">explicitly allowed</a> in local names.
+          These appear as a <a href="#cp-percent-sign"><code title="percent sign">%</code></a>
+          followed by two hex characters and represent that
+          same sequence of three characters. These sequences are <em>not</em>
+          decoded during processing.
+          A term written as <code>&lt;http://a.example/%66oo-bar&gt;</code>
+          designates the IRI <code>http://a.example/%66oo-bar</code>
+          and not IRI <code>http://a.example/foo-bar</code>.
+          A term written as <code>ex:%66oo-bar</code> with a prefix
+          <code>PREFIX ex: &lt;http://a.example/&gt;</code>
+          also designates the IRI <code>http://a.example/%66oo-bar</code>.</p>
+      </section>
+
+      <section id="grammar">
+        <h3>Grammar</h3>
+        <p>The <abbr title="Extended Backus–Naur Form">EBNF</abbr> used here is defined in XML 1.0
+          [[!EBNF-NOTATION]].
+        </p>
+        <div>
+          <p>Notes:</p>
+          <ol>
+            <li>
+              Keywords are case-insensitive except for 
+              '<code class="grammar-literal">a</code>'
+              which is case-sensitive.
+            </li>
+            <li>
+              Escape sequences <a href="#rUCHAR"><code>UCHAR</code></a>
+              and <a href="#rECHAR"><code>ECHAR</code></a>
+              are case sensitive.
+            </li>
+            <li>
+              When tokenizing the input and choosing grammar rules, the longest match is chosen.
+            </li>
+            <li>
+              The Shapes Rules Language grammar is LL(1) and LALR(1) when the rules with uppercased names
+              are used as terminals.
+            </li>
+            <li>
+              The entry point into the grammar is <a href="#rRuleSet"><code>RuleSet</code></a>.
+            </li>
+          </ol>
+        </div>
+
+        <div data-include="shapes-rule-language.html"></div>
+
+        <p>
+          A text version of this grammar is available 
+          <a href="shapes-rule-language.bnf">here</a>.
+        </p>
+        
+      </section>
+
+      <section id ="terminal-literal-strings">
+        <h3>Selected Terminal Literal Strings</h3>
+        <p>
+          This document uses some specific terminal literal strings
+          [[EBNF-NOTATION]].  To clarify the Unicode code points used for these
+          terminal literal strings, the following table describes specific
+          characters used in this section.
+        </p>
+        <table class="cp-definitions">
+          <thead>
+            <tr><th>Code</th><th>Glyph</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr id="cp-line-feed">
+              <td><code class="codepoint">U+000A</code></td>
+              <td><code title="line feed">LF</code></td>
+              <td>Line feed</td>
+            </tr>
+            <tr id="cp-carriage-return">
+              <td><code class="codepoint">U+000D</code></td>
+              <td><code title="carriage return">CR</code></td>
+              <td>Carriage return</td>
+            </tr>
+            <tr id="cp-number-sign">
+              <td><code class="codepoint">U+0023</code></td>
+              <td><code title="number sign">#</code></td>
+              <td>Number sign</td>
+            </tr>
+            <tr id="cp-percent-sign">
+              <td><code class="codepoint">U+0025</code></td>
+              <td><code title="percent sign">%</code></td>
+              <td>Percent sign</td>
+            </tr>
+            <tr id="cp-backslash">
+              <td><code class="codepoint">U+005C</code></td>
+              <td><code title="backslash">\</code></td>
+              <td>Backslash</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
 
     </section>
 
@@ -2960,22 +2350,22 @@ the result is GI
 
     <section id="security" class="appendix informative">
       <h2>Security Considerations</h2>
-      <p>TODO</p>
+      <p class="todo">TODO</p>
     </section>
 
     <section id="privacy" class="appendix informative">
       <h2>Privacy Considerations</h2>
-      <p>TODO</p>
+      <p class="todo">TODO</p>
     </section>
 
     <section id="internationalization" class="appendix informative">
       <h2>Internationalization Considerations</h2>
-      <p>TODO</p>
+      <p class="todo">TODO</p>
     </section>
 
     <section id="ack" class="appendix informative">
       <h2>Acknowledgements</h2>
-      <p>Many people contributed to this document, including members of the RDF Data Shapes Working Group.</p>
+      <p class="todo">TODO</p>
     </section>
 
     <section id="index"></section>

--- a/shacl12-rules/shapes-rule-language.bnf
+++ b/shacl12-rules/shapes-rule-language.bnf
@@ -1,0 +1,209 @@
+RuleSet                   ::= RuleOrDataBlock
+RuleOrDataBlock           ::= Prologue ( RuleOrData+ ( Prologue1 RuleOrData? )* )?
+RuleOrData                ::= Rule | Data
+Prologue                  ::= Prologue1*
+Prologue1                 ::= BaseDecl | PrefixDecl | VersionDecl | ImportsDecl
+BaseDecl                  ::= 'BASE' IRIREF
+PrefixDecl                ::= 'PREFIX' PNAME_NS IRIREF
+VersionDecl               ::= 'VERSION' VersionSpecifier
+VersionSpecifier          ::= STRING_LITERAL1 | STRING_LITERAL2
+ImportsDecl               ::= 'IMPORTS' iri
+Rule                      ::= Rule1 | Rule2 | Declaration
+Rule1                     ::= 'RULE' HeadTemplate 'WHERE' BodyPattern
+Rule2                     ::= 'IF' BodyPattern 'THEN' HeadTemplate
+Declaration               ::= ( 'TRANSITIVE' '(' iri ')' | 'SYMMETRIC' '(' iri ')' | 'INVERSE' '(' iri ',' iri ')' )
+Data                      ::= 'DATA' '{' TriplesDataBlock? '}'
+TriplesDataBlock          ::= TriplesSameSubject ( '.' TriplesDataBlock? )?
+HeadTemplate              ::= '{' HeadTemplateBlock? '}'
+BodyPattern               ::= '{' BodyTriplesBlock? ( BodyNotTriples BodyTriplesBlock? )* '}'
+BodyNotTriples            ::= Filter | Negation | Assignment
+BodyTriplesBlock          ::= TriplesBlock
+Negation                  ::= 'NOT' '{' BodyBasic '}'
+BodyBasic                 ::= BodyTriplesBlock? ( Filter BodyTriplesBlock? )*
+HeadTemplateBlock         ::= TriplesBlock
+TriplesBlock              ::= TriplesSameSubjectPath ( '.' TriplesBlock? )?
+ReifiedTripleBlock        ::= ReifiedTriple PropertyList
+ReifiedTripleBlockPath    ::= ReifiedTriple PropertyListPath
+Assignment                ::= 'SET' '(' Var ':=' Expression ')'
+Reifier                   ::= '~' VarOrReifierId?
+VarOrReifierId            ::= Var | iri | BlankNode
+Filter                    ::= 'FILTER' Constraint
+Constraint                ::= BrackettedExpression | BuiltInCall | FunctionCall
+FunctionCall              ::= iri ArgList
+ArgList                   ::= NIL | '(' Expression ( ',' Expression )* ')' 
+ExpressionList            ::= NIL | '(' Expression ( ',' Expression )* ')' 
+TriplesSameSubject        ::= VarOrTerm PropertyListNotEmpty | TriplesNode PropertyList | ReifiedTripleBlock
+PropertyList              ::= PropertyListNotEmpty?
+PropertyListNotEmpty      ::= Verb ObjectList ( ';' ( Verb ObjectList )? )*
+Verb                      ::= VarOrIri | 'a'
+ObjectList                ::= Object ( ',' Object )*
+Object                    ::= GraphNode Annotation
+TriplesSameSubjectPath    ::= VarOrTerm PropertyListPathNotEmpty | TriplesNodePath PropertyListPath | ReifiedTripleBlockPath
+PropertyListPath          ::= PropertyListPathNotEmpty?
+PropertyListPathNotEmpty  ::= ( VerbPath | VerbSimple ) ObjectListPath ( ';' ( ( VerbPath | VerbSimple ) ObjectListPath )? )*
+VerbPath                  ::= Path
+VerbSimple                ::= Var
+ObjectListPath            ::= ObjectPath ( ',' ObjectPath )*
+ObjectPath                ::= GraphNodePath AnnotationPath
+Path                      ::= PathSequence
+PathSequence              ::= PathEltOrInverse ( '/' PathEltOrInverse )*
+PathEltOrInverse          ::= PathElt | '^' PathElt
+PathElt                   ::= PathPrimary
+PathPrimary               ::= iri | 'a' | '(' Path ')' 
+TriplesNode               ::= Collection | BlankNodePropertyList
+BlankNodePropertyList     ::= '[' PropertyListNotEmpty ']'
+TriplesNodePath           ::= CollectionPath | BlankNodePropertyListPath
+BlankNodePropertyListPath ::= '[' PropertyListPathNotEmpty ']'
+Collection                ::= '(' GraphNode+ ')'
+CollectionPath            ::= '(' GraphNodePath+ ')'
+AnnotationPath            ::= ( Reifier | AnnotationBlockPath )*
+AnnotationBlockPath       ::= '{|' PropertyListPathNotEmpty '|}'
+Annotation                ::= ( Reifier | AnnotationBlock )*
+AnnotationBlock           ::= '{|' PropertyListNotEmpty '|}'
+GraphNode                 ::= VarOrTerm | TriplesNode | ReifiedTriple
+GraphNodePath             ::= VarOrTerm | TriplesNodePath | ReifiedTriple
+VarOrTerm                 ::= Var | RDFTerm
+RDFTerm                   ::= iri | RDFLiteral | NumericLiteral | BooleanLiteral | BlankNode | NIL | TripleTerm
+ReifiedTriple             ::= '<<' ReifiedTripleSubject Verb ReifiedTripleObject Reifier? '>>'
+ReifiedTripleSubject      ::= Var | iri | RDFLiteral | NumericLiteral | BooleanLiteral | BlankNode | ReifiedTriple
+ReifiedTripleObject       ::= Var | iri | RDFLiteral | NumericLiteral | BooleanLiteral | BlankNode | ReifiedTriple | TripleTerm
+TripleTerm                ::= '<<(' TripleTermSubject Verb TripleTermObject ')>>'
+TripleTermSubject         ::= Var | iri | RDFLiteral | NumericLiteral | BooleanLiteral | BlankNode
+TripleTermObject          ::= Var | iri | RDFLiteral | NumericLiteral | BooleanLiteral | BlankNode | TripleTerm
+TripleTermData            ::= '<<(' TripleTermDataSubject ( iri | 'a' ) TripleTermDataObject ')>>'
+TripleTermDataSubject     ::= iri | RDFLiteral | NumericLiteral | BooleanLiteral
+TripleTermDataObject      ::= iri | RDFLiteral | NumericLiteral | BooleanLiteral | TripleTermData
+VarOrIri                  ::= Var | iri
+Var                       ::= VAR1 | VAR2
+Expression                ::= ConditionalOrExpression
+ConditionalOrExpression   ::= ConditionalAndExpression ( '||' ConditionalAndExpression )*
+ConditionalAndExpression  ::= ValueLogical ( '&&' ValueLogical )*
+ValueLogical              ::= RelationalExpression
+RelationalExpression      ::= NumericExpression ( '=' NumericExpression | '!=' NumericExpression | '<' NumericExpression | '>' NumericExpression | '<=' NumericExpression | '>=' NumericExpression | 'IN' ExpressionList | 'NOT' 'IN' ExpressionList )?
+NumericExpression         ::= AdditiveExpression
+AdditiveExpression        ::= MultiplicativeExpression ( '+' MultiplicativeExpression | '-' MultiplicativeExpression | ( NumericLiteralPositive | NumericLiteralNegative ) ( ( '*' UnaryExpression ) | ( '/' UnaryExpression ) )* )*
+MultiplicativeExpression  ::= UnaryExpression ( '*' UnaryExpression | '/' UnaryExpression )*
+UnaryExpression           ::= '!' PrimaryExpression 
+                          |   '+' PrimaryExpression 
+                          |   '-' PrimaryExpression 
+                          |   PrimaryExpression
+PrimaryExpression         ::= BrackettedExpression | BuiltInCall | iriOrFunction | RDFLiteral | NumericLiteral | BooleanLiteral | Var | ExprTripleTerm
+ExprTripleTerm            ::= '<<(' ExprTripleTermSubject Verb ExprTripleTermObject ')>>'
+ExprTripleTermSubject     ::= iri | RDFLiteral | NumericLiteral | BooleanLiteral | Var
+ExprTripleTermObject      ::= iri | RDFLiteral | NumericLiteral | BooleanLiteral | Var | ExprTripleTerm
+BrackettedExpression      ::= '(' Expression ')'
+BuiltInCall               ::= 'STR' '(' Expression ')' 
+                          |   'LANG' '(' Expression ')' 
+                          |   'LANGMATCHES' '(' Expression ',' Expression ')' 
+                          |   'LANGDIR' '(' Expression ')' 
+                          |   'DATATYPE' '(' Expression ')' 
+                          |   'IRI' '(' Expression ')' 
+                          |   'URI' '(' Expression ')' 
+                          |   'BNODE' ( '(' Expression ')' | NIL ) 
+                          |   'ABS' '(' Expression ')' 
+                          |   'CEIL' '(' Expression ')' 
+                          |   'FLOOR' '(' Expression ')' 
+                          |   'ROUND' '(' Expression ')' 
+                          |   'CONCAT' ExpressionList 
+                          |   'SUBSTR' '(' Expression ',' Expression ( ',' Expression )? ')' 
+                          |   'STRLEN' '(' Expression ')' 
+                          |   'REPLACE' '(' Expression ',' Expression ',' Expression ( ',' Expression )? ')' 
+                          |   'UCASE' '(' Expression ')' 
+                          |   'LCASE' '(' Expression ')' 
+                          |   'ENCODE_FOR_URI' '(' Expression ')' 
+                          |   'CONTAINS' '(' Expression ',' Expression ')' 
+                          |   'STRSTARTS' '(' Expression ',' Expression ')' 
+                          |   'STRENDS' '(' Expression ',' Expression ')' 
+                          |   'STRBEFORE' '(' Expression ',' Expression ')' 
+                          |   'STRAFTER' '(' Expression ',' Expression ')' 
+                          |   'YEAR' '(' Expression ')' 
+                          |   'MONTH' '(' Expression ')' 
+                          |   'DAY' '(' Expression ')' 
+                          |   'HOURS' '(' Expression ')' 
+                          |   'MINUTES' '(' Expression ')' 
+                          |   'SECONDS' '(' Expression ')' 
+                          |   'TIMEZONE' '(' Expression ')' 
+                          |   'TZ' '(' Expression ')' 
+                          |   'NOW' NIL 
+                          |   'UUID' NIL 
+                          |   'STRUUID' NIL 
+                          |   'IF' '(' Expression ',' Expression ',' Expression ')' 
+                          |   'STRLANG' '(' Expression ',' Expression ')' 
+                          |   'STRLANGDIR' '(' Expression ',' Expression ',' Expression ')' 
+                          |   'STRDT' '(' Expression ',' Expression ')' 
+                          |   'sameTerm' '(' Expression ',' Expression ')' 
+                          |   'isIRI' '(' Expression ')' 
+                          |   'isURI' '(' Expression ')' 
+                          |   'isBLANK' '(' Expression ')' 
+                          |   'isLITERAL' '(' Expression ')' 
+                          |   'isNUMERIC' '(' Expression ')' 
+                          |   'hasLANG' '(' Expression ')' 
+                          |   'hasLANGDIR' '(' Expression ')' 
+                          |   'REGEX' '(' Expression ',' Expression ( ',' Expression )? ')' 
+                          |   'isTRIPLE' '(' Expression ')' 
+                          |   'TRIPLE' '(' Expression ',' Expression ',' Expression ')' 
+                          |   'SUBJECT' '(' Expression ')' 
+                          |   'PREDICATE' '(' Expression ')' 
+                          |   'OBJECT' '(' Expression ')'
+iriOrFunction             ::= iri ArgList?
+RDFLiteral                ::= String ( LANG_DIR | '^^' iri )?
+NumericLiteral            ::= NumericLiteralUnsigned | NumericLiteralPositive | NumericLiteralNegative
+NumericLiteralUnsigned    ::= INTEGER | DECIMAL | DOUBLE
+NumericLiteralPositive    ::= INTEGER_POSITIVE | DECIMAL_POSITIVE | DOUBLE_POSITIVE
+NumericLiteralNegative    ::= INTEGER_NEGATIVE | DECIMAL_NEGATIVE | DOUBLE_NEGATIVE
+BooleanLiteral            ::= 'true' | 'false'
+String                    ::= STRING_LITERAL1 | STRING_LITERAL2 | STRING_LITERAL_LONG1 | STRING_LITERAL_LONG2
+iri                       ::= IRIREF | PrefixedName
+PrefixedName              ::= PNAME_LN | PNAME_NS
+BlankNode                 ::= BLANK_NODE_LABEL | ANON
+
+@terminals
+
+IRIREF                    ::= '<' ([^<>"{}|^`\]-[#x00-#x20] | <UCHAR> )* '>'
+PNAME_NS                  ::= PN_PREFIX? ':'
+PNAME_LN                  ::= PNAME_NS PN_LOCAL
+BLANK_NODE_LABEL          ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
+VAR1                      ::= '?' VARNAME
+VAR2                      ::= '$' VARNAME
+LANG_DIR                  ::= '@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)* ('--' [a-zA-Z]+)?
+INTEGER                   ::= [0-9]+
+DECIMAL                   ::= [0-9]* '.' [0-9]+
+DOUBLE                    ::= ( ([0-9]+ ('.'[0-9]*)? ) | ( '.' ([0-9])+ ) ) [eE][+-]?[0-9]+
+INTEGER_POSITIVE          ::= '+' INTEGER
+DECIMAL_POSITIVE          ::= '+' DECIMAL
+DOUBLE_POSITIVE           ::= '+' DOUBLE
+INTEGER_NEGATIVE          ::= '-' INTEGER
+DECIMAL_NEGATIVE          ::= '-' DECIMAL
+DOUBLE_NEGATIVE           ::= '-' DOUBLE
+STRING_LITERAL1           ::= "'" ( ([^#x27#x5C#xA#xD]) | ECHAR | UCHAR )* "'"
+STRING_LITERAL2           ::= '"' ( ([^#x22#x5C#xA#xD]) | ECHAR | UCHAR )* '"'
+STRING_LITERAL_LONG1      ::= "'''" ( ( "'" | "''" )? ( [^'\] | ECHAR | UCHAR ) )* "'''"
+STRING_LITERAL_LONG2      ::= '"""' ( ( '"' | '""' )? ( [^"\] | ECHAR | UCHAR ) )* '"""'
+ECHAR                     ::= '\' [tbnrf\"']
+UCHAR                     ::= ('\u' HEX HEX HEX HEX) | ('\U' HEX HEX HEX HEX HEX HEX HEX HEX)
+NIL                       ::= '(' WS* ')'
+WS                        ::= #x20 | #x9 | #xD | #xA
+ANON                      ::= '['  WS* ']'
+PN_CHARS_BASE             ::= [A-Z] 
+                          |   [a-z] 
+                          |   [#x00C0-#x00D6] 
+                          |   [#x00D8-#x00F6] 
+                          |   [#x00F8-#x02FF] 
+                          |   [#x0370-#x037D] 
+                          |   [#x037F-#x1FFF] 
+                          |   [#x200C-#x200D] 
+                          |   [#x2070-#x218F] 
+                          |   [#x2C00-#x2FEF] 
+                          |   [#x3001-#xD7FF] 
+                          |   [#xF900-#xFDCF] 
+                          |   [#xFDF0-#xFFFD] 
+                          |   [#x10000-#xEFFFF]
+PN_CHARS_U                ::= PN_CHARS_BASE | '_'
+VARNAME                   ::= ( PN_CHARS_U  | [0-9] ) ( PN_CHARS_U | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040] )*
+PN_CHARS                  ::= PN_CHARS_U | '-' | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040]
+PN_PREFIX                 ::= PN_CHARS_BASE ((PN_CHARS|'.')* PN_CHARS)?
+PN_LOCAL                  ::= (PN_CHARS_U | ':' | [0-9] | PLX ) ((PN_CHARS | '.' | ':' | PLX)* (PN_CHARS | ':' | PLX) )?
+PLX                       ::= PERCENT | PN_LOCAL_ESC
+PERCENT                   ::= '%' HEX HEX
+HEX                       ::= [0-9] | [A-F] | [a-f]
+PN_LOCAL_ESC              ::= '\' ( '_' | '~' | '.' | '-' | '!' | '$' | '&' | "'" | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%' )

--- a/shacl12-rules/shapes-rule-language.html
+++ b/shacl12-rules/shapes-rule-language.html
@@ -1,0 +1,977 @@
+<!-- GRAMMAR -->
+<div class="grammarTable">
+  <table><tbody>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[1]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rRuleSet">RuleSet</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rRuleOrDataBlock">RuleOrDataBlock</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[2]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rRuleOrDataBlock">RuleOrDataBlock</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPrologue">Prologue</a> ( <a href="#rRuleOrData">RuleOrData</a>+ ( <a href="#rPrologue1">Prologue1</a> <a href="#rRuleOrData">RuleOrData</a>? )* )?</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[3]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rRuleOrData">RuleOrData</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rRule">Rule</a> | <a href="#rData">Data</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[4]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPrologue">Prologue</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPrologue1">Prologue1</a>*</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[5]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPrologue1">Prologue1</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rBaseDecl">BaseDecl</a> | <a href="#rPrefixDecl">PrefixDecl</a> | <a href="#rVersionDecl">VersionDecl</a> | <a href="#rImportsDecl">ImportsDecl</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[6]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rBaseDecl">BaseDecl</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'BASE'</span> <a href="#rIRIREF">IRIREF</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[7]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPrefixDecl">PrefixDecl</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'PREFIX'</span> <a href="#rPNAME_NS">PNAME_NS</a> <a href="#rIRIREF">IRIREF</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[8]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rVersionDecl">VersionDecl</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'VERSION'</span> <a href="#rVersionSpecifier">VersionSpecifier</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[9]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rVersionSpecifier">VersionSpecifier</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rSTRING_LITERAL1">STRING_LITERAL1</a> | <a href="#rSTRING_LITERAL2">STRING_LITERAL2</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[10]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rImportsDecl">ImportsDecl</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'IMPORTS'</span> <a href="#riri">iri</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[11]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rRule">Rule</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rRule1">Rule1</a> | <a href="#rRule2">Rule2</a> | <a href="#rDeclaration">Declaration</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[12]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rRule1">Rule1</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'RULE'</span> <a href="#rHeadTemplate">HeadTemplate</a> <span class="token">'WHERE'</span> <a href="#rBodyPattern">BodyPattern</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[13]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rRule2">Rule2</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'IF'</span> <a href="#rBodyPattern">BodyPattern</a> <span class="token">'THEN'</span> <a href="#rHeadTemplate">HeadTemplate</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[14]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rDeclaration">Declaration</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">( <span class="token">'TRANSITIVE'</span> <span class="token">'('</span> <a href="#riri">iri</a> <span class="token">')'</span> | <span class="token">'SYMMETRIC'</span> <span class="token">'('</span> <a href="#riri">iri</a> <span class="token">')'</span> | <span class="token">'INVERSE'</span> <span class="token">'('</span> <a href="#riri">iri</a> <span class="token">','</span> <a href="#riri">iri</a> <span class="token">')'</span> )</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[15]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rData">Data</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'DATA'</span> <span class="token">'{'</span> <a href="#rTriplesDataBlock">TriplesDataBlock</a>? <span class="token">'}'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[16]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rTriplesDataBlock">TriplesDataBlock</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rTriplesSameSubject">TriplesSameSubject</a> ( <span class="token">'.'</span> <a href="#rTriplesDataBlock">TriplesDataBlock</a>? )?</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[17]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rHeadTemplate">HeadTemplate</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rHeadTemplateBlock">HeadTemplateBlock</a>? <span class="token">'}'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[18]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rBodyPattern">BodyPattern</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'{'</span> <a href="#rBodyTriplesBlock">BodyTriplesBlock</a>? ( <a href="#rBodyNotTriples">BodyNotTriples</a> <a href="#rBodyTriplesBlock">BodyTriplesBlock</a>? )* <span class="token">'}'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[19]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rBodyNotTriples">BodyNotTriples</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rFilter">Filter</a> | <a href="#rNegation">Negation</a> | <a href="#rAssignment">Assignment</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[20]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rBodyTriplesBlock">BodyTriplesBlock</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rTriplesBlock">TriplesBlock</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[21]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rNegation">Negation</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'NOT'</span> <span class="token">'{'</span> <a href="#rBodyBasic">BodyBasic</a> <span class="token">'}'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[22]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rBodyBasic">BodyBasic</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rBodyTriplesBlock">BodyTriplesBlock</a>? ( <a href="#rFilter">Filter</a> <a href="#rBodyTriplesBlock">BodyTriplesBlock</a>? )*</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[23]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rHeadTemplateBlock">HeadTemplateBlock</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rTriplesBlock">TriplesBlock</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[24]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rTriplesBlock">TriplesBlock</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rTriplesSameSubjectPath">TriplesSameSubjectPath</a> ( <span class="token">'.'</span> <a href="#rTriplesBlock">TriplesBlock</a>? )?</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[25]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rReifiedTripleBlock">ReifiedTripleBlock</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rReifiedTriple">ReifiedTriple</a> <a href="#rPropertyList">PropertyList</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[26]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rReifiedTripleBlockPath">ReifiedTripleBlockPath</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rReifiedTriple">ReifiedTriple</a> <a href="#rPropertyListPath">PropertyListPath</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[27]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rAssignment">Assignment</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'SET'</span> <span class="token">'('</span> <a href="#rVar">Var</a> <span class="token">':='</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[28]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rReifier">Reifier</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'~'</span> <a href="#rVarOrReifierId">VarOrReifierId</a>?</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[29]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rVarOrReifierId">VarOrReifierId</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rBlankNode">BlankNode</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[30]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rFilter">Filter</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'FILTER'</span> <a href="#rConstraint">Constraint</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[31]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rConstraint">Constraint</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#rFunctionCall">FunctionCall</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[32]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rFunctionCall">FunctionCall</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#riri">iri</a> <a href="#rArgList">ArgList</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[33]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rArgList">ArgList</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rNIL">NIL</a> | <span class="token">'('</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )* <span class="token">')'</span> </code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[34]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rExpressionList">ExpressionList</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rNIL">NIL</a> | <span class="token">'('</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )* <span class="token">')'</span> </code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[35]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rTriplesSameSubject">TriplesSameSubject</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> | <a href="#rTriplesNode">TriplesNode</a> <a href="#rPropertyList">PropertyList</a> | <a href="#rReifiedTripleBlock">ReifiedTripleBlock</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[36]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPropertyList">PropertyList</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a>?</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[37]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPropertyListNotEmpty">PropertyListNotEmpty</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVerb">Verb</a> <a href="#rObjectList">ObjectList</a> ( <span class="token">';'</span> ( <a href="#rVerb">Verb</a> <a href="#rObjectList">ObjectList</a> )? )*</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[38]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rVerb">Verb</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVarOrIri">VarOrIri</a> | <span class="token">'a'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[39]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rObjectList">ObjectList</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rObject">Object</a> ( <span class="token">','</span> <a href="#rObject">Object</a> )*</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[40]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rObject">Object</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rGraphNode">GraphNode</a> <a href="#rAnnotation">Annotation</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[41]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rTriplesSameSubjectPath">TriplesSameSubjectPath</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> | <a href="#rTriplesNodePath">TriplesNodePath</a> <a href="#rPropertyListPath">PropertyListPath</a> | <a href="#rReifiedTripleBlockPath">ReifiedTripleBlockPath</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[42]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPropertyListPath">PropertyListPath</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a>?</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[43]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPropertyListPathNotEmpty">PropertyListPathNotEmpty</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> ( <span class="token">';'</span> ( ( <a href="#rVerbPath">VerbPath</a> | <a href="#rVerbSimple">VerbSimple</a> ) <a href="#rObjectListPath">ObjectListPath</a> )? )*</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[44]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rVerbPath">VerbPath</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPath">Path</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[45]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rVerbSimple">VerbSimple</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVar">Var</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[46]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rObjectListPath">ObjectListPath</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rObjectPath">ObjectPath</a> ( <span class="token">','</span> <a href="#rObjectPath">ObjectPath</a> )*</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[47]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rObjectPath">ObjectPath</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rGraphNodePath">GraphNodePath</a> <a href="#rAnnotationPath">AnnotationPath</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[48]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPath">Path</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPathSequence">PathSequence</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[49]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPathSequence">PathSequence</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPathEltOrInverse">PathEltOrInverse</a> ( <span class="token">'/'</span> <a href="#rPathEltOrInverse">PathEltOrInverse</a> )*</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[50]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPathEltOrInverse">PathEltOrInverse</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPathElt">PathElt</a> | <span class="token">'^'</span> <a href="#rPathElt">PathElt</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[51]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPathElt">PathElt</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPathPrimary">PathPrimary</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[52]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPathPrimary">PathPrimary</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#riri">iri</a> | <span class="token">'a'</span> | <span class="token">'('</span> <a href="#rPath">Path</a> <span class="token">')'</span> </code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[53]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rTriplesNode">TriplesNode</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rCollection">Collection</a> | <a href="#rBlankNodePropertyList">BlankNodePropertyList</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[54]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rBlankNodePropertyList">BlankNodePropertyList</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'['</span> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> <span class="token">']'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[55]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rTriplesNodePath">TriplesNodePath</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rCollectionPath">CollectionPath</a> | <a href="#rBlankNodePropertyListPath">BlankNodePropertyListPath</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[56]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rBlankNodePropertyListPath">BlankNodePropertyListPath</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'['</span> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> <span class="token">']'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[57]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rCollection">Collection</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rGraphNode">GraphNode</a>+ <span class="token">')'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[58]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rCollectionPath">CollectionPath</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rGraphNodePath">GraphNodePath</a>+ <span class="token">')'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[59]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rAnnotationPath">AnnotationPath</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">( <a href="#rReifier">Reifier</a> | <a href="#rAnnotationBlockPath">AnnotationBlockPath</a> )*</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[60]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rAnnotationBlockPath">AnnotationBlockPath</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'{|'</span> <a href="#rPropertyListPathNotEmpty">PropertyListPathNotEmpty</a> <span class="token">'|}'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[61]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rAnnotation">Annotation</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">( <a href="#rReifier">Reifier</a> | <a href="#rAnnotationBlock">AnnotationBlock</a> )*</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[62]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rAnnotationBlock">AnnotationBlock</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'{|'</span> <a href="#rPropertyListNotEmpty">PropertyListNotEmpty</a> <span class="token">'|}'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[63]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rGraphNode">GraphNode</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> | <a href="#rTriplesNode">TriplesNode</a> | <a href="#rReifiedTriple">ReifiedTriple</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[64]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rGraphNodePath">GraphNodePath</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVarOrTerm">VarOrTerm</a> | <a href="#rTriplesNodePath">TriplesNodePath</a> | <a href="#rReifiedTriple">ReifiedTriple</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[65]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rVarOrTerm">VarOrTerm</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#rRDFTerm">RDFTerm</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[66]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rRDFTerm">RDFTerm</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rNIL">NIL</a> | <a href="#rTripleTerm">TripleTerm</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[67]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rReifiedTriple">ReifiedTriple</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'&lt;&lt;'</span> <a href="#rReifiedTripleSubject">ReifiedTripleSubject</a> <a href="#rVerb">Verb</a> <a href="#rReifiedTripleObject">ReifiedTripleObject</a> <a href="#rReifier">Reifier</a>? <span class="token">'&gt;&gt;'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[68]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rReifiedTripleSubject">ReifiedTripleSubject</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rReifiedTriple">ReifiedTriple</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[69]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rReifiedTripleObject">ReifiedTripleObject</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rReifiedTriple">ReifiedTriple</a> | <a href="#rTripleTerm">TripleTerm</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[70]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rTripleTerm">TripleTerm</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'&lt;&lt;('</span> <a href="#rTripleTermSubject">TripleTermSubject</a> <a href="#rVerb">Verb</a> <a href="#rTripleTermObject">TripleTermObject</a> <span class="token">')&gt;&gt;'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[71]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rTripleTermSubject">TripleTermSubject</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[72]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rTripleTermObject">TripleTermObject</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rBlankNode">BlankNode</a> | <a href="#rTripleTerm">TripleTerm</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[73]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rTripleTermData">TripleTermData</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'&lt;&lt;('</span> <a href="#rTripleTermDataSubject">TripleTermDataSubject</a> ( <a href="#riri">iri</a> | <span class="token">'a'</span> ) <a href="#rTripleTermDataObject">TripleTermDataObject</a> <span class="token">')&gt;&gt;'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[74]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rTripleTermDataSubject">TripleTermDataSubject</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[75]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rTripleTermDataObject">TripleTermDataObject</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rTripleTermData">TripleTermData</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[76]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rVarOrIri">VarOrIri</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVar">Var</a> | <a href="#riri">iri</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[77]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rVar">Var</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rVAR1">VAR1</a> | <a href="#rVAR2">VAR2</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[78]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rExpression">Expression</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rConditionalOrExpression">ConditionalOrExpression</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[79]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rConditionalOrExpression">ConditionalOrExpression</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rConditionalAndExpression">ConditionalAndExpression</a> ( <span class="token">'||'</span> <a href="#rConditionalAndExpression">ConditionalAndExpression</a> )*</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[80]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rConditionalAndExpression">ConditionalAndExpression</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rValueLogical">ValueLogical</a> ( <span class="token">'&amp;&amp;'</span> <a href="#rValueLogical">ValueLogical</a> )*</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[81]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rValueLogical">ValueLogical</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rRelationalExpression">RelationalExpression</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[82]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rRelationalExpression">RelationalExpression</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rNumericExpression">NumericExpression</a> ( <span class="token">'='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'!='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;'</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&lt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'&gt;='</span> <a href="#rNumericExpression">NumericExpression</a> | <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> | <span class="token">'NOT'</span> <span class="token">'IN'</span> <a href="#rExpressionList">ExpressionList</a> )?</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[83]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rNumericExpression">NumericExpression</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rAdditiveExpression">AdditiveExpression</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[84]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rAdditiveExpression">AdditiveExpression</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rMultiplicativeExpression">MultiplicativeExpression</a> ( <span class="token">'+'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | <span class="token">'-'</span> <a href="#rMultiplicativeExpression">MultiplicativeExpression</a> | ( <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a> ) ( ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) | ( <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> ) )* )*</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[85]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rMultiplicativeExpression">MultiplicativeExpression</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rUnaryExpression">UnaryExpression</a> ( <span class="token">'*'</span> <a href="#rUnaryExpression">UnaryExpression</a> | <span class="token">'/'</span> <a href="#rUnaryExpression">UnaryExpression</a> )*</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[86]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rUnaryExpression">UnaryExpression</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'!'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>| <span class="token">'+'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>| <span class="token">'-'</span> <a href="#rPrimaryExpression">PrimaryExpression</a> <br/>| <a href="#rPrimaryExpression">PrimaryExpression</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[87]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPrimaryExpression">PrimaryExpression</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rBrackettedExpression">BrackettedExpression</a> | <a href="#rBuiltInCall">BuiltInCall</a> | <a href="#ririOrFunction">iriOrFunction</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprTripleTerm">ExprTripleTerm</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[88]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rExprTripleTerm">ExprTripleTerm</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'&lt;&lt;('</span> <a href="#rExprTripleTermSubject">ExprTripleTermSubject</a> <a href="#rVerb">Verb</a> <a href="#rExprTripleTermObject">ExprTripleTermObject</a> <span class="token">')&gt;&gt;'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[89]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rExprTripleTermSubject">ExprTripleTermSubject</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[90]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rExprTripleTermObject">ExprTripleTermObject</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#riri">iri</a> | <a href="#rRDFLiteral">RDFLiteral</a> | <a href="#rNumericLiteral">NumericLiteral</a> | <a href="#rBooleanLiteral">BooleanLiteral</a> | <a href="#rVar">Var</a> | <a href="#rExprTripleTerm">ExprTripleTerm</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[91]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rBrackettedExpression">BrackettedExpression</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[92]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rBuiltInCall">BuiltInCall</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">&nbsp;&nbsp;<span class="token">'STR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'LANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'LANGMATCHES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'LANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'DATATYPE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'IRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'BNODE'</span> ( <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> | <a href="#rNIL">NIL</a> ) <br/>| <span class="token">'ABS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'CEIL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'FLOOR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'ROUND'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'CONCAT'</span> <a href="#rExpressionList">ExpressionList</a> <br/>| <span class="token">'SUBSTR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span> <br/>| <span class="token">'STRLEN'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'REPLACE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span> <br/>| <span class="token">'UCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'LCASE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'ENCODE_FOR_URI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'CONTAINS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRSTARTS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRENDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRBEFORE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRAFTER'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'YEAR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'MONTH'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'DAY'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'HOURS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'MINUTES'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'SECONDS'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'TIMEZONE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'TZ'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'NOW'</span> <a href="#rNIL">NIL</a> <br/>| <span class="token">'UUID'</span> <a href="#rNIL">NIL</a> <br/>| <span class="token">'STRUUID'</span> <a href="#rNIL">NIL</a> <br/>| <span class="token">'IF'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRLANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'STRDT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'sameTerm'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isIRI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isURI'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isBLANK'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isLITERAL'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'isNUMERIC'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'hasLANG'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'hasLANGDIR'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'REGEX'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> ( <span class="token">','</span> <a href="#rExpression">Expression</a> )? <span class="token">')'</span> <br/>| <span class="token">'isTRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'TRIPLE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">','</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'SUBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'PREDICATE'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span> <br/>| <span class="token">'OBJECT'</span> <span class="token">'('</span> <a href="#rExpression">Expression</a> <span class="token">')'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[93]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="ririOrFunction">iriOrFunction</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#riri">iri</a> <a href="#rArgList">ArgList</a>?</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[94]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rRDFLiteral">RDFLiteral</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rString">String</a> ( <a href="#rLANG_DIR">LANG_DIR</a> | <span class="token">'^^'</span> <a href="#riri">iri</a> )?</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[95]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rNumericLiteral">NumericLiteral</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rNumericLiteralUnsigned">NumericLiteralUnsigned</a> | <a href="#rNumericLiteralPositive">NumericLiteralPositive</a> | <a href="#rNumericLiteralNegative">NumericLiteralNegative</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[96]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rNumericLiteralUnsigned">NumericLiteralUnsigned</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rINTEGER">INTEGER</a> | <a href="#rDECIMAL">DECIMAL</a> | <a href="#rDOUBLE">DOUBLE</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[97]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rNumericLiteralPositive">NumericLiteralPositive</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rINTEGER_POSITIVE">INTEGER_POSITIVE</a> | <a href="#rDECIMAL_POSITIVE">DECIMAL_POSITIVE</a> | <a href="#rDOUBLE_POSITIVE">DOUBLE_POSITIVE</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[98]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rNumericLiteralNegative">NumericLiteralNegative</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rINTEGER_NEGATIVE">INTEGER_NEGATIVE</a> | <a href="#rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</a> | <a href="#rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[99]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rBooleanLiteral">BooleanLiteral</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'true'</span> | <span class="token">'false'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[100]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rString">String</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rSTRING_LITERAL1">STRING_LITERAL1</a> | <a href="#rSTRING_LITERAL2">STRING_LITERAL2</a> | <a href="#rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</a> | <a href="#rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[101]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="riri">iri</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rIRIREF">IRIREF</a> | <a href="#rPrefixedName">PrefixedName</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[102]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPrefixedName">PrefixedName</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPNAME_LN">PNAME_LN</a> | <a href="#rPNAME_NS">PNAME_NS</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[103]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rBlankNode">BlankNode</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rBLANK_NODE_LABEL">BLANK_NODE_LABEL</a> | <a href="#rANON">ANON</a></code></td>
+      </tr>
+  </tbody></table>
+</div>
+<p>Productions for terminals:</p>
+<div class="grammarTable">
+  <table><tbody>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[104]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rIRIREF">IRIREF</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'&lt;' ([^&lt;&gt;"{}|^`\]-[#x00-#x20] | <a href="#rUCHAR">UCHAR</a> )* '&gt;'</span></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[105]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPNAME_NS">PNAME_NS</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPN_PREFIX">PN_PREFIX</a>? ':'</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[106]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPNAME_LN">PNAME_LN</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPNAME_NS">PNAME_NS</a> <a href="#rPN_LOCAL">PN_LOCAL</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[107]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rBLANK_NODE_LABEL">BLANK_NODE_LABEL</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">'_:' ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] ) ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[108]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rVAR1">VAR1</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">'?' <a href="#rVARNAME">VARNAME</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[109]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rVAR2">VAR2</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">'$' <a href="#rVARNAME">VARNAME</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[110]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rLANG_DIR">LANG_DIR</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">'@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)* ('--' [a-zA-Z]+)?</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[111]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rINTEGER">INTEGER</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">[0-9]+</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[112]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rDECIMAL">DECIMAL</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">[0-9]* '.' [0-9]+</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[113]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rDOUBLE">DOUBLE</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">( ([0-9]+ ('.'[0-9]*)? ) | ( '.' ([0-9])+ ) ) [eE][+-]?[0-9]+</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[114]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rINTEGER_POSITIVE">INTEGER_POSITIVE</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rINTEGER">INTEGER</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[115]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rDECIMAL_POSITIVE">DECIMAL_POSITIVE</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[116]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rDOUBLE_POSITIVE">DOUBLE_POSITIVE</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'+'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[117]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rINTEGER_NEGATIVE">INTEGER_NEGATIVE</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rINTEGER">INTEGER</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[118]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rDECIMAL_NEGATIVE">DECIMAL_NEGATIVE</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rDECIMAL">DECIMAL</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[119]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rDOUBLE_NEGATIVE">DOUBLE_NEGATIVE</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><span class="token">'-'</span> <a href="#rDOUBLE">DOUBLE</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[120]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rSTRING_LITERAL1">STRING_LITERAL1</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">"'" ( ([^#x27#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> | <a href="#rUCHAR">UCHAR</a> )* "'"</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[121]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rSTRING_LITERAL2">STRING_LITERAL2</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">'"' ( ([^#x22#x5C#xA#xD]) | <a href="#rECHAR">ECHAR</a> | <a href="#rUCHAR">UCHAR</a> )* '"'</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[122]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG1">STRING_LITERAL_LONG1</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">"'''" ( ( "'" | "''" )? ( [^'\] | <a href="#rECHAR">ECHAR</a> | <a href="#rUCHAR">UCHAR</a> ) )* "'''"</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[123]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rSTRING_LITERAL_LONG2">STRING_LITERAL_LONG2</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">'"""' ( ( '"' | '""' )? ( [^"\] | <a href="#rECHAR">ECHAR</a> | <a href="#rUCHAR">UCHAR</a> ) )* '"""'</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[124]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rECHAR">ECHAR</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">'\' [tbnrf\"']</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[125]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rUCHAR">UCHAR</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">('\u' HEX HEX HEX HEX) | ('\U' HEX HEX HEX HEX HEX HEX HEX HEX)</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[126]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rNIL">NIL</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">'(' <a href="#rWS">WS</a>* ')'</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[127]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rWS">WS</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">#x20 | #x9 | #xD | #xA</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[128]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rANON">ANON</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">'['  <a href="#rWS">WS</a>* ']'</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[129]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPN_CHARS_BASE">PN_CHARS_BASE</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">[A-Z] | [a-z] | [#x00C0-#x00D6] | [#x00D8-#x00F6] | [#x00F8-#x02FF] | [#x0370-#x037D] | [#x037F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[130]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPN_CHARS_U">PN_CHARS_U</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> | '_'</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[131]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rVARNAME">VARNAME</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">( <a href="#rPN_CHARS_U">PN_CHARS_U</a>  | [0-9] ) ( <a href="#rPN_CHARS_U">PN_CHARS_U</a> | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040] )*</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[132]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPN_CHARS">PN_CHARS</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPN_CHARS_U">PN_CHARS_U</a> | '-' | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040]</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[133]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPN_PREFIX">PN_PREFIX</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPN_CHARS_BASE">PN_CHARS_BASE</a> ((<a href="#rPN_CHARS">PN_CHARS</a>|'.')* <a href="#rPN_CHARS">PN_CHARS</a>)?</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[134]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPN_LOCAL">PN_LOCAL</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">(<a href="#rPN_CHARS_U">PN_CHARS_U</a> | ':' | [0-9] | <a href="#rPLX">PLX</a> ) ((<a href="#rPN_CHARS">PN_CHARS</a> | '.' | ':' | <a href="#rPLX">PLX</a>)* (<a href="#rPN_CHARS">PN_CHARS</a> | ':' | <a href="#rPLX">PLX</a>) )?</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[135]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPLX">PLX</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody"><a href="#rPERCENT">PERCENT</a> | <a href="#rPN_LOCAL_ESC">PN_LOCAL_ESC</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[136]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPERCENT">PERCENT</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">'%' <a href="#rHEX">HEX</a> <a href="#rHEX">HEX</a></code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[137]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rHEX">HEX</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">[0-9] | [A-F] | [a-f]</code></td>
+      </tr>
+
+      <tr style="vertical-align: baseline">
+        <td><code>[138]&nbsp;&nbsp;</code></td>
+        <td><code><span class="doc-ref" id="rPN_LOCAL_ESC">PN_LOCAL_ESC</span></code></td>
+        <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>
+        <td><code class="gRuleBody">'\' ( '_' | '~' | '.' | '-' | '!' | '$' | '&amp;' | "'" | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%' )</code></td>
+      </tr>
+  </tbody></table>
+</div>
+<!-- GRAMMAR -->


### PR DESCRIPTION
Work on the SHACL Rules document.

* Update grammar for `UCHAR` escape sequences using the Turtle approach
  Take Turtle content for escape sequences defintions in the grammar section
* Use file inclusion for the grammar. 
* Provide a text BNF file
* Conformance section
  This has to be a top-level section so all sections following are renumbered unfortunately

ReSpec only includes http/https URLs. This means the grammar does not show up in local editting but if you run a local HTTP server to server `shacl12-rules` directory, the grammar should be displayed.

[See this PR rendered online here](https://raw.githack.com/w3c/data-shapes/rules-grammar-updates/shacl12-rules/index.html)
