### PR TITLE
Rework well-formedness (rules)

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -161,6 +161,10 @@
       .term2escape-yes { background-color: lightgreen; }
       .darkmode .term2escape-yes { background-color: darkgreen; }
 
+      <!-- lists -->
+      .list-indent     { margin-left: 5px; }
+      .list-no-bullet  { list-style: none; }
+      .list-inner      { list-style: disc; }
       
     </style>
 
@@ -277,37 +281,37 @@
           bindings given above.
         </p>
         <!--
-        <pre class="example-shapes">        # This box represents a shapes graph</pre>
+            <pre class="example-shapes">        # This box represents a shapes graph</pre>
 
-        <pre class="example-data">        # This box represents a data graph.</pre>
+            <pre class="example-data">        # This box represents a data graph.</pre>
 
-        <pre class="example-results">        # This box represents an output results graph</pre>
-        -->
+            <pre class="example-results">        # This box represents an output results graph</pre>
+            -->
 
-        <!--
-        <p>Formal definitions appear in blue boxes:</p>
-        <div class="def def-sparql">
-          <div class="def-header">TEXTUAL DEFINITIONS</div>
-          <pre class="def-sparql-body">          # This box contains textual definitions. </pre>
-        </div>
-        -->
+            <!--
+                <p>Formal definitions appear in blue boxes:</p>
+                <div class="def def-sparql">
+                  <div class="def-header">TEXTUAL DEFINITIONS</div>
+                  <pre class="def-sparql-body">          # This box contains textual definitions. </pre>
+                </div>
+                -->
 
-        <!--
-        <p class="syntax">Grey boxes such as this include syntax rules that apply to the shapes graph.</p>
-        -->
+                <!--
+                    <p class="syntax">Grey boxes such as this include syntax rules that apply to the shapes graph.</p>
+                    -->
 
-        <!--
-        <p>
-          <code>true</code>
-          denotes the RDF term
-          <code>"true"^^xsd:boolean</code>
-          .
-          <code>false</code>
-          denotes the RDF term
-          <code>"false"^^xsd:boolean</code>
-          .
-        </p>
-        -->
+                    <!--
+                        <p>
+                          <code>true</code>
+                          denotes the RDF term
+                          <code>"true"^^xsd:boolean</code>
+                          .
+                          <code>false</code>
+                          denotes the RDF term
+                          <code>"false"^^xsd:boolean</code>
+                          .
+                        </p>
+                        -->
       </section>
     </section>
 
@@ -409,52 +413,52 @@
         <p>In this first example, we have the following data graph and rule set:</p>
 
         <div class="data">
-<pre>
-   :A :fatherOf :X .
-   :B :motherOf :X .
-   :C :motherOf :A .
-</pre>
+          <pre>
+            :A :fatherOf :X .
+            :B :motherOf :X .
+            :C :motherOf :A .
+          </pre>
         </div>
 
         <div class="rules">
-<pre>
-RULE { ?x :childOf ?y } WHERE { ?y :fatherOf ?x }
-RULE { ?x :childOf ?y } WHERE { ?y :motherOf ?x }
-</pre>
+          <pre>
+            RULE { ?x :childOf ?y } WHERE { ?y :fatherOf ?x }
+            RULE { ?x :childOf ?y } WHERE { ?y :motherOf ?x }
+          </pre>
         </div>
         <p>The above rules, applied to the data, will conclude 
           that: `:X` is the `:childOf` `:A` and `:B`:
         </p>
         <div class="inferred">
-<pre>
-   :X :childOf :A .
-   :X :childOf :B .
-   :A :childOf :C .
-</pre>
+          <pre>
+            :X :childOf :A .
+            :X :childOf :B .
+            :A :childOf :C .
+          </pre>
         </div>
         <p>
           We can then derive `:descendedFrom` relationships by adding a rule that depends
           on `:childOf` triples produced by the other rules:
         </p>
         <div class="rules">
-<pre>
-RULE { ?x :childOf ?y } WHERE { ?y :fatherOf ?x }
-RULE { ?x :childOf ?y } WHERE { ?y :motherOf ?x }
-RULE { ?x :descendedFrom ?y } WHERE { ?x :childOf ?y }
-</pre>
+          <pre>
+            RULE { ?x :childOf ?y } WHERE { ?y :fatherOf ?x }
+            RULE { ?x :childOf ?y } WHERE { ?y :motherOf ?x }
+            RULE { ?x :descendedFrom ?y } WHERE { ?x :childOf ?y }
+          </pre>
         </div>
         <p>
           The outcome is:
         </p>
         <div class="inferred">
-<pre>
-   :A :descendedFrom :C .
-   :X :descendedFrom :B .
-   :X :descendedFrom :A .
-   :X :childOf :B .
-   :X :childOf :A .
-   :A :childOf :C .
-</pre>
+          <pre>
+            :A :descendedFrom :C .
+            :X :descendedFrom :B .
+            :X :descendedFrom :A .
+            :X :childOf :B .
+            :X :childOf :A .
+            :A :childOf :C .
+          </pre>
         </div>
       </section>
       <section id="desc-recursion">
@@ -464,24 +468,24 @@ RULE { ?x :descendedFrom ?y } WHERE { ?x :childOf ?y }
           to infer that `:X` is `:descendedFrom` `:C`:
         </p>
         <div class="rules">
-<pre>
-RULE { ?x :childOf ?y } WHERE { ?y :fatherOf ?x }
-RULE { ?x :childOf ?y } WHERE { ?y :motherOf ?x }
-RULE { ?x :descendedFrom ?y } WHERE { ?x :childOf ?y }
-RULE { ?x :descendedFrom ?y } WHERE { ?x :childOf ?z . ?z :descendedFrom ?y }
-</pre>
+          <pre>
+            RULE { ?x :childOf ?y } WHERE { ?y :fatherOf ?x }
+            RULE { ?x :childOf ?y } WHERE { ?y :motherOf ?x }
+            RULE { ?x :descendedFrom ?y } WHERE { ?x :childOf ?y }
+            RULE { ?x :descendedFrom ?y } WHERE { ?x :childOf ?z . ?z :descendedFrom ?y }
+          </pre>
         </div>
         <p>giving:</p>
         <div class="inferred">
-<pre>
-   :A :descendedFrom :C .
-   :X :descendedFrom :C .
-   :X :descendedFrom :B .
-   :X :descendedFrom :A .
-   :X :childOf :B .
-   :X :childOf :A .
-   :A :childOf :C .
-</pre>
+          <pre>
+            :A :descendedFrom :C .
+            :X :descendedFrom :C .
+            :X :descendedFrom :B .
+            :X :descendedFrom :A .
+            :X :childOf :B .
+            :X :childOf :A .
+            :A :childOf :C .
+          </pre>
         </div>
         <p>This adds the triple `:X :descendedFrom :C`.</p>
         <p>
@@ -501,20 +505,20 @@ RULE { ?x :descendedFrom ?y } WHERE { ?x :childOf ?z . ?z :descendedFrom ?y }
         </p>
 
         <div class="data">
-<pre>
-:town1 :population 1000 .
-:town2 :population 2000 .
-</pre>          
+          <pre>
+            :town1 :population 1000 .
+            :town2 :population 2000 .
+          </pre>          
         </div>
         <div class="rules">
-<pre>
-RULE { ?x rdf:type :largeTown } WHERE { ?x :population ?p . FILTER(?p > 1500) }
-</pre>          
+          <pre>
+            RULE { ?x rdf:type :largeTown } WHERE { ?x :population ?p . FILTER(?p > 1500) }
+          </pre>          
         </div>
         <div class="inferred">
-<pre>
-:town2 rdf:type :largeTown .
-</pre>          
+          <pre>
+            :town2 rdf:type :largeTown .
+          </pre>          
         </div>
         <p>
           `FILTER` evaluates an expression and keeps the current
@@ -541,28 +545,28 @@ RULE { ?x rdf:type :largeTown } WHERE { ?x :population ?p . FILTER(?p > 1500) }
           from inferred triples inferred by other rules.
         </p>
         <div class="data">
-<pre>
-:X1 rdf:type :Place ;
-    :population 1000 .
+          <pre>
+            :X1 rdf:type :Place ;
+            :population 1000 .
 
-:X2 rdf:type :Place ;
-    :population 2000 .
+            :X2 rdf:type :Place ;
+            :population 2000 .
 
-:X3 rdf:type :Place .
-</pre>
+            :X3 rdf:type :Place .
+          </pre>
         </div>
         <div class="rules">
-<pre>
-  RULE { ?x rdf:type :UnclassifiedSize } WHERE { 
-      ?x rdf:type :Place .
-      NOT { ?x :population ?p . }
-  }
-</pre>
+          <pre>
+            RULE { ?x rdf:type :UnclassifiedSize } WHERE { 
+            ?x rdf:type :Place .
+            NOT { ?x :population ?p . }
+            }
+          </pre>
         </div>
         <div class="inferred">
-<pre>
-:X3 rdf:type :UnclassifiedSize .
-</pre>
+          <pre>
+            :X3 rdf:type :UnclassifiedSize .
+          </pre>
         </div>
       </section>
 
@@ -574,27 +578,27 @@ RULE { ?x rdf:type :largeTown } WHERE { ?x :population ?p . FILTER(?p > 1500) }
           on the data.
         </p>
         <div class="rules">
-<pre>
-RULE { ?x :distanceKm ?kilometers }
-WHERE { 
-    ?x :distanceMiles ?miles .
-    SET ( ?kilometers := ?miles * 1.60934 )
-}
-</pre>    
+          <pre>
+            RULE { ?x :distanceKm ?kilometers }
+            WHERE { 
+            ?x :distanceMiles ?miles .
+            SET ( ?kilometers := ?miles * 1.60934 )
+            }
+          </pre>    
         </div>
         <p>
           This can be combined with testing for the absence of a triple
           already recording the distance in kilometers.
         </p>
         <div class="rules">
-<pre>
-RULE { ?x :distanceKm ?kilometers }
-WHERE { 
-    ?x :distanceMiles ?miles
-    NOT { ?x :distanceKm ?km }
-    SET ( ?kilometers := ?miles * 1.60934 )
-}
-</pre>    
+          <pre>
+            RULE { ?x :distanceKm ?kilometers }
+            WHERE { 
+            ?x :distanceMiles ?miles
+            NOT { ?x :distanceKm ?km }
+            SET ( ?kilometers := ?miles * 1.60934 )
+            }
+          </pre>    
         </div>
         <p>
           Rules involving [=assignments=] and rules that create blank nodes in 
@@ -663,14 +667,14 @@ WHERE {
         </p>
         <p>@@examples to be updated</p>
 
-          <div class="rules">
-<pre>
-DATA {
-  :father rdfs:subClassOf :familyRelationship .
-  :mother rdfs:subClassOf :familyRelationship .
-}
-</pre>
-        </p>
+        <div class="rules">
+          <pre>
+            DATA {
+            :father rdfs:subClassOf :familyRelationship .
+            :mother rdfs:subClassOf :familyRelationship .
+            }
+          </pre>
+        </div>
       </section>
 
       <section id="rule-tuples">
@@ -726,22 +730,14 @@ DATA {
 
           <dt><dfn>Expression</dfn></dt>
           <dd>
-            <p>
-              An [=expression=] is a function or a functional form;
-              the arguments are [=RDF terms=].
-              An expression is evaluated with respect to a [=solution mapping=], giving
-              an [=RDF term=] as the result.
-              <a>Expressions</a> are compatible with
-              <a data-cite="shacl12-node-expr#dfn-list-parameter-function"
-                 >SHACL list parameter functions</a>
-              and with <a data-cite="sparql12-query#expressions">SPARQL expressions</a>.</p>
-          </dd>
-          <dt><dfn >Condition</dfn></dt>
-          <dd>
-            <p>
-              A [=condition=] is an [=expression=] that evaluates to true or false.
-              [=Conditions=] are used to restrict the values of variables in pattern matching.
-            </p>
+            An [=expression=] is a function or a functional form;
+            the arguments are [=RDF terms=].
+            An expression is evaluated with respect to a [=solution mapping=], giving
+            an [=RDF term=] as the result.
+            <a>Expressions</a> are compatible with
+            <a data-cite="shacl12-node-expr#dfn-list-parameter-function"
+               >SHACL list parameter functions</a>
+            and with <a data-cite="sparql12-query#expressions">SPARQL expressions</a>.
           </dd>
           <dt><dfn data-lt="data-block">Data block</dfn></dt>
           <dd>
@@ -763,58 +759,52 @@ DATA {
             A [=triple pattern=] is 3-tuple where each element is either a
             [=variable=] or an [=RDF term=] (which might be a triple term).
             The second element of the tuple must be an [=IRI=] or a [=variable=].
-            [=Triple patterns=] can appear as [=triple pattern elements=]
-            as well as inside [=negation elements=].
           </dd>
 
-          <dt><dfn>Condition element</dfn></dt>
+          <dt><dfn>Filter element</dfn></dt>
           <dd>
-            A [=condition element=] is a [=condition=]
-            that appears as a [=rule body element=].
+            A [=filter element=] is an [=expression=]
+            that appears as a [=rule element=]
+            It is used to restrict the values of variables
+            in pattern matching.
           </dd>
 
           <dt><dfn>Triple pattern element</dfn></dt>
           <dd>
             A [=triple pattern element=] is a [=triple pattern=]
-            used as a [=rule body element=].
+            that appears as a [=rule element=].
           </dd>
 
           <dt><dfn>Negation element</dfn></dt>
           <dd>
-            A [=negation element=] is a [=rule body element=]
-            comprised of a sequence of [=triple patterns=] and
-            [=conditions=].
+            A [=negation element=] is a [=rule element=].
+            It has a <dfn>negation element body</dfn>
+            comprised of a sequence of [=triple pattern elements=] and
+            [=filter elements=].
           </dd>
 
           <dt><dfn data-lt="assignment element|assignment">Assignment element</dfn></dt>
           <dd>
-            An [=assignment element=] is a pair consisting 
+            An [=assignment element=] is a [=rule element=] that is
+            a pair consisting 
             of a <a>variable</a>, called the <dfn>assignment variable</dfn>, 
             and an <a>expression</a>, called the <dfn>assignment expression</dfn>.
-            [=Assignment elements=] appear in the [=body=] of a [=rule=].
           </dd>
 
           <!-- Pending
-          <dt><dfn>aggregation element</dfn></dt>
+               <dt><dfn>aggregation element</dfn></dt>
           <dd>
             An [=aggregation element=] is ..@@.. .
-             [=Aggregation elements=] appear in the [=body=] of a [=rule=].
+            [=Aggregation elements=] appear in the [=body=] of a [=rule=].
           </dd>
           -->
 
-          <dt><dfn 
-                data-lt="rule body element|rule element"
-                >Rule body element</dfn></dt>
-          <dd>
-            A [=rule body element=] (often just "rule element") is any element that
-            can appear in a [=rule body=], i.e.,
-            a [=triple pattern element=],
-            a [=condition element=],
-            a [=negation element=],
-            or an [=assignment element=].
-            <!-- Pending
-            or an [=aggregation element=].
-            -->
+          <dt><dfn>Rule element</dfn></dt>
+          <dd>A [=rule element=] is any one of 
+            [=triple pattern element=],
+            [=filter element=],
+            [=negation element=], or
+            [=assignment element=].
           </dd>
 
           <dt><dfn data-lt="rule head|head">Rule head</dfn></dt>
@@ -824,7 +814,12 @@ DATA {
 
           <dt><dfn data-lt="rule body|body">Rule body</dfn></dt>
           <dd> 
-            A [=rule body=] is a sequence of [=rule body elements=].
+            A [=rule body=] is a sequence of [=rule elements=];
+            that is, each sequence element is one of
+            a [=triple pattern element=],
+            a [=filter element=],
+            a [=negation element=],
+            or an [=assignment element=].
           </dd>
 
           <dt><dfn data-lt="rule imports|imports">Rule imports</dfn></dt>
@@ -894,66 +889,127 @@ DATA {
           position 3 is informally called the <em>object</em>.
         </p>
 
+        <p class="note">
+          The elements of a sequence of [=rule elements=] are labelled starting at 1.
+        </p>
+
       </section>
 
       <section id="wellformed">
         <h3>Well-formedness Conditions</h3>
         <p>
-          Well-formedness is a set of conditions on the abstract syntax of
-          SHACL rules. Together, these conditions ensure that a [=variable=] in the
+          <em>Well-formedness</em> is a set of conditions on the abstract syntax of
+          a [=rule set=]. Together, these conditions ensure 
+          that a [=variable=] in the
           [=head=] of a rule has a value defined in the [=body=] of the rule;
-          that each variable in an [=condition element=]
+          that each variable in an [=filter element=]
           or [=assignment expression=]
-          has a value at the point of evaluation; and that each
+          has a value at the point of evaluation; 
+          and that each
           assignment in a rule introduces a new variable,
           one that has not been used earlier in the rule body.
         </p>
         <p>
-          A [=rule=] is a <dfn>well-formed rule</dfn> if all of the following
-          conditions are met:
+          We define <em>well-formedness</em> for a sequence of [=rule elements=]
+          given an initial starting set of variables.  
         </p>
-        <ul>
-          <li>For every [=variable=] appearing in a [=triple template=]
-            of the [=head=] of the [=rule=],
-            there is one or more occurrences of a [=variable=]
-            of the same name in the [=triple patterns=] in the [=body=],
-            or in an [=assignment element=] in the body, or in both.
-          </li>
-          <li>
-            For every [=variable=] in an [=expression=] at position <em>i</em>
-            of the [=body=], there is a corresponding [=variable=] of the same
-            name occurring in a [=triple pattern=] at some position <em>j</em>,
-            or there is an [=assignment variable=] at some position <em>j</em>,
-            where <em>i &gt; j</em>.
-          </li>
-          <li>
-            For every [=variable=] in an expression in a [=negation element=] 
-            at position <em>i</em> of the [=body=], either 
-            there is a corresponding [=variable=] of the same
-            name occurring in a [=triple pattern=] 
-            or an [=assignment variable=] at some position <em>j</em>,
-            where <em>i &gt; j</em>,
-            or a  [=variable=] of the same name occurring in some [=triple pattern=] 
-            or [=assignment variable=] of the [=negation element=] 
-            preceeding the expression of the [=negation element=].
-          </li>
-          <li>
-            Each [=assignment variable=] is used in only one [=assignment element=] in
-            the [=body=] of the [=rule=].
-          </li>
-          <li>
-            An [=assignment variable=] at position <em>i</em> of a [=rule body=] does not
-            occur in any [=triple pattern=] at position <em>j</em> where <em>i &gt; j</em>.
-          </li>
-        </ul>
         <p>
-          A [=rule set=] is "well-formed" if and only if all of the [=rules=] of the
-          rule set are "well-formed".
+          Let <var>elt<sub>i</sub></var> be the i-th element of a sequence of [=rule elements=].
+        </p>
+        <p>
+          Let <var>vars<sub>i</sub></var> be the set of variables defined by 
+          <var>elt<sub>i</sub></var> where:
+        </p>
+        <div class="list-indent">
+          <ul class="list-no-bullet">
+            <li>
+              If <var>elt<sub>i</sub></var> is a [=triple pattern element=] then
+              <ul class="list-inner">
+                <li>
+                  <var>vars<sub>i</sub></var> is the set of [=variables=] 
+                  that occurs in the [=triple pattern element=].
+                </li>
+              </ul>
+            </li>
+            <li>
+              If <var>elt<sub>i</sub></var> is a [=assignment element=] then
+              <ul class="list-inner">
+                <li>
+                  <var>vars<sub>i</sub></var> is the set of the [=assignment variable=].
+                </li>
+              </ul>
+            <li>
+              Otherwise,
+              <ul class="list-inner">
+                <li>
+                  <var>vars<sub>i</sub></var> is the empty set.
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+        <p>
+          Let <var>V<sub>0</sub></var> be the initial variables of a sequence.
+        </p>
+        <p>
+          Let <var>V<sub>i</sub></var> 
+          be the union of <var>V<sub>0</sub></var> and all <var>vars<sub>j</sub></var>, 
+          where <var>j</var> is less than <var>i</var>.
+        </p>
+        <p>
+          Let <var>V<sub>all</sub></var> be <var>V<sub>N</sub></var> 
+          where N is the length of the sequence.
+        </p>
+        <p>
+          A <dfn>well-formed sequence</dfn> is a sequence of [=rule elements=], 
+          given a set of variables <var>V<sub>0</sub></var>,
+          if the following conditions are met:
+        </p>
+        <div class="list-indent">
+          <ul class="list-no-bullet">
+            <li>
+              If <var>elt<sub>i</sub></var> is a [=filter element=] then
+              <ul class="list-inner">
+                <li>every [=variable=] mentioned in a [=filter element=]
+                  is an element of <var>V<sub>i-1</sub></var>.
+                </li>
+              </ul>
+            </li>
+            <li>
+              If <var>elt<sub>i</sub></var> is a [=assignment element=] then
+              <ul class="list-inner">
+                <li>every variable mentioned in the [=assignment expression=]
+                  is an element of <var>V<sub>i-1</sub></var>
+                </li>
+                <li>
+                  the [=assignment variable=] is an not element of <var>V<sub>i-1</sub></var>.
+                </li>
+              </ul>
+            </li>
+            <li>
+              If <var>elt<sub>i</sub></var> is a [=negation element=] then
+              <ul class="list-inner">
+                <li>
+                  the sequence of [=rule elements=] in the 
+                  [=negation element body=] is a [=well-formed sequence=]
+                  given the set of variables <var>V<sub>i-1</sub></var>.
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+        <p>
+          A [=rule=] is a <dfn>well-formed rule</dfn>
+          if the sequence of the [=rule body=] is a [=well-formed sequence=] given
+          <var>V<sub>0</sub></var> is the empty set,
+          and each variable in a [=triple template=] of the [=rule head=]
+          is an element of <var>V<sub>all</sub></var>.
+        </p>
+        <p>
+          A [=rule set=] is a <dfn>well-formed rule set</dfn> if and only if all
+          rules of the rule set are [=well-formed rules=].
         </p>
 
-        <p class="ednote">
-          Revisit
-        </p>
       </section>
 
       <section id="rule-dependency">
@@ -1151,7 +1207,7 @@ define buildDependencyGraph(ruleSet):
         ## Classify each triple pattern TP in the rule as requiring "open" or "closed"
         ## depending on whether it is in a negation element or not.
         let bodyDependencies = {}
-        foreach rule body element RBE in the body of R1:
+        foreach rule element RBE in the body of R1:
             if RBE is a negation element:
                 foreach triple pattern TP in RBE:
                     let item be a pair (TP, "closed")
@@ -1844,7 +1900,7 @@ result is imports(RS, V)
       <section id="eval-expression">
         <h3>Evaluation of an Expression</h3>
         <p>
-          An expression, whether used in a [=condition element=] or 
+          An expression, whether used in a [=filter element=] or 
           an [=assignment element=], is evaluated with
           respect to a solution mapping which provides a value which is an RDF term,
           for each variable in the expression. 


### PR DESCRIPTION
* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/rules-wellformed/shacl12-rules/index.html)

The V1 way wasn't very good at expressing the conditions on negation.

The idea is that well-formedness is defined on a sequence of rule elements and an initial set of active variables a rule is a body is sequence of rule elements where the initial set of active variables is empty.

A negation is a sequence of rule elements, with restrictions on the rule elements allowed, where the initial set of active  variables is the accumulated of the body-level rule elements preceding the negation element.

Some definition changes - there is is no "rule body element" anymore, "condition" goes away and "condition element" becomes "filter element".
