### PR TITLE
GH-917: Add media type parameters and define version label

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -148,8 +148,8 @@
           font-size: 12px;
       }
 
-      /* CSS from Turtle*/
-
+      table { border-collapse: collapse }
+      table.simple td, table th { border: 1px solid #444; padding: 0.2em 0.5em; }
       table.cp-definitions { border-collapse:collapse; background-color: #DDDDFF}
       body.darkmode table.cp-definitions { background-color: black}
 
@@ -333,7 +333,39 @@
         <a href="#shapes-rules-grammar" class="sectionRef"></a>
       </p>
 
-      <p class="note">This specification does not define how SHACL Rules processors handle non-conforming input documents.</p>
+      <p class="note">
+        This specification does not define how SHACL Rules processors
+        handle non-conforming input documents.
+      </p>
+
+      <section id="defined-version-labels">
+        <h3>Version Labels</h3>
+        <p>
+          A <dfn>version label</dfn> is a string that identifies the syntax and semantics conformance
+          for the Shacl Rules Language.
+        </p>
+
+        <table id="tab-version-labels" class="simple">
+          <caption>Version Labels</caption>
+          <thead>
+            <tr>
+              <th style="text-align: center">Version Label</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>"1.2"</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>
+          For serializations supporting in-line version announcement,
+          the version announcement SHOULD be made early in the document.
+        </p>
+
+      </section>
+
     </section>
 
     <section id="overview" class="informative">
@@ -2242,9 +2274,11 @@ the result is GI
     <section id="mediaType" class="appendix">
       <h2>Internet Media Type, File Extension and Macintosh File Type</h2>
 
-      <p class="ednote">@@see the Turtle registration for format</p>
-
-      <p>The Internet Media Type (formerly known as MIME Type) for @@ is "<code>text/shape-rules</code>".</p>
+      <p>
+        The Internet Media Type (formerly known as MIME Type) for the
+        Shapes Rules Language is
+        "<code>application/shape-rules</code>".
+      </p>
 
       <p>
         The information that follows has been submitted to the Internet Engineering
@@ -2263,13 +2297,28 @@ the result is GI
           <dd>None</dd>
 
           <dt>Optional parameters:</dt>
-          <dd>@@version, @@profile</dd>
+          <dt><code>version</code></dt>
+          <dd>
+            This parameter is optional.
+            If present, acceptable values of <code>version</code> are defined in
+            <a href="#defined-version-labels">Version Labels</a>.
+          </dd>
+          <dt><code>profile</code></dt>
+          <dd>
+            This parameter is optional and is used to include additional information.
+            It does not change the semantics of the resource representation when
+            processed without knowledge of the profile. The value of a
+            <code>profile</code> parameter is a non-empty list of space-separated URIs.
+            For more information and background, please refer to [[RFC6906]].
+          </dd>
 
           <dt>Encoding considerations:</dt>
-          <dd>The syntax of the SHACL Rules Language is expressed over code points in Unicode
+          <dd>
+            The syntax of the SHACL Rules Language is expressed over code points in Unicode
             [[UNICODE]]. The encoding is always UTF-8 [[RFC3629]].</dd>
           <dd>Unicode code points may also be expressed using an \uXXXX (U+0 to U+FFFF) or
-            \UXXXXXXXX syntax (for U+10000 onwards) where X is a hexadecimal digit [0-9A-F]</dd>
+            \UXXXXXXXX syntax (for U+10000 onwards) where X is a hexadecimal digit [0-9A-F]
+          </dd>
           <dt>Security considerations:</dt>
           <dd>
             See appendix C, <a href="#security" class="sectionRef">Security Considerations</a> as well as
@@ -2281,9 +2330,6 @@ the result is GI
 
           <dt>Published specification:</dt>
           <dd>This specification.</dd>
-
-          <dt>Applications which use this media type:</dt>
-          <dd>@@</dd>
 
           <dt>Additional information:</dt>
 
@@ -2302,8 +2348,6 @@ the result is GI
                 current base URI for relative IRIrefs in the query language that
                 are used sequentially later in the document.
               </dd>
-              <dt>Macintosh file type code(s):</dt>
-              <dd>"TEXT"</dd>
             </dl>
           </dd>
 


### PR DESCRIPTION
Closes #917

Adds text taken from RDF 1.2 Turtle/RDF 1.2 Concepts.

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/media-type-registration/shacl12-rules/index.html)
