### PR TITLE
#176: Use all prefix declarations if no sh:prefixes are declared, allow xsd:string at sh:namespace

### DIFF
--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2035,7 +2035,7 @@ WHERE {
 				<li>SERVICE clauses are conditionally permitted, see <a href="https://github.com/w3c/data-shapes/issues/374">Issue 374</a></li>
 				<li>Removed support for the optional pre-bound variables <code>shapesGraph</code> and <code>currentShape</code>, see <a href="https://github.com/w3c/data-shapes/issues/426">Issue 426</a></li>
 				<li>SPARQL constraints can now directly specify a <code>sh:severity</code>, see <a href="https://github.com/w3c/data-shapes/issues/573">Issue 573</a></li>
-				<li>If no sh:prefixes are present, the system will use any sh:prefix/sh:namespace pair, see <a href="https://github.com/w3c/data-shapes/issues/176">Issue 176</a></li>
+				<li>If no sh:prefixes are present, the system will use any sh:prefix/sh:namespace pair declared in sh:ShapesGraph, see <a href="https://github.com/w3c/data-shapes/issues/176">Issue 176</a></li>
 			</ul>
 		</section>
 	</body>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2035,7 +2035,7 @@ WHERE {
 				<li>SERVICE clauses are conditionally permitted, see <a href="https://github.com/w3c/data-shapes/issues/374">Issue 374</a></li>
 				<li>Removed support for the optional pre-bound variables <code>shapesGraph</code> and <code>currentShape</code>, see <a href="https://github.com/w3c/data-shapes/issues/426">Issue 426</a></li>
 				<li>SPARQL constraints can now directly specify a <code>sh:severity</code>, see <a href="https://github.com/w3c/data-shapes/issues/573">Issue 573</a></li>
-				<li>If no sh:prefixes are present, the system will use any sh:prefix/sh:namespace pair declared in sh:ShapesGraph, see <a href="https://github.com/w3c/data-shapes/issues/176">Issue 176</a></li>
+				<li>If no <code>sh:prefixes</code> are present, the system will use any <code>sh:prefix</code>/<code>sh:namespace</code> pair declared in any <code>sh:ShapesGraph</code>, see <a href="https://github.com/w3c/data-shapes/issues/176">Issue 176</a></li>
 			</ul>
 		</section>
 	</body>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -688,13 +688,13 @@ ex:
 		sh:prefix "schema" ;
 		sh:namespace "http://schema.org/" ;
 	] ;
-	a owl:Ontology ;    # Optional
+	a sh:ShapesGraph ;    # Optional
 	owl:imports sh: .   # Optional
 							</div>
 							<div class="jsonld">
 								<pre class="jsonld">{
 	"@id": "http://example.com/ns#",
-	"@type": "owl:Ontology",
+	"@type": "sh:ShapesGraph",
 	"owl:imports": {
 		"@id": "http://www.w3.org/ns/shacl#"
 	},
@@ -729,7 +729,7 @@ ex:
 					</p>
 					<p>
 						The recommended <a>subject</a> for values of <code>sh:declare</code> is the IRI of the named graph containing the shapes that use the prefixes.
-						These IRIs are often declared as an instance of <code>owl:Ontology</code>, but this is not required.
+						These IRIs are often declared as an instance of <code>sh:ShapesGraph</code> or <code>owl:Ontology</code>, but this is not required.
 					</p>
 					<p>
 						<a>Prefix declarations</a> can be used by <a>SPARQL-based constraints</a>,
@@ -752,8 +752,8 @@ ex:
 						(Note that SHACL processors MAY ignore prefix declarations that are never reached).
 					</p>
 					<p id="no-prefixes">
-						If a SPARQL query has no <a>value</a> for <code>sh:prefixes</code> then the system will use all <a>prefix declarations</a>
-						from the <a>shapes graph</a>.
+						If a SPARQL query has no <a>value</a> for <code>sh:prefixes</code> then the system will use those <a>prefix declarations</a>
+						from the <a>shapes graph</a> that are <a>values</a> of <code>sh:declare</code> at a <a>SHACL instance</a> of <code>sh:ShapesGraph</code>.
 					</p>
 					<p>
 						A SHACL processor transforms the values of <code>sh:select</code> (and similar properties such as <code>sh:ask</code>)

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -686,7 +686,7 @@ ex:
 	] ;
 	sh:declare [
 		sh:prefix "schema" ;
-		sh:namespace "http://schema.org/"^^xsd:anyURI ;
+		sh:namespace "http://schema.org/" ;
 	] ;
 	a owl:Ontology ;    # Optional
 	owl:imports sh: .   # Optional
@@ -707,10 +707,7 @@ ex:
 			"sh:prefix": "ex"
 		},
 		{
-			"sh:namespace": {
-				"@type": "xsd:anyURI",
-				"@value": "http://schema.org/"
-			},
+			"sh:namespace": "http://schema.org/",
 			"sh:prefix": "schema"
 		}
 	]
@@ -719,15 +716,16 @@ ex:
 						</div>
 					</aside>
 					<p class="syntax">
-						<span data-syntax-rule="declare-nodeKind">The <a>values</a> of the property <code>sh:declare</code> are <a>IRIs</a> or <a>blank nodes</a></span>,
-						and these values are called <dfn data-lt="prefix declaration">prefix declarations</dfn>.
+						<a>IRIs</a> or <a>blank nodes</a> that have <a>values</a> for both <code>sh:prefix</code> and <code>sh:namespace</code>
+						are called <dfn data-lt="prefix declaration">prefix declarations</dfn>.
 						The SHACL vocabulary includes the class <code>sh:PrefixDeclaration</code> as type for such <a>prefix declarations</a>
 						although no <code>rdf:type</code> triple is required for them.
 						<span data-syntax-rule="prefix-count"><a>Prefix declarations</a> have exactly one value for the property <code>sh:prefix</code></span>.
 						<span data-syntax-rule="prefix-datatype">The values of <code>sh:prefix</code> are <a>literals</a> of datatype <code>xsd:string</code>.</span>
 						<span data-syntax-rule="namespace-count"><a>Prefix declarations</a> have exactly one value for the property <code>sh:namespace</code>.</span>
-						<span data-syntax-rule="namespace-datatype">The values of <code>sh:namespace</code> are <a>literals</a> of datatype <code>xsd:anyURI</code>.</span>
+						<span data-syntax-rule="namespace-datatype">The values of <code>sh:namespace</code> are <a>literals</a> of datatype <code>xsd:anyURI</code> or <code>xsd:string</code>.</span>
 						Such a pair of values specifies a single mapping of a prefix to a namespace.
+						<span data-syntax-rule="declare-nodeKind">The <a>values</a> of the property <code>sh:declare</code> are <a>prefix declarations</a></span>.
 					</p>
 					<p>
 						The recommended <a>subject</a> for values of <code>sh:declare</code> is the IRI of the named graph containing the shapes that use the prefixes.
@@ -752,6 +750,10 @@ ex:
 						If such a collection of prefix declarations contains multiple different namespaces for the same <a>value</a> of <code>sh:prefix</code>,
 						then the <a>shapes graph</a> is <a>ill-formed</a>.</span>
 						(Note that SHACL processors MAY ignore prefix declarations that are never reached).
+					</p>
+					<p id="no-prefixes">
+						If a SPARQL query has no <a>value</a> for <code>sh:prefixes</code> then the system will use all <a>prefix declarations</a>
+						from the <a>shapes graph</a>.
 					</p>
 					<p>
 						A SHACL processor transforms the values of <code>sh:select</code> (and similar properties such as <code>sh:ask</code>)
@@ -2033,6 +2035,7 @@ WHERE {
 				<li>SERVICE clauses are conditionally permitted, see <a href="https://github.com/w3c/data-shapes/issues/374">Issue 374</a></li>
 				<li>Removed support for the optional pre-bound variables <code>shapesGraph</code> and <code>currentShape</code>, see <a href="https://github.com/w3c/data-shapes/issues/426">Issue 426</a></li>
 				<li>SPARQL constraints can now directly specify a <code>sh:severity</code>, see <a href="https://github.com/w3c/data-shapes/issues/573">Issue 573</a></li>
+				<li>If no sh:prefixes are present, the system will use any sh:prefix/sh:namespace pair, see <a href="https://github.com/w3c/data-shapes/issues/176">Issue 176</a></li>
 			</ul>
 		</section>
 	</body>

--- a/shacl12-test-suite/tests/sparql/node/manifest.ttl
+++ b/shacl12-test-suite/tests/sparql/node/manifest.ttl
@@ -4,8 +4,8 @@
 
 <>
 	a mf:Manifest ;
-	rdfs:label "Tests converted from http://datashapes.org/sh/tests/tests/sparql/node" ;
 	mf:include <prefixes-001.ttl> ;
+	mf:include <prefixes-002.ttl> ;
 	mf:include <sparql-001.ttl> ;
 	mf:include <sparql-002.ttl> ;
 	mf:include <sparql-003.ttl> ;

--- a/shacl12-test-suite/tests/sparql/node/prefixes-002.ttl
+++ b/shacl12-test-suite/tests/sparql/node/prefixes-002.ttl
@@ -1,0 +1,76 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:PrefixDeclaration
+  rdf:type sh:PrefixDeclaration ;
+  sh:namespace "http://example.com/ns#" ;
+  sh:prefix "ex" ;
+.
+ex:InvalidResource1
+  ex:property <http://test.com/ns#Value> ;
+.
+[
+  sh:namespace "http://test.com/ns#"^^xsd:anyURI ;
+  sh:prefix "test" ;
+]
+.
+ex:TestSPARQL
+  sh:select """
+		SELECT $this ?value
+		WHERE {
+			$this ex:property ?value .
+			FILTER (?value = test:Value) .
+		} """ ;
+.
+ex:TestSPARQL2
+  rdfs:comment "Here we locally redefine the test prefix so that no violation should happen" ;
+  sh:select """
+    PREFIX test: <urn:other:ns>
+		SELECT $this ?value
+		WHERE {
+			$this ex:property ?value .
+			FILTER (?value = test:Value) .
+		} """ ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:sparql ex:TestSPARQL ;
+  sh:sparql ex:TestSPARQL2 ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:ValidResource1 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <prefixes-002>
+    ) ;
+.
+<prefixes-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:prefixes 002 without explicit sh:prefixes triple" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint ex:TestSPARQL ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value <http://test.com/ns#Value> ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl12-test-suite/tests/sparql/node/prefixes-002.ttl
+++ b/shacl12-test-suite/tests/sparql/node/prefixes-002.ttl
@@ -18,6 +18,10 @@ ex:UnusedPrefixDeclaration
   sh:namespace "http://example.com/ns2#" ;
   sh:prefix "ex" ;
 .
+ex:SomeOntology
+  rdf:type owl:Ontology ;
+  sh:declare ex:UnusedPrefixDeclaration ;
+.
 ex:InvalidResource1
   ex:property <http://test.com/ns#Value> ;
 .

--- a/shacl12-test-suite/tests/sparql/node/prefixes-002.ttl
+++ b/shacl12-test-suite/tests/sparql/node/prefixes-002.ttl
@@ -13,13 +13,21 @@ ex:PrefixDeclaration
   sh:namespace "http://example.com/ns#" ;
   sh:prefix "ex" ;
 .
+ex:UnusedPrefixDeclaration
+  rdf:type sh:PrefixDeclaration ;
+  sh:namespace "http://example.com/ns2#" ;
+  sh:prefix "ex" ;
+.
 ex:InvalidResource1
   ex:property <http://test.com/ns#Value> ;
 .
-[
-  sh:namespace "http://test.com/ns#"^^xsd:anyURI ;
-  sh:prefix "test" ;
-]
+ex:SomeShapesGraph 
+  rdf:type sh:ShapesGraph ;
+  sh:declare [
+    sh:namespace "http://test.com/ns#"^^xsd:anyURI ;
+    sh:prefix "test" ;
+  ] ;
+  sh:declare ex:PrefixDeclaration ;
 .
 ex:TestSPARQL
   sh:select """

--- a/shacl12-test-suite/tests/sparql/targets/targetNode-select-001.ttl
+++ b/shacl12-test-suite/tests/sparql/targets/targetNode-select-001.ttl
@@ -15,7 +15,7 @@ ex:ChildShape
 	sh:targetNode [
 		sh:select """
 			PREFIX ex: <http://example.com/ns#>
-            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+			PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 			SELECT ?person
 			WHERE {
 				?person a/rdfs:subClassOf* ex:Person .

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1638,7 +1638,6 @@ sh:namespace
 	rdfs:label "namespace"@en ;
 	rdfs:comment "The namespace associated with a prefix in a prefix declaration."@en ;
 	rdfs:domain sh:PrefixDeclaration ;
-	rdfs:range xsd:anyURI ;
 	rdfs:isDefinedBy sh: .
 
 


### PR DESCRIPTION
Closes #176

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-176/shacl12-sparql/index.html#sparql-prefixes)

This implements the idea at https://github.com/w3c/data-shapes/issues/176#issuecomment-4700587832 plus Andy's suggestion to generalize the datatype of sh:namespace to include xsd:string.
