### PR TITLE
Adding display provider, resource filter and shacl sparql pattern for autocomplete widgets

### DIFF
--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1615,6 +1615,169 @@ ex:book1 a ex:Book ;
           </p>
         </aside>
       </section>
+
+    </section>
+
+
+    <section id="display-provider">
+      <h2>Display provider</h2>
+      <p>In certain situations, it is helpful to supply a custom display provider to a shape to control what data is used for rendering UI components.
+        A <code>shui:DisplayProvider</code> can be attached to a shape to provide custom data fetching for labels, descriptions and other UI elements.
+      </p>
+
+      <p>Properties available for <code>shui:DisplayProvider</code>:</p>
+
+      <ul>
+        <li><strong>shui:LabelRole</strong> <em>or</em> <strong>label</strong>: a label of the resource.</li>
+        <li><strong>shui:DescriptionRole</strong> <em>or</em> <strong>description</strong>: the description of a resource.</li>
+        <li><strong>shui:DepictionRole</strong> <em>or</em> <strong>depiction</strong>: a depiction of a resource.</li>
+        <li><strong>shui:IconRole</strong> <em>or</em> <strong>icon</strong>: an icon representing the resource.</li>
+      </ul>
+
+      <p class="note">The above role IRIs are used in combination with <code>shui:role</code> within shapes, see next example. 
+        The name following the IRI can be used within <a href="https://www.w3.org/TR/shacl12-sparql/">SHACL SPARQL</a> as a variable name, see second following example.</p>
+
+      <section>
+        <h3>Display provider with property paths</h3>
+
+        <p>A display provider can be used to specify custom paths for fetching labels, descriptions, depictions, and icons for a resource. This allows for more flexible and dynamic UI rendering based on the data available.</p>
+
+        <aside class="example" title="Display provider with property paths">
+          <div class="shapes-graph">
+            <div class="turtle">
+  ex:CreatorDisplayProvider
+    a shui:DisplayProvider ;
+    sh:property [
+      sh:path rdfs:label ;
+      sh:role shui:LabelRole ;
+    ] ;
+    sh:property [
+      sh:path schema:depiction ;
+      sh:role shui:DepictionRole ;
+    ] .
+
+  ex:BookShape
+    a sh:NodeShape ;
+    sh:targetClass ex:Book ;
+    sh:property [
+        sh:path dct:creator ;
+        shui:displayProvider ex:CreatorDisplayProvider ;
+    ] .
+            </div>
+          </div>
+
+          <p>
+            In this example, the <code>ex:CreatorDisplayProvider</code> is attached to the <code>dct:creator</code> property shape. When rendering the creator of a book, the renderer can use the display provider to fetch both the label and depiction for the creator, using the specified paths in the display provider shape.
+          </p>
+        </aside>
+      </section>
+
+      <section>
+        <h3>Display provider with SHACL SPARQL</h3>
+
+        <p>A display provider can also use SHACL SPARQL to specify a custom query for fetching the data needed for rendering. This allows for even more complex and dynamic data retrieval, including federated queries across multiple endpoints.</p>
+
+        <aside class="example" title="Display provider with SHACL SPARQL">
+          <div class="shapes-graph">
+            <div class="turtle">
+  ex:CreatorDisplayProvider
+    a shui:DisplayProvider ;
+    sh:select """
+      select $value $label $depiction $description where {
+        SERVICE <http://example.org/sparql> {
+          $value rdfs:label $label .
+          FILTER(lang($label) = "en")
+          
+          optional { $value schema:depiction $depiction }
+          optional { $value schema:description $description }
+        }
+      }
+    """ .
+
+  ex:BookShape
+    a sh:NodeShape ;
+    sh:targetClass ex:Book ;
+    sh:property [
+        sh:path dct:creator ;
+        shui:displayProvider ex:CreatorDisplayProvider ;
+    ] .
+            </div>
+          </div>
+
+          <p>
+            In this example, the data is fetched via a <a href="https://www.w3.org/TR/shacl12-sparql/#SelectExpression">select expression</a> of <a href="https://www.w3.org/TR/shacl12-sparql/">SHACL SPARQL</a>.
+          </p>
+        </aside>
+
+      </section>
+
+    </section>
+
+
+    <section id="resource-filter">
+      <h2>Resource Filter</h2>
+      <p>
+        A <code>shui:ResourceFilter</code> can be attached to a shape to provide custom filtering of resources for UI components such as select lists and autocomplete lists.
+        This allows applications to implement dynamic filtering based on user input or other criteria. The current search term MUST be bound in the variable <code>searchTerm</code> for use in the filter query.
+      </p>
+
+      <p>Properties available for <code>shui:ResourceFilter</code>:</p>
+      <ul>
+        <li><strong>shui:SearchTermRole</strong> <em>or</em> <strong>searchTerm</strong>: a search term for filtering resources.</li>
+      </ul>
+
+      <section>
+        <h3>Resource Filter with property paths</h3>
+
+        <aside class="example" title="Resource filter with property paths">
+          <div class="shapes-graph">
+            <div class="turtle">
+  ex:CreatorResourceFilter
+    a shui:ResourceFilter ;
+    sh:property [
+      sh:path rdfs:label ;
+      sh:role shui:SearchTermRole ;
+      sh:minCount 1 ;
+    ] ;
+    sh:property [
+      sh:path rdf:type ;
+      sh:hasValue ex:Author ;
+    ] .
+
+  ex:BookShape
+    a sh:NodeShape ;
+    sh:targetClass ex:Book ;
+    sh:property [
+        sh:path dct:creator ;
+        shui:resourceFilter ex:CreatorResourceFilter ;
+    ] .
+            </div>
+          </div>
+        </aside>
+      </section>
+
+      <section>
+        <h3>Resource Filter with SHACL SPARQL</h3>
+
+        <aside class="example" title="Resource filter with SHACL SPARQL">
+          <div class="shapes-graph">
+            <div class="turtle">
+  ex:CreatorResourceFilter
+    a shui:ResourceFilter ;
+    sh:select """
+      select $value where {
+        SERVICE <http://example.org/sparql> {
+          $value rdfs:label ?label .
+          $value a ex:Author .
+          filter(contains(?label, $searchTerm))
+        }
+      }
+    """ .
+            </div>
+          </div>
+        </aside>
+      </section>
+
     </section>
 
     <section id="patterns">
@@ -1641,6 +1804,78 @@ ex:book1 a ex:Book ;
         Some of the UI meetings have discussed using node expressions, dynamic SHACL, and SPARQL with the SERVICE clause.
       </p>
       <div class="issue" data-number="846"></div>
+      <section>
+        <h4>Using SPARQL containing SERVICE clauses for federated autocomplete widgets</h4>
+        <p>Form creators might use SPARQL queries with SERVICE clauses to fetch autocomplete options from remote endpoints.</p>
+        <p>Required ingredients:</p>
+        <ul>
+          <li>A property shape with a sh:path and a sh:in that contains a <a href="https://www.w3.org/TR/shacl12-sparql/#SelectExpression">select expression</a> with a SERVICE clause. 
+            This is supported by combining <a href="https://www.w3.org/TR/shacl12-sparql/">SHACL SPARQL</a> and <a href="https://www.w3.org/TR/shacl12-node-expr/#dynamic-shacl">dynamic SHACL</a></li>
+          <li>A <code>shui:ResourceFilter</code> that also uses a sh:select with a SERVICE clause to filter options based on the user’s search term.</li>
+          <li>A <code>shui:DisplayProvider</code> that uses a sh:select with a SERVICE clause to fetch labels, descriptions, and depictions for the options.</li>
+        </ul>
+
+
+        <aside class="example" title="An autocomplete widget with a SPARQL SERVICE clause">
+          <div class="shapes-graph">
+            <div class="turtle">
+ex:propertyCity
+  a sh:PropertyShape ;
+  sh:path ex:city ;
+  shui:displayProvider ex:myDisplay ;
+  shui:resourceFilter ex:myFilter ;
+  sh:in [
+	  sh:select """
+		select ?city where {
+			SERVICE <http://example.org/sparql> {
+				?city a ex:City .
+			}
+		}
+		""" ;
+  ] .  
+
+ex:myFilter
+	a shui:ResourceFilter ;
+	sh:select """
+		select $value where {
+			SERVICE <http://example.org/sparql> {
+				$value rdfs:label ?label .
+				$value ex:synonym ?synonym .
+				$value rdfs:comment ?description .
+				bind (concat(
+					?label, " ", 
+					?synonym, " ", 
+					?description
+				) as ?allText)
+
+				filter(contains(?allText, $searchTerm))
+			}
+		}
+	""" .
+
+
+ex:myDisplay
+	a shui:DisplayProvider ;
+	sh:select """
+		select $value $label $depiction $description where {
+			SERVICE <http://example.org/sparql> {
+				$value rdfs:label $label .
+				FILTER(lang($label) = "en")
+				
+				optional { $value schema:depiction $depiction }
+				optional { $value schema:description $description }
+			}
+		}
+	""" .
+            </div>
+          </div>
+
+          <p>
+            In this example, the data is fetched via a <a href="https://www.w3.org/TR/shacl12-sparql/#SelectExpression">select expression</a> of <a href="https://www.w3.org/TR/shacl12-sparql/">SHACL SPARQL</a>.
+          </p>
+        </aside>
+
+      </section>
       <h4>Fetching values from named graphs</h4>
       <div class="issue" data-number="672"></div>
 
@@ -1675,8 +1910,8 @@ ex:book1 a ex:Book ;
         This sub-section should address the <em>"Mapping validation results to the form"</em> mentioned in <a href="https://github.com/w3c/data-shapes/issues/823">ISSUE 823</a>.
       </p>
       <p class="ednote">
-        The pattern should describe how renderers may associate `sh:ValidationResult` entries with property UI components or node UI components,
-        using `sh:focusNode`, `sh:resultPath`, `sh:value`, `sh:sourceShape`, `sh:resultSeverity`, and `sh:resultMessage`. It should avoid defining when validation
+        The pattern should describe how renderers may associate <code>sh:ValidationResult</code> entries with property UI components or node UI components,
+        using <code>sh:focusNode</code>, <code>sh:resultPath</code>, <code>sh:value</code>, <code>sh:sourceShape</code>, <code>sh:resultSeverity</code>, and <code>sh:resultMessage</code>. It should avoid defining when validation
         runs or how an applications prevents malformed submissions.
       </p>
     </section>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1684,10 +1684,10 @@ ex:book1 a ex:Book ;
     a shui:DisplayProvider ;
     sh:select """
       select $value $label $depiction $description where {
-        SERVICE <http://example.org/sparql> {
+        SERVICE &lt;http://example.org/sparql&gt; {
           $value rdfs:label $label .
           FILTER(lang($label) = "en")
-          
+
           optional { $value schema:depiction $depiction }
           optional { $value schema:description $description }
         }
@@ -1729,6 +1729,8 @@ ex:book1 a ex:Book ;
       <section>
         <h3>Resource Filter with property paths</h3>
 
+        <p>A resource filter can use property paths to specify which properties of a resource should be considered for filtering.</p>
+
         <aside class="example" title="Resource filter with property paths">
           <div class="shapes-graph">
             <div class="turtle">
@@ -1759,6 +1761,8 @@ ex:book1 a ex:Book ;
       <section>
         <h3>Resource Filter with SHACL SPARQL</h3>
 
+        <p>A resource filter can also use SHACL SPARQL to specify a custom query for filtering resources. A resource filter SPARQL query MUST return exactly one binding, implementations MUST throw an exception if the query does not return one binding.</p>
+
         <aside class="example" title="Resource filter with SHACL SPARQL">
           <div class="shapes-graph">
             <div class="turtle">
@@ -1766,7 +1770,7 @@ ex:book1 a ex:Book ;
     a shui:ResourceFilter ;
     sh:select """
       select $value where {
-        SERVICE <http://example.org/sparql> {
+        SERVICE &lt;http://example.org/sparql&gt; {
           $value rdfs:label ?label .
           $value a ex:Author .
           filter(contains(?label, $searchTerm))
@@ -1803,10 +1807,15 @@ ex:book1 a ex:Book ;
 
         Some of the UI meetings have discussed using node expressions, dynamic SHACL, and SPARQL with the SERVICE clause.
       </p>
-      <div class="issue" data-number="846"></div>
+
       <section>
-        <h4>Using SPARQL containing SERVICE clauses for federated autocomplete widgets</h4>
-        <p>Form creators might use SPARQL queries with SERVICE clauses to fetch autocomplete options from remote endpoints.</p>
+        <h4>Using SPARQL containing SERVICE clauses for federated autocomplete or enum widgets</h4>
+        <p>Requirements:</p>
+        <ul>
+          <li><a href="https://www.w3.org/TR/shacl12-node-expr/#dynamic-shacl">Dynamic SHACL</a></li>
+          <li><a href="https://www.w3.org/TR/shacl12-sparql/">SHACL SPARQL</a></li>
+        </ul>
+        <p>Form creators might use SPARQL queries with SERVICE clauses to fetch autocomplete or enum options from remote endpoints.</p>
         <p>Required ingredients:</p>
         <ul>
           <li>A property shape with a sh:path and a sh:in that contains a <a href="https://www.w3.org/TR/shacl12-sparql/#SelectExpression">select expression</a> with a SERVICE clause. 
@@ -1827,7 +1836,7 @@ ex:propertyCity
   sh:in [
 	  sh:select """
 		select ?city where {
-			SERVICE <http://example.org/sparql> {
+			SERVICE &lt;http://example.org/sparql&gt; {
 				?city a ex:City .
 			}
 		}
@@ -1838,7 +1847,7 @@ ex:myFilter
 	a shui:ResourceFilter ;
 	sh:select """
 		select $value where {
-			SERVICE <http://example.org/sparql> {
+			SERVICE &lt;http://example.org/sparql&gt; {
 				$value rdfs:label ?label .
 				$value ex:synonym ?synonym .
 				$value rdfs:comment ?description .
@@ -1858,7 +1867,7 @@ ex:myDisplay
 	a shui:DisplayProvider ;
 	sh:select """
 		select $value $label $depiction $description where {
-			SERVICE <http://example.org/sparql> {
+			SERVICE &lt;http://example.org/sparql&gt; {
 				$value rdfs:label $label .
 				FILTER(lang($label) = "en")
 				

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1621,21 +1621,39 @@ ex:book1 a ex:Book ;
 
     <section id="display-provider">
       <h2>Display provider</h2>
-      <p>In certain situations, it is helpful to supply a custom display provider to a shape to control what data is used for rendering UI components.
-        A <code>shui:DisplayProvider</code> can be attached to a shape to provide custom data fetching for labels, descriptions and other UI elements.
+      <p>A <code>shui:DisplayProvider</code> can be attached to a shape to provide custom data fetching for labels, descriptions and other UI elements. This can be done with property shapes 
+        and also by using SPARQL queries. The fetched data can then be used by widgets such as the <code>shui:AutoCompleteEditor</code> and the <code>shui:EnumSelectEditor</code>.
       </p>
 
       <p>Properties available for <code>shui:DisplayProvider</code>:</p>
 
-      <ul>
-        <li><strong>shui:LabelRole</strong> <em>or</em> <strong>label</strong>: a label of the resource.</li>
-        <li><strong>shui:DescriptionRole</strong> <em>or</em> <strong>description</strong>: the description of a resource.</li>
-        <li><strong>shui:DepictionRole</strong> <em>or</em> <strong>depiction</strong>: a depiction of a resource.</li>
-        <li><strong>shui:IconRole</strong> <em>or</em> <strong>icon</strong>: an icon representing the resource.</li>
-      </ul>
-
-      <p class="note">The above role IRIs are used in combination with <code>shui:propertyRole</code> within shapes, see next example. 
-        The name following the IRI can be used within <a href="https://www.w3.org/TR/shacl12-sparql/">SHACL SPARQL</a> as a variable name, see second following example.</p>
+      <table class="term-table">
+        <tr>
+          <th>Property Role</th>
+          <th>SPARQL variable name</th>
+          <th>Description</th>
+        </tr>
+        <tr>
+          <td><code>shui:LabelRole</code></td>
+          <td><code>label</code></td>
+          <td>A label of the resource.</td>
+        </tr>
+        <tr>
+          <td><code>shui:DescriptionRole</code></td>
+          <td><code>description</code></td>
+          <td>The description of a resource.</td>
+        </tr>
+        <tr>
+          <td><code>shui:DepictionRole</code></td>
+          <td><code>depiction</code></td>
+          <td>A depiction of a resource.</td>
+        </tr>
+        <tr>
+          <td><code>shui:IconRole</code></td>
+          <td><code>icon</code></td>
+          <td>An icon representing the resource.</td>
+        </tr>
+      </table>
 
       <section>
         <h3>Display provider with property paths</h3>
@@ -1684,13 +1702,11 @@ ex:book1 a ex:Book ;
     a shui:DisplayProvider ;
     sh:select """
       select $value $label $depiction $description where {
-        SERVICE &lt;http://example.org/sparql&gt; {
-          $value rdfs:label $label .
-          FILTER(lang($label) = "en")
+        $value rdfs:label $label .
+        FILTER(lang($label) = "en")
 
-          optional { $value schema:depiction $depiction }
-          optional { $value schema:description $description }
-        }
+        optional { $value schema:depiction $depiction }
+        optional { $value schema:description $description }
       }
     """ .
 
@@ -1722,9 +1738,26 @@ ex:book1 a ex:Book ;
       </p>
 
       <p>Properties available for <code>shui:ResourceFilter</code>:</p>
-      <ul>
-        <li><strong>shui:SearchTermRole</strong> <em>or</em> <strong>searchTerm</strong>: a search term for filtering resources.</li>
-      </ul>
+
+      <table class="term-table">
+        <tr>
+          <th>Property Role</th>
+          <th>SPARQL variable name</th>
+          <th>Description</th>
+        </tr>
+        <tr>
+          <td><code>shui:SearchTermRole</code></td>
+          <td><code>searchTerm</code></td>
+          <td>A search term for filtering resources.</td>
+        </tr>
+        <tr>
+          <td><code>shui:CurrentLanguageRole</code></td>
+          <td><code>currentLanguage</code></td>
+          <td>the current language for filtering resources.</td>
+        </tr>
+      </table>
+
+      <p>A <code>shui:ResourceFilter</code> MUST use either property shapes or SHACL SPARQL queries. The query is malformed if both or none are present.</p>
 
       <section>
         <h3>Resource Filter with property paths</h3>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1634,7 +1634,7 @@ ex:book1 a ex:Book ;
         <li><strong>shui:IconRole</strong> <em>or</em> <strong>icon</strong>: an icon representing the resource.</li>
       </ul>
 
-      <p class="note">The above role IRIs are used in combination with <code>shui:role</code> within shapes, see next example. 
+      <p class="note">The above role IRIs are used in combination with <code>shui:propertyRole</code> within shapes, see next example. 
         The name following the IRI can be used within <a href="https://www.w3.org/TR/shacl12-sparql/">SHACL SPARQL</a> as a variable name, see second following example.</p>
 
       <section>
@@ -1649,11 +1649,11 @@ ex:book1 a ex:Book ;
     a shui:DisplayProvider ;
     sh:property [
       sh:path rdfs:label ;
-      sh:role shui:LabelRole ;
+      shui:propertyRole shui:LabelRole ;
     ] ;
     sh:property [
       sh:path schema:depiction ;
-      sh:role shui:DepictionRole ;
+      shui:propertyRole shui:DepictionRole ;
     ] .
 
   ex:BookShape
@@ -1736,7 +1736,7 @@ ex:book1 a ex:Book ;
     a shui:ResourceFilter ;
     sh:property [
       sh:path rdfs:label ;
-      sh:role shui:SearchTermRole ;
+      shui:propertyRole shui:SearchTermRole ;
       sh:minCount 1 ;
     ] ;
     sh:property [


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #846

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue846/shacl12-ui/index.html)

As described in #846 we wish to allow using SHACL SPARQL to get autocomplete list items. I searched for a way to also allow standard SHACL to use the shui:ResourceFilter and the shui:DisplayProvider.

Questions:

- Is it okay to have these new chapters (Display Provider and Resource filter)? I first had them under the label and language resolution but it does not fit fully to my mind.