### PR TITLE
Fix example typing for prof:hasArtifact

### DIFF
--- a/shacl12-profiling/index.html
+++ b/shacl12-profiling/index.html
@@ -788,7 +788,7 @@ ex:ont-N
   prof:hasRole role:Specification ;
   dcterms:format "text/html" ;
   dcterms:conformsTo &lt;http://www.w3.org/TR/html5/> ;
-  prof:hasArtifact "https://www.w3.org/TR/shacl12-core/"^^xsd:anyURI ;
+  prof:hasArtifact &lt;https://www.w3.org/TR/shacl12-core/> ;
 .
 
 # Core validator
@@ -797,7 +797,7 @@ ex:ont-N
   prof:hasRole role:Validation ;
   dcterms:format "text/turtle" ;
   dcterms:conformsTo &lt;https://www.w3.org/TR/shacl/> ;
-  prof:hasArtifact "http://www.w3.org/ns/shacl-shacl/core"^^xsd:anyURI ;
+  prof:hasArtifact &lt;http://www.w3.org/ns/shacl-shacl/core> ;
 .
     </div>
     <p>


### PR DESCRIPTION
`prof:hasArtifact` is an `owl:ObjectProperty`.  Range unspecified.

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/prof_fix_hasArtifact_typing/shacl12-profiling/index.html)
