### PR TITLE
Fix wording and grammar in index.html

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -595,12 +595,12 @@ WHERE {
           Rules involving assignment are [=run-once rules=]. Rules with assignment
           are run after all the rules that could produce the data that they depend on
           and before any rules that depend on the data they produce. 
-          Rules that involve blank node in the [=rule head=] are also creating new
+          Rules that involve blank nodes in the [=rule head=] also create new
           RDF terms and are run-once rules.
         </p>
         <p>
           This condition ensures that rules that create RDF terms do not generate new terms
-          multiple times, with potentially different outcomes and also that such rules do not 
+          multiple times, with potentially different outcomes, and also that such rules do not 
           loop back to themselves and cause an unbounded number of RDF terms.
         </p>
       </section>
@@ -924,9 +924,9 @@ WHERE {
           either as a [=triple pattern element=] or inside a [=negation element=].
         </p>
         <p>
-          There are two kinds of dependencies: 
-          a <dfn data-lt="closed dependency">closed rule dependency</dfn>
-          and an <dfn data-lt="open dependency">open rule dependency</dfn>.
+          There are two kinds of dependency: 
+          <dfn data-lt="closed dependency">closed rule dependencies</dfn>
+          and <dfn data-lt="open dependency">open rule dependencies</dfn>.
           A <em>closed dependency</em> requires that rule `R2`
           has generated all its possible output before rule `R1` can be executed.
           This happens when `R1` has a [=triple pattern=] in a [=negation element=]
@@ -945,7 +945,7 @@ WHERE {
           <dd>
           <p>
             A [=triple pattern=] matches a [=triple template=] if 
-            the triple template may generate a triple that matches the triple pattern.
+            the triple template can generate a triple that matches the triple pattern.
           </p>
           </dd>
 
@@ -1188,7 +1188,7 @@ define buildDependencyGraph(ruleSet):
               blank nodes in the [=rule head=]; these rules are each evaluated exactly
               once at the start of evaluation of the [=stratification layer=].
               `SL.general` contains the remaining rules, which are evaluated 
-              until no new triples are inferred.
+              repeatedly until no new triples are inferred.
             </p>
           </dd>
           <dt><dfn>Stratification</dfn></dt>


### PR DESCRIPTION
As requested post-merge of #865.

Does not have an associated issue. These are editorial changes that I meant to submit on an open PR. My bad.

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/gh-pages/TallTed-patch-1/index.html)

(I hope I plucked the right URI details for the online render.}