### PR TITLE
Externalise Profiling's e.g.s

### DIFF
--- a/shacl12-profiling/examples/01.ttl
+++ b/shacl12-profiling/examples/01.ttl
@@ -1,0 +1,8 @@
+ex:ont-M
+    a sh:ShapesGraph ;
+.
+
+ex:shape-1
+    a sh:NodeShape ;
+    rdfs:isDefinedBy ex:ont-M ;
+.

--- a/shacl12-profiling/examples/02.ttl
+++ b/shacl12-profiling/examples/02.ttl
@@ -1,0 +1,14 @@
+# 'Ontology M' uses a Shape defined by 'Ontology Other'
+ex:ont-M
+    a sh:ShapesGraph ;
+    rdfs:member ex:shape-1 ;
+.
+
+ex:ont-Other
+    a sh:ShapesGraph ;
+.
+
+ex:shape-1
+    a sh:NodeShape ;
+    rdfs:isDefinedBy ex:ont-Other ;
+.

--- a/shacl12-profiling/examples/03.ttl
+++ b/shacl12-profiling/examples/03.ttl
@@ -1,0 +1,9 @@
+# 'Ontology N' imports 'Ontology M'
+ex:ont-M
+    a owl:Ontology ;
+.
+
+ex:ont-N
+    a owl:Ontology ;
+    owl:imports ex:ont-M ;
+.

--- a/shacl12-profiling/examples/04.ttl
+++ b/shacl12-profiling/examples/04.ttl
@@ -1,26 +1,26 @@
 # declaration of the Core profile
-&lt;http://www.w3.org/ns/shacl/profile/core>
+<http://www.w3.org/ns/shacl/profile/core>
   a prof:Profile ;
-  prof:isProfileOf &lt;https://www.w3.org/TR/shacl/> ;
+  prof:isProfileOf <https://www.w3.org/TR/shacl/> ;
   prof:hasResource
-    &lt;https://www.w3.org/TR/shacl12-core/> ,
-    &lt;http://www.w3.org/ns/shacl-shacl/core> ;
+    <https://www.w3.org/TR/shacl12-core/> ,
+    <http://www.w3.org/ns/shacl-shacl/core> ;
 .
 
 # Core specification
-&lt;https://www.w3.org/TR/shacl12-core/>
+<https://www.w3.org/TR/shacl12-core/>
   a prof:ResourceDescriptor ;
   prof:hasRole role:Specification ;
   dcterms:format "text/html" ;
-  dcterms:conformsTo &lt;http://www.w3.org/TR/html5/> ;
-  prof:hasArtifact &lt;https://www.w3.org/TR/shacl12-core/> ;
+  dcterms:conformsTo <http://www.w3.org/TR/html5/> ;
+  prof:hasArtifact <https://www.w3.org/TR/shacl12-core/> ;
 .
 
 # Core validator
-&lt;http://www.w3.org/ns/shacl-shacl/core>
+<http://www.w3.org/ns/shacl-shacl/core>
   a prof:ResourceDescriptor ;
   prof:hasRole role:Validation ;
   dcterms:format "text/turtle" ;
-  dcterms:conformsTo &lt;https://www.w3.org/TR/shacl/> ;
-  prof:hasArtifact &lt;http://www.w3.org/ns/shacl-shacl/core> ;
+  dcterms:conformsTo <https://www.w3.org/TR/shacl/> ;
+  prof:hasArtifact <http://www.w3.org/ns/shacl-shacl/core> ;
 .

--- a/shacl12-profiling/examples/04.ttl
+++ b/shacl12-profiling/examples/04.ttl
@@ -1,0 +1,26 @@
+# declaration of the Core profile
+&lt;http://www.w3.org/ns/shacl/profile/core>
+  a prof:Profile ;
+  prof:isProfileOf &lt;https://www.w3.org/TR/shacl/> ;
+  prof:hasResource
+    &lt;https://www.w3.org/TR/shacl12-core/> ,
+    &lt;http://www.w3.org/ns/shacl-shacl/core> ;
+.
+
+# Core specification
+&lt;https://www.w3.org/TR/shacl12-core/>
+  a prof:ResourceDescriptor ;
+  prof:hasRole role:Specification ;
+  dcterms:format "text/html" ;
+  dcterms:conformsTo &lt;http://www.w3.org/TR/html5/> ;
+  prof:hasArtifact &lt;https://www.w3.org/TR/shacl12-core/> ;
+.
+
+# Core validator
+&lt;http://www.w3.org/ns/shacl-shacl/core>
+  a prof:ResourceDescriptor ;
+  prof:hasRole role:Validation ;
+  dcterms:format "text/turtle" ;
+  dcterms:conformsTo &lt;https://www.w3.org/TR/shacl/> ;
+  prof:hasArtifact &lt;http://www.w3.org/ns/shacl-shacl/core> ;
+.

--- a/shacl12-profiling/examples/05.ttl
+++ b/shacl12-profiling/examples/05.ttl
@@ -1,4 +1,4 @@
-&lt;SG1>
+<SG1>
     a prof:Profile ;
-    prof:isProfileOf &lt;S1> ;
+    prof:isProfileOf <S1> ;
 .

--- a/shacl12-profiling/examples/05.ttl
+++ b/shacl12-profiling/examples/05.ttl
@@ -1,0 +1,4 @@
+&lt;SG1>
+    a prof:Profile ;
+    prof:isProfileOf &lt;S1> ;
+.

--- a/shacl12-profiling/examples/06.ttl
+++ b/shacl12-profiling/examples/06.ttl
@@ -1,8 +1,8 @@
-&lt;SG1>
+<SG1>
     a prof:Profile ;
-    prof:isProfileOf &lt;S1> ;
+    prof:isProfileOf <S1> ;
     prof:hasResource [
-        prof:hasArtifact &lt;SG1> ;
+        prof:hasArtifact <SG1> ;
         prof:hasRole role:validation ;
     ] ;
 .

--- a/shacl12-profiling/examples/06.ttl
+++ b/shacl12-profiling/examples/06.ttl
@@ -1,0 +1,8 @@
+&lt;SG1>
+    a prof:Profile ;
+    prof:isProfileOf &lt;S1> ;
+    prof:hasResource [
+        prof:hasArtifact &lt;SG1> ;
+        prof:hasRole role:validation ;
+    ] ;
+.

--- a/shacl12-profiling/examples/07.ttl
+++ b/shacl12-profiling/examples/07.ttl
@@ -1,10 +1,10 @@
-&lt;SG1>
+<SG1>
     a prof:Profile ;
-    prof:isProfileOf &lt;S1> ;
+    prof:isProfileOf <S1> ;
     prof:hasResource [
-        prof:hasArtifact &lt;S1> ;
+        prof:hasArtifact <S1> ;
         prof:hasRole role:validation ;
-        dcterms:conformsTo &lt;https://www.w3.org/TR/shacl12-core/> ;
+        dcterms:conformsTo <https://www.w3.org/TR/shacl12-core/> ;
         dcterms:format "text/turtle" ;
     ] ;
 .

--- a/shacl12-profiling/examples/07.ttl
+++ b/shacl12-profiling/examples/07.ttl
@@ -1,0 +1,10 @@
+&lt;SG1>
+    a prof:Profile ;
+    prof:isProfileOf &lt;S1> ;
+    prof:hasResource [
+        prof:hasArtifact &lt;S1> ;
+        prof:hasRole role:validation ;
+        dcterms:conformsTo &lt;https://www.w3.org/TR/shacl12-core/> ;
+        dcterms:format "text/turtle" ;
+    ] ;
+.

--- a/shacl12-profiling/examples/08.ttl
+++ b/shacl12-profiling/examples/08.ttl
@@ -1,13 +1,13 @@
-&lt;SG1>
+<SG1>
     a prof:Profile ;
-    prof:isProfileOf &lt;S1> ;
+    prof:isProfileOf <S1> ;
     prof:hasResource [
-        prof:hasArtifact &lt;S1> ;
+        prof:hasArtifact <S1> ;
         prof:hasRole
         role:constraints ,
         role:specification ,
         role:validation ;
-        dcterms:conformsTo &lt;https://www.w3.org/TR/shacl12-core/> ;
+        dcterms:conformsTo <https://www.w3.org/TR/shacl12-core/> ;
         dcterms:format "text/turtle" ;
     ] ;
 .

--- a/shacl12-profiling/examples/08.ttl
+++ b/shacl12-profiling/examples/08.ttl
@@ -1,0 +1,13 @@
+&lt;SG1>
+    a prof:Profile ;
+    prof:isProfileOf &lt;S1> ;
+    prof:hasResource [
+        prof:hasArtifact &lt;S1> ;
+        prof:hasRole
+        role:constraints ,
+        role:specification ,
+        role:validation ;
+        dcterms:conformsTo &lt;https://www.w3.org/TR/shacl12-core/> ;
+        dcterms:format "text/turtle" ;
+    ] ;
+.

--- a/shacl12-profiling/examples/09.ttl
+++ b/shacl12-profiling/examples/09.ttl
@@ -1,1 +1,1 @@
-&lt;DG1> dcterms:conformsTo &lt;SG1> .  # via RDFS or OWL-RL reasoning
+<DG1> dcterms:conformsTo <SG1> .  # via RDFS or OWL-RL reasoning

--- a/shacl12-profiling/examples/09.ttl
+++ b/shacl12-profiling/examples/09.ttl
@@ -1,0 +1,1 @@
+&lt;DG1> dcterms:conformsTo &lt;SG1> .  # via RDFS or OWL-RL reasoning

--- a/shacl12-profiling/examples/10.ttl
+++ b/shacl12-profiling/examples/10.ttl
@@ -1,0 +1,1 @@
+&lt;DG1> dcterms:conformsTo &lt;SG1> .

--- a/shacl12-profiling/examples/10.ttl
+++ b/shacl12-profiling/examples/10.ttl
@@ -1,1 +1,1 @@
-&lt;DG1> dcterms:conformsTo &lt;SG1> .
+<DG1> dcterms:conformsTo <SG1> .

--- a/shacl12-profiling/examples/11.ttl
+++ b/shacl12-profiling/examples/11.ttl
@@ -1,1 +1,1 @@
-&lt;SG1> prof:isProfileOf &lt;S1> .
+<SG1> prof:isProfileOf <S1> .

--- a/shacl12-profiling/examples/11.ttl
+++ b/shacl12-profiling/examples/11.ttl
@@ -1,0 +1,1 @@
+&lt;SG1> prof:isProfileOf &lt;S1> .

--- a/shacl12-profiling/examples/12.ttl
+++ b/shacl12-profiling/examples/12.ttl
@@ -1,0 +1,1 @@
+&lt;DG1> dcterms:conformsTo &lt;S1> .

--- a/shacl12-profiling/examples/12.ttl
+++ b/shacl12-profiling/examples/12.ttl
@@ -1,1 +1,1 @@
-&lt;DG1> dcterms:conformsTo &lt;S1> .
+<DG1> dcterms:conformsTo <S1> .

--- a/shacl12-profiling/examples/13.ttl
+++ b/shacl12-profiling/examples/13.ttl
@@ -1,4 +1,4 @@
-&lt;http://www.w3.org/ns/shacl/profile/cd1>
+<http://www.w3.org/ns/shacl/profile/cd1>
     a
         owl:Ontology ,
         prof:Profile ;

--- a/shacl12-profiling/examples/13.ttl
+++ b/shacl12-profiling/examples/13.ttl
@@ -1,0 +1,19 @@
+&lt;http://www.w3.org/ns/shacl/profile/cd1>
+    a
+        owl:Ontology ,
+        prof:Profile ;
+    prof:isProfileOf sh: ;
+    rdfs:label "CD1 Profile of SHACL"@en ;
+    rdfs:comment """This is a Profile of SHACL 1.2 that excludes shapes found to
+be computationally intensive.
+
+Vocabulary elements of SHACL that are not listed as members of this profile may
+not be used for implementations claiming conformance to this profile."""@en ;
+    rdfs:member
+        sh:AbstractResult ,
+        sh:AndConstraintComponent ,
+        # ... many skipped members
+        sh:xone ,
+        sh:zeroOrMorePath ,
+        sh:zeroOrOnePath ;
+.

--- a/shacl12-profiling/examples/README.md
+++ b/shacl12-profiling/examples/README.md
@@ -4,7 +4,7 @@ This directory contains example files in pseudo-Turtle format used within the Pr
 
 All examples are included using ReSpec commands like this:
 
-`<div class="turtle" data-include="examples/defining-profiles-of-shacl.ttl"></div>`
+`<div class="turtle" data-include="examples/01.ttl"  data-include-format="text"></div>`
 
 ## Validation
 

--- a/shacl12-profiling/examples/README.md
+++ b/shacl12-profiling/examples/README.md
@@ -1,0 +1,17 @@
+# Examples
+
+This directory contains example files in pseudo-Turtle format used within the Profiling HTML document.
+
+All examples are included using ReSpect commands like this:
+
+`<div class="turtle" data-include="examples/defining-profiles-of-shacl.ttl"></div>`
+
+## Validation
+
+To validate an example you will need Python installed and the [rdflib](https://pypi.org/project/rdflib/) package installed. You cna then run `validate.py` with any example file as an argument, e.g.:
+
+```bash
+python check-rdf.py 01.ttl
+```
+
+The script will print "OK" if there are no syntax errors or else an error message.

--- a/shacl12-profiling/examples/README.md
+++ b/shacl12-profiling/examples/README.md
@@ -2,7 +2,7 @@
 
 This directory contains example files in pseudo-Turtle format used within the Profiling HTML document.
 
-All examples are included using ReSpect commands like this:
+All examples are included using ReSpec commands like this:
 
 `<div class="turtle" data-include="examples/defining-profiles-of-shacl.ttl"></div>`
 

--- a/shacl12-profiling/examples/_prefixes.ttl
+++ b/shacl12-profiling/examples/_prefixes.ttl
@@ -1,0 +1,8 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX ex:      <http://example.com/ns#>
+PREFIX owl:     <http://www.w3.org/2002/07/owl#>
+PREFIX prof:    <http://www.w3.org/ns/dx/prof/>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX role:    <http://www.w3.org/ns/dx/prof/role/>
+PREFIX sh:      <http://www.w3.org/ns/shacl#>
+PREFIX shpr:    <http://www.w3.org/ns/shpr#>

--- a/shacl12-profiling/examples/check-rdf.py
+++ b/shacl12-profiling/examples/check-rdf.py
@@ -4,8 +4,6 @@ from rdflib import Graph
 prefixes = open("_prefixes.ttl").read()
 example_data = open(sys.argv[1]).read()
 
-example_data = example_data.replace("&lt;", "<")
-
 total = prefixes + "\n\n" + example_data
 
 # print(total)

--- a/shacl12-profiling/examples/check-rdf.py
+++ b/shacl12-profiling/examples/check-rdf.py
@@ -1,0 +1,13 @@
+import sys
+from rdflib import Graph
+
+prefixes = open("_prefixes.ttl").read()
+example_data = open(sys.argv[1]).read()
+
+example_data = example_data.replace("&lt;", "<")
+
+total = prefixes + "\n\n" + example_data
+
+# print(total)
+g = Graph().parse(data=total, format="turtle")
+print("ok")

--- a/shacl12-profiling/index.html
+++ b/shacl12-profiling/index.html
@@ -653,7 +653,7 @@ ex:graph-y {
       This recommendation suggests that the creator of a <a>SHACL element</a> SHOULD indicate the group
       within which the <a>SHACL element</a> is defined. An example of such an assertion in RDF is as follows:
     </p>
-    <div class="turtle" data-include="examples/01.ttl"></div>
+    <div class="turtle" data-include="examples/01.ttl" data-include-format="text"></div>
     <p class="note">
       In Section <a data-cite="shacl12-core#syntactic-variations-of-shapes-and-classes">2.5 Syntactic Variations of Shapes and Classes</a> of [[[shacl12-core]]],
       a warning is issued that while <a data-cite="shacl12-core#dfn-property-shape">property shapes</a> may be declared
@@ -678,7 +678,7 @@ ex:graph-y {
       An example of the use of the <code>rdfs:member</code> predicate to indicate inclusion of a <a>SHACL element</a> in a group
       that does not define it, as well use of <code>rdfs:isDefinedBy</code>, as in the example above, is as follows:
     </p>
-    <div class="turtle" data-include="examples/02.ttl"></div>
+    <div class="turtle" data-include="examples/02.ttl" data-include-format="text"></div>
   </section>
   <section id="rec-imports">
     <h3>Indicating group dependence</h3>
@@ -697,7 +697,7 @@ ex:graph-y {
     <p>
       An example of <code>owl:imports</code> is as per the example below.
     </p>
-    <div class="turtle" data-include="examples/03.ttl"></div>
+    <div class="turtle" data-include="examples/03.ttl" data-include-format="text"></div>
   </section>
   <section id="dependencies">
     <h3>Calculating Dependencies</h3>
@@ -737,7 +737,7 @@ ex:graph-y {
     <p>
       Profiles of SHACL should be declared using [[[dx-prof]]]. The declaration of the Core profile of SHACL 1.2 is as follows:
     </p>
-    <div class="turtle" data-include="examples/04.ttl"></div>
+    <div class="turtle" data-include="examples/04.ttl" data-include-format="text"></div>
     <p>
       This declaration identifies the Core profile with the IRI <code>&lt;http://www.w3.org/ns/shacl/profile/core></code> and
       indicates it is an instance of <code>prof:Profile</code>, that it is a profile of the original SHACL publication from
@@ -867,12 +867,12 @@ ex:graph-y {
         If a <em>Shapes Graph</em> <code>SG1</code> is profiling a <em>specification</em> <code>S1</code> then, following
         the characterisation of [[[dx-prof]]]:
       </p>
-      <div class="turtle" data-include="examples/05.ttl"></div>
+      <div class="turtle" data-include="examples/05.ttl" data-include-format="text"></div>
       <p>
         However, <code>SG1</code> is also playing the role of <a href="https://www.w3.org/TR/dx-prof/#Role:validation">Validation</a>,
         so a more complete [[[dx-prof]]] characterisation of the situation would be:
       </p>
-      <div class="turtle" data-include="examples/06.ttl"></div>
+      <div class="turtle" data-include="examples/06.ttl" data-include-format="text"></div>
       <p>
         This is an unexpected use of [[[dx-prof]]], where the profile is also playing a role usually performed by a part of,
         or one of, the resources of the profile, rather than having a single profile resource playing all roles, but it is legitimate,
@@ -883,7 +883,7 @@ ex:graph-y {
         To indicate that a profile resource is using [[[shacl12-core]]] and available in Turtle, the following can also be added to
         the characterisation:
       </p>
-      <div class="turtle" data-include="examples/07.ttl"></div>
+      <div class="turtle" data-include="examples/07.ttl" data-include-format="text"></div>
       <p>
         If <code>SG1</code> is also considered the normative expression of the profile's requirements, as opposed to perhaps a
         separate human language document containing them, then the <code>prof:hasRole</code> value of <code>role:constraints</code>
@@ -895,7 +895,7 @@ ex:graph-y {
         <code>role:specification</code> is specified to "[define] the profile in human-readable form" and while SHACL is
         human-readable, natural language prose is expected.
       </p>
-      <div class="turtle" data-include="examples/08.ttl"></div>
+      <div class="turtle" data-include="examples/08.ttl" data-include-format="text"></div>
       <p class="todo">
         What Use Cases does this reasoning address?
       </p>
@@ -912,19 +912,19 @@ ex:graph-y {
         have been asserted after testing the conformance of the Data Graph to the Shapes Graph by <a data-cite="shacl12-core#dfn-validation">validation</a>
         we can infer that:
       </p>
-      <div class="turtle" data-include="examples/09.ttl"></div>
+      <div class="turtle" data-include="examples/09.ttl" data-include-format="text"></div>
       <p>
         Following the [[[dx-prof]]] axiom of <code>dcterms:conformsTo owl:propertyChainAxiom ( dcterms:conformsTo prof:isProfileOf )</code> then, if given
       </p>
-      <div class="turtle" data-include="examples/10.ttl"></div>
+      <div class="turtle" data-include="examples/10.ttl" data-include-format="text"></div>
       <p>
         and
       </p>
-      <div class="turtle" data-include="examples/11.ttl"></div>
+      <div class="turtle" data-include="examples/11.ttl" data-include-format="text"></div>
       <p>
         we can conclude that
       </p>
-      <div class="turtle" data-include="examples/12.ttl"></div>
+      <div class="turtle" data-include="examples/12.ttl" data-include-format="text"></div>
       <p>
         This reasoning allows for static conformance claims of data to profiles of specifications and specifications
         themselves to be made which will have utility for data whose conformance to these things must be known but which
@@ -1506,7 +1506,7 @@ WHERE {
     <p>
       This profile is defined in the resource <a href="http://www.w3.org/ns/shacl/profile/cd1">http://www.w3.org/ns/shacl/profile/cd1</a>, a portion of which is as follows:
     </p>
-    <div class="turtle" data-include="examples/13.ttl"></div>
+    <div class="turtle" data-include="examples/13.ttl" data-include-format="text"></div>
     <p>
       All the class and property elements of SHACL 1.2 are listed where <code>... many skipped members</code>
       is indicated above except for:

--- a/shacl12-profiling/index.html
+++ b/shacl12-profiling/index.html
@@ -653,18 +653,7 @@ ex:graph-y {
       This recommendation suggests that the creator of a <a>SHACL element</a> SHOULD indicate the group
       within which the <a>SHACL element</a> is defined. An example of such an assertion in RDF is as follows:
     </p>
-    <div class="turtle">
-ex:ont-M
-  a owl:Ontology ;
-ex:ont-M
-  a sh:ShapesGraph ;
-.
-
-ex:shape-1
-  a sh:NodeShape ;
-  rdfs:isDefinedBy ex:ont-M ;
-.
-    </div>
+    <div class="turtle" data-include="examples/01.ttl"></div>
     <p class="note">
       In Section <a data-cite="shacl12-core#syntactic-variations-of-shapes-and-classes">2.5 Syntactic Variations of Shapes and Classes</a> of [[[shacl12-core]]],
       a warning is issued that while <a data-cite="shacl12-core#dfn-property-shape">property shapes</a> may be declared
@@ -689,22 +678,7 @@ ex:shape-1
       An example of the use of the <code>rdfs:member</code> predicate to indicate inclusion of a <a>SHACL element</a> in a group
       that does not define it, as well use of <code>rdfs:isDefinedBy</code>, as in the example above, is as follows:
     </p>
-    <div class="turtle">
-# 'Ontology M' uses a Shape defined by 'Ontology Other'
-ex:ont-M
-  a sh:ShapesGraph ;
-  rdfs:member ex:shape-1 ;
-.
-
-ex:ont-Other
-  a sh:ShapesGraph ;
-.
-
-ex:shape-1
-  a sh:NodeShape ;
-  rdfs:isDefinedBy ex:ont-Other ;
-.
-    </div>
+    <div class="turtle" data-include="examples/02.ttl"></div>
   </section>
   <section id="rec-imports">
     <h3>Indicating group dependence</h3>
@@ -723,16 +697,7 @@ ex:shape-1
     <p>
       An example of <code>owl:imports</code> is as per the example below.
     </p>
-    <div class="turtle">
-# 'Ontology N' imports 'Ontology M'
-ex:ont-M
-  a owl:Ontology ;
-.
-
-ex:ont-N
-  a owl:Ontology ;
-  owl:imports ex:ont-M ;
-.</div>
+    <div class="turtle" data-include="examples/03.ttl"></div>
   </section>
   <section id="dependencies">
     <h3>Calculating Dependencies</h3>
@@ -772,34 +737,7 @@ ex:ont-N
     <p>
       Profiles of SHACL should be declared using [[[dx-prof]]]. The declaration of the Core profile of SHACL 1.2 is as follows:
     </p>
-    <div class="turtle">
-# declaration of the Core profile
-&lt;http://www.w3.org/ns/shacl/profile/core>
-  a prof:Profile ;
-  prof:isProfileOf &lt;https://www.w3.org/TR/shacl/>
-  prof:hasResource
-    &lt;https://www.w3.org/TR/shacl12-core/> ,
-    &lt;http://www.w3.org/ns/shacl-shacl/core> ;
-.
-
-# Core specification
-&lt;https://www.w3.org/TR/shacl12-core/>
-  a prof:ResourceDescriptor ;
-  prof:hasRole role:Specification ;
-  dcterms:format "text/html" ;
-  dcterms:conformsTo &lt;http://www.w3.org/TR/html5/> ;
-  prof:hasArtifact &lt;https://www.w3.org/TR/shacl12-core/> ;
-.
-
-# Core validator
-&lt;http://www.w3.org/ns/shacl-shacl/core>
-  a prof:ResourceDescriptor ;
-  prof:hasRole role:Validation ;
-  dcterms:format "text/turtle" ;
-  dcterms:conformsTo &lt;https://www.w3.org/TR/shacl/> ;
-  prof:hasArtifact &lt;http://www.w3.org/ns/shacl-shacl/core> ;
-.
-    </div>
+    <div class="turtle" data-include="examples/04.ttl"></div>
     <p>
       This declaration identifies the Core profile with the IRI <code>&lt;http://www.w3.org/ns/shacl/profile/core></code> and
       indicates it is an instance of <code>prof:Profile</code>, that it is a profile of the original SHACL publication from
@@ -929,26 +867,12 @@ ex:ont-N
         If a <em>Shapes Graph</em> <code>SG1</code> is profiling a <em>specification</em> <code>S1</code> then, following
         the characterisation of [[[dx-prof]]]:
       </p>
-      <div class="turtle">
-  &lt;SG1>
-    a prof:Profile ;
-    prof:isProfileOf &lt;S1> ;
-  .
-      </div>
+      <div class="turtle" data-include="examples/05.ttl"></div>
       <p>
         However, <code>SG1</code> is also playing the role of <a href="https://www.w3.org/TR/dx-prof/#Role:validation">Validation</a>,
         so a more complete [[[dx-prof]]] characterisation of the situation would be:
       </p>
-      <div class="turtle">
-  &lt;SG1>
-    a prof:Profile ;
-    prof:isProfileOf &lt;S1> ;
-    prof:hasResource [
-      prof:hasArtifact &lt;SG1> ;
-      prof:hasRole role:validation ;
-    ] ;
-  .
-      </div>
+      <div class="turtle" data-include="examples/06.ttl"></div>
       <p>
         This is an unexpected use of [[[dx-prof]]], where the profile is also playing a role usually performed by a part of,
         or one of, the resources of the profile, rather than having a single profile resource playing all roles, but it is legitimate,
@@ -959,18 +883,7 @@ ex:ont-N
         To indicate that a profile resource is using [[[shacl12-core]]] and available in Turtle, the following can also be added to
         the characterisation:
       </p>
-      <div class="turtle">
-  &lt;SG1>
-    a prof:Profile ;
-    prof:isProfileOf &lt;S1> ;
-    prof:hasResource [
-      prof:hasArtifact &lt;S1> ;
-      prof:hasRole role:validation ;
-      dcterms:conformsTo &lt;https://www.w3.org/TR/shacl12-core/> ;
-      dcterms:format "text/turtle" ;
-    ] ;
-  .
-      </div>
+      <div class="turtle" data-include="examples/07.ttl"></div>
       <p>
         If <code>SG1</code> is also considered the normative expression of the profile's requirements, as opposed to perhaps a
         separate human language document containing them, then the <code>prof:hasRole</code> value of <code>role:constraints</code>
@@ -982,21 +895,7 @@ ex:ont-N
         <code>role:specification</code> is specified to "[define] the profile in human-readable form" and while SHACL is
         human-readable, natural language prose is expected.
       </p>
-      <div class="turtle">
-  &lt;SG1>
-    a prof:Profile ;
-    prof:isProfileOf &lt;S1> ;
-    prof:hasResource [
-      prof:hasArtifact &lt;S1> ;
-      prof:hasRole
-        role:constraints ,
-        role:specification ,
-        role:validation ;
-      dcterms:conformsTo &lt;https://www.w3.org/TR/shacl12-core/> ;
-      dcterms:format "text/turtle" ;
-    ] ;
-  .
-      </div>
+      <div class="turtle" data-include="examples/08.ttl"></div>
       <p class="todo">
         What Use Cases does this reasoning address?
       </p>
@@ -1013,27 +912,19 @@ ex:ont-N
         have been asserted after testing the conformance of the Data Graph to the Shapes Graph by <a data-cite="shacl12-core#dfn-validation">validation</a>
         we can infer that:
       </p>
-      <div class="turtle">
-&lt;DG1> dcterms:conformsTo &lt;SG1> .  # via RDFS or OWL-RL reasoning
-      </div>
+      <div class="turtle" data-include="examples/09.ttl"></div>
       <p>
         Following the [[[dx-prof]]] axiom of <code>dcterms:conformsTo owl:propertyChainAxiom ( dcterms:conformsTo prof:isProfileOf )</code> then, if given
       </p>
-      <div class="turtle">
-&lt;DG1> dcterms:conformsTo &lt;SG1> .
-      </div>
+      <div class="turtle" data-include="examples/10.ttl"></div>
       <p>
         and
       </p>
-      <div class="turtle">
-&lt;SG1> prof:isProfileOf &lt;S1> .
-      </div>
+      <div class="turtle" data-include="examples/11.ttl"></div>
       <p>
         we can conclude that
       </p>
-      <div class="turtle">
-&lt;DG1> dcterms:conformsTo &lt;S1> .
-      </div>
+      <div class="turtle" data-include="examples/12.ttl"></div>
       <p>
         This reasoning allows for static conformance claims of data to profiles of specifications and specifications
         themselves to be made which will have utility for data whose conformance to these things must be known but which
@@ -1615,27 +1506,7 @@ WHERE {
     <p>
       This profile is defined in the resource <a href="http://www.w3.org/ns/shacl/profile/cd1">http://www.w3.org/ns/shacl/profile/cd1</a>, a portion of which is as follows:
     </p>
-    <div class="turtle">
-&lt;http://www.w3.org/ns/shacl/profile/cd1>
-  a
-      owl:Ontology ,
-      prof:Profile ;
-  prof:isProfileOf sh: ;
-  rdfs:label "CD1 Profile of SHACL"@en ;
-  rdfs:comment """This is a Profile of SHACL 1.2 that excludes shapes found to
-be computationally intensive.
-
-Vocabulary elements of SHACL that are not listed as members of this profile may
-not be used for implementations claiming conformance to this profile."""@en ;
-  rdfs:member
-    sh:AbstractResult ,
-    sh:AndConstraintComponent ,
-    # ... many skipped members
-    sh:xone ,
-    sh:zeroOrMorePath ,
-    sh:zeroOrOnePath ;
-.
-    </div>
+    <div class="turtle" data-include="examples/13.ttl"></div>
     <p>
       All the class and property elements of SHACL 1.2 are listed where <code>... many skipped members</code>
       is indicated above except for:


### PR DESCRIPTION
Move all the example Turtle in Profiling to external files to allow content syntax validation.

Closes #926 