### PR TITLE
move vocabs to DCTERMS off schema.org

### DIFF
--- a/shacl12-vocabularies/shacl-shacl.ttl
+++ b/shacl12-vocabularies/shacl-shacl.ttl
@@ -1,16 +1,14 @@
-# baseURI: http://www.w3.org/ns/shacl-shacl#
-
 # A SHACL shapes graph to validate SHACL shapes graphs
 
 # THIS VERSION IS UNDER DEVELOPMENT BY THE DATA-SHAPES (SHACL 1.2) WG
 
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix owl:  <http://www.w3.org/2002/07/owl#> .
-@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix sh:   <http://www.w3.org/ns/shacl#> .
-@prefix shsh: <http://www.w3.org/ns/shacl-shacl#> .
-@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix shsh:    <http://www.w3.org/ns/shacl-shacl#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 
 shsh:
     a owl:Ontology ;
@@ -23,7 +21,7 @@ shsh:
     # dcterms:created ""^^xsd:date ;
     # dcterms:issued ""^^xsd:date ;
     # dcterms:modified ""^^xsd:date ;
-    dcterms:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
+    dcterms:license "https://www.w3.org/copyright/software-license/"^^xsd:anyURI ;
 	sh:declare [
 		sh:prefix "shsh" ;
 		sh:namespace "http://www.w3.org/ns/shacl-shacl#"^^xsd:anyURI ;

--- a/shacl12-vocabularies/shacl-shacl.ttl
+++ b/shacl12-vocabularies/shacl-shacl.ttl
@@ -4,14 +4,13 @@
 
 # THIS VERSION IS UNDER DEVELOPMENT BY THE DATA-SHAPES (SHACL 1.2) WG
 
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl:  <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh:   <http://www.w3.org/ns/shacl#> .
-@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
-
 @prefix shsh: <http://www.w3.org/ns/shacl-shacl#> .
-@prefix schema: <https://schema.org/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 
 shsh:
     a owl:Ontology ;
@@ -19,12 +18,12 @@ shsh:
     owl:versionIRI shsh:1.2 ;
 	rdfs:label "W3C SHACL for SHACL Validator"@en ;
 	rdfs:comment "This shapes graph can be used to validate SHACL shapes graphs against a subset of the syntax rules."@en ;
-    schema:creator "W3C Data Shapes Working Group" ;
-    # schema:dateCreated ""^^xsd:date ;
-    # schema:dateIssued ""^^xsd:date ;
-    # schema:dateModified ""^^xsd:date ;
-    schema:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
-    schema:version "1.2" ;
+    dcterms:creator "W3C Data Shapes Working Group" ;
+    dcterms:publisher "World Wide Web Consortium" ;
+    # dcterms:created ""^^xsd:date ;
+    # dcterms:issued ""^^xsd:date ;
+    # dcterms:modified ""^^xsd:date ;
+    dcterms:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
 	sh:declare [
 		sh:prefix "shsh" ;
 		sh:namespace "http://www.w3.org/ns/shacl-shacl#"^^xsd:anyURI ;

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -6,24 +6,24 @@
 
 # THIS VERSION IS UNDER DEVELOPMENT BY THE DATA-SHAPES (SHACL 1.2) WG
 
-@prefix owl:  <http://www.w3.org/2002/07/owl#> .
-@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
-@prefix schema: <https://schema.org/> .
-@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
 
 sh:
 	a owl:Ontology ;
 	owl:versionIRI sh:1.2 ;
 	rdfs:label "W3C Shapes Constraint Language (SHACL) Vocabulary"@en ;
 	rdfs:comment "This vocabulary defines terms used in SHACL, the W3C Shapes Constraint Language."@en ;
-    schema:creator "W3C Data Shapes Working Group" ;
-    # schema:dateCreated ""^^xsd:date ;
-    # schema:dateIssued ""^^xsd:date ;
-    # schema:dateModified ""^^xsd:date ;
-    schema:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
-    schema:version "1.2" ;
+    dcterms:creator "W3C Data Shapes Working Group" ;
+    dcterms:publisher "World Wide Web Consortium" ;
+    # dcterms:created ""^^xsd:date ;
+    # dcterms:issued ""^^xsd:date ;
+    # dcterms:modified ""^^xsd:date ;
+    dcterms:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
 	sh:declare [
 		sh:prefix "sh" ;
 		sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1,7 +1,3 @@
-## W3C SOFTWARE AND DOCUMENT NOTICE AND LICENSE
-## https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
-## --------
-
 # W3C Shapes Constraint Language (SHACL) Vocabulary
 
 # THIS VERSION IS UNDER DEVELOPMENT BY THE DATA-SHAPES (SHACL 1.2) WG
@@ -23,7 +19,7 @@ sh:
     # dcterms:created ""^^xsd:date ;
     # dcterms:issued ""^^xsd:date ;
     # dcterms:modified ""^^xsd:date ;
-    dcterms:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
+    dcterms:license "https://www.w3.org/copyright/software-license/"^^xsd:anyURI ;
 	sh:declare [
 		sh:prefix "sh" ;
 		sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;

--- a/shacl12-vocabularies/shnex-sparql.ttl
+++ b/shacl12-vocabularies/shnex-sparql.ttl
@@ -6,15 +6,15 @@
 
 # THIS VERSION IS UNDER DEVELOPMENT BY THE DATA-SHAPES (SHACL 1.2) WG
 
-@prefix owl:   <http://www.w3.org/2002/07/owl#> .
-@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
-@prefix sh:    <http://www.w3.org/ns/shacl#> .
-@prefix shnex: <http://www.w3.org/ns/shacl-node-expr#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix shnex:   <http://www.w3.org/ns/shacl-node-expr#> .
 @prefix shnex-sparql: <http://www.w3.org/ns/shacl-node-expr-sparql#> .
 @prefix sparql:  <http://www.w3.org/ns/sparql#> .
-@prefix schema: <https://schema.org/> .
 
 shnex-sparql:
 	a owl:Ontology ;
@@ -22,12 +22,12 @@ shnex-sparql:
 	owl:versionIRI shnex-sparql:1.2 ;
 	rdfs:label "W3C SHACL SPARQL Extensions Vocabulary"@en ;
 	rdfs:comment "This vocabulary defines terms used in the SHACL SPARQL specification."@en ;
-    schema:creator "W3C Data Shapes Working Group" ;
-    # schema:dateCreated ""^^xsd:date ;
-    # schema:dateIssued ""^^xsd:date ;
-    # schema:dateModified ""^^xsd:date ;
-    schema:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
-    schema:version "1.2" ;
+    dcterms:creator "W3C Data Shapes Working Group" ;
+    dcterms:publisher "World Wide Web Consortium" ;
+    # dcterms:created ""^^xsd:date ;
+    # dcterms:issued ""^^xsd:date ;
+    # dcterms:modified ""^^xsd:date ;
+    dcterms:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
 	sh:declare [
 		sh:prefix "shnex-sparql" ;
 		sh:namespace "http://www.w3.org/ns/shacl-node-expr-sparql#"^^xsd:anyURI ;

--- a/shacl12-vocabularies/shnex-sparql.ttl
+++ b/shacl12-vocabularies/shnex-sparql.ttl
@@ -1,7 +1,3 @@
-## W3C SOFTWARE AND DOCUMENT NOTICE AND LICENSE
-## https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
-## --------
-
 # W3C SHACL Node Expressions Vocabulary
 
 # THIS VERSION IS UNDER DEVELOPMENT BY THE DATA-SHAPES (SHACL 1.2) WG
@@ -10,11 +6,11 @@
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh:      <http://www.w3.org/ns/shacl#> .
 @prefix shnex:   <http://www.w3.org/ns/shacl-node-expr#> .
 @prefix shnex-sparql: <http://www.w3.org/ns/shacl-node-expr-sparql#> .
 @prefix sparql:  <http://www.w3.org/ns/sparql#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 
 shnex-sparql:
 	a owl:Ontology ;
@@ -27,7 +23,7 @@ shnex-sparql:
     # dcterms:created ""^^xsd:date ;
     # dcterms:issued ""^^xsd:date ;
     # dcterms:modified ""^^xsd:date ;
-    dcterms:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
+    dcterms:license "https://www.w3.org/copyright/software-license/"^^xsd:anyURI ;
 	sh:declare [
 		sh:prefix "shnex-sparql" ;
 		sh:namespace "http://www.w3.org/ns/shacl-node-expr-sparql#"^^xsd:anyURI ;

--- a/shacl12-vocabularies/shnex.ttl
+++ b/shacl12-vocabularies/shnex.ttl
@@ -1,7 +1,3 @@
-## W3C SOFTWARE AND DOCUMENT NOTICE AND LICENSE
-## https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
-## --------
-
 # W3C SHACL Node Expressions Vocabulary
 
 # THIS VERSION IS UNDER DEVELOPMENT BY THE DATA-SHAPES (SHACL 1.2) WG
@@ -10,9 +6,9 @@
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh:      <http://www.w3.org/ns/shacl#> .
 @prefix shnex:   <http://www.w3.org/ns/shacl-node-expr#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 
 shnex:
 	a owl:Ontology ;
@@ -25,7 +21,7 @@ shnex:
     # dcterms:created ""^^xsd:date ;
     # dcterms:issued ""^^xsd:date ;
     # dcterms:modified ""^^xsd:date ;
-    dcterms:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
+    dcterms:license "https://www.w3.org/copyright/software-license/"^^xsd:anyURI ;
 	sh:declare [
 		sh:prefix "shnex" ;
 		sh:namespace "http://www.w3.org/ns/shacl-node-expr#"^^xsd:anyURI ;

--- a/shacl12-vocabularies/shnex.ttl
+++ b/shacl12-vocabularies/shnex.ttl
@@ -6,13 +6,13 @@
 
 # THIS VERSION IS UNDER DEVELOPMENT BY THE DATA-SHAPES (SHACL 1.2) WG
 
-@prefix owl:   <http://www.w3.org/2002/07/owl#> .
-@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
-@prefix schema: <https://schema.org/> .
-@prefix sh:    <http://www.w3.org/ns/shacl#> .
-@prefix shnex: <http://www.w3.org/ns/shacl-node-expr#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix shnex:   <http://www.w3.org/ns/shacl-node-expr#> .
 
 shnex:
 	a owl:Ontology ;
@@ -20,12 +20,12 @@ shnex:
 	owl:versionIRI shnex:1.2 ;
 	rdfs:label "W3C SHACL Node Expressions Vocabulary"@en ;
 	rdfs:comment "This vocabulary defines terms used in the SHACL Node Expressions specification."@en ;
-    schema:creator "W3C Data Shapes Working Group" ;
-    # schema:dateCreated ""^^xsd:date ;
-    # schema:dateIssued ""^^xsd:date ;
-    # schema:dateModified ""^^xsd:date ;
-    schema:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
-    schema:version "1.2" ;
+    dcterms:creator "W3C Data Shapes Working Group" ;
+    dcterms:publisher "World Wide Web Consortium" ;
+    # dcterms:created ""^^xsd:date ;
+    # dcterms:issued ""^^xsd:date ;
+    # dcterms:modified ""^^xsd:date ;
+    dcterms:license "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"^^xsd:anyURI ;
 	sh:declare [
 		sh:prefix "shnex" ;
 		sh:namespace "http://www.w3.org/ns/shacl-node-expr#"^^xsd:anyURI ;


### PR DESCRIPTION
* move vocabs from using schema.org metadata predicates to DCTERMS

Closes Issue #943