### PR TITLE
GH-765: Remove section 'Attaching Rules To Shapes'

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -590,30 +590,6 @@ WHERE {
         </p>
       </section>
 
-      <section id="attaching-rules-to-shapes">
-        <h3>Attaching Rules To Shapes</h3>
-
-        <div class="issue" data-number="765">
-          <p>
-            Allow one or more SHACL Rule to be attached to a shape, using a property such as `sh:rule`.
-          </p>
-          <p>Sketch:</p>
-          <pre>
-[] rdf:type sh:NodeShape ;
-    sh:rule                   ## Different property?
-      [ a srl:SHACLRule ;
-        srl:ruleSet "...";    ## SRL syntax
-        sh:prefixes ... ;
-      ];
-[] rdf:type sh:NodeShape ;
-    sh:rule
-      [ a srl:SHACLRule ;
-        srl:ruleSet [ ... RDF syntax ... ] ;
-      ];
-</pre>
-        </div>
-      </section>
-
       <section id="rules-sparql-relationship">
         <h3>Relationship between SHACL Rules and SPARQL</h3>
         <p>


### PR DESCRIPTION
The Rules Task Force is currently planning on writing a migration and usage patterns for migration from SHACL-AF Rules to SHACL 1.2 Rules. This can be more extensive than material in the specification and and can be updated in the future as experience is reported. PR: #879.


* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/remove-at-risk-shacl-af/shacl12-rules/index.html)

This PR removes the placeholder section from the draft specification.
