### PR TITLE
Fix typos in SHACL profiling documentation

### DIFF
--- a/shacl12-profiling/index.html
+++ b/shacl12-profiling/index.html
@@ -1251,7 +1251,7 @@ ex:ont-N
           </tr>
           <tr>
             <th>See also:</th>
-            <td><a href="https://www.w3.org/TR/rdf12-schema/#ch_member">RDF 1.2 Schema: member</a></td>
+            <td><a data-cite="rdf12-schema#ch_member">RDF 1.2 Schema: member</a></td>
 		  </tr>
           <tr>
             <th>Scope note:</th>

--- a/shacl12-profiling/index.html
+++ b/shacl12-profiling/index.html
@@ -892,7 +892,7 @@ ex:ont-N
     This section describes how to create profiles of different kinds of things with SHACL.
   </p>
   <p>
-    General profiling terms and elements from [[[dx-prof]]] are use as well as more
+    General profiling terms and elements from [[[dx-prof]]] are used as well as more
     specialised SHACL profiling elements defined in the <a href="#vocabulary"></a>.
   </p>
   <section id="profiling-specifications">
@@ -1066,8 +1066,8 @@ ex:ont-N
       to declare Node and Property Shapes just as OWL can be used to declare Classes and Properties.
     </p>
     <p>
-      SHACL shapes naturally constrain models and data, therefore if used to indicate how a profile contrains a thing
-      profiles — a standard or another profile — they could perform the role of
+      SHACL shapes naturally constrain models and data, therefore if used to indicate how a profile constrains a thing
+      — a standard or another profile — they could perform the role of
       <a href="https://www.w3.org/TR/dx-prof/#Role:constraints">Constraints</a>.
     </p>
     <p>
@@ -1251,8 +1251,8 @@ ex:ont-N
           </tr>
           <tr>
             <th>See also:</th>
-            <td><a data-cite="shacl12-core#ch_member">RDF 1.2 Schema: member</a></td>
-          </tr>
+            <td><a href="https://www.w3.org/TR/rdf12-schema/#ch_member">RDF 1.2 Schema: member</a></td>
+		  </tr>
           <tr>
             <th>Scope note:</th>
             <td>


### PR DESCRIPTION
Minor typo and wording corrections in the SHACL 1.2 profiling draft.

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/fix-typos/shacl12-profiling/index.html)
