### PR TITLE
Clarify definition of shapes graph

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2089,12 +2089,18 @@ ex:SomeClass-alternativePathExample
 			<section id="shapes-graph">
 				<h3>Shapes Graph</h3>
 				<p>
-					A <dfn>shapes graph</dfn> is an RDF graph containing zero or more shapes
-					that may be passed into a SHACL <a>validation</a> process so that a <a>data graph</a> can be validated against the shapes.
+					A <dfn>shapes graph</dfn> is an <a>RDF graph</a> in the role of providing <a>shapes</a> and related information
+					to a SHACL <a>validation</a> process so that a <a>data graph</a> can be validated against the shapes.
 				</p>
 				<p>
 					<span data-syntax-rule="ShapesGraph">The <code>sh:ShapesGraph</code> class MAY be used as an <code>rdf:type</code>
-					of the <a>IRI</a> of a graph that is typically used as a <a>shapes graph</a>.</span>
+					of the <a>IRI</a> of a graph that typically acts in the role of a <a>shapes graph</a>.</span>
+				</p>
+				<p>
+					The <a>shapes graph</a> for a given <a>validation</a> may be the result of combining multiple shapes graphs,
+					for example through <code>owl:imports</code> or <code>sh:shapesGraph</code>.
+					However it is constructed, the <a>shapes graph</a> used for validation MUST remain immutable during the <a>validation</a> process.
+					See <a href="#validation-definition"></a> for further details.
 				</p>
 				<p><em>The remainder of this section is non-normative.</em></p>
 				<p>
@@ -2198,7 +2204,7 @@ ex:CompanyShape
 				</aside>
 
 				<p>
-					The resulting graph forms the input <a>shapes graph</a> for validation and MUST NOT be further modified during the validation process.
+					The resulting graph forms the immutable <a>shapes graph</a> for validation.
 				</p>
 				<p class="note">
 					When using <code>owl:versionIRI</code> to import versioned shapes graphs, care should be taken to

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2099,7 +2099,7 @@ ex:SomeClass-alternativePathExample
 				<p>
 					The <a>shapes graph</a> for a given <a>validation</a> may be the result of combining multiple shapes graphs,
 					for example through <code>owl:imports</code> or <code>sh:shapesGraph</code>.
-					However it is constructed, the <a>shapes graph</a> used for validation MUST remain immutable during the <a>validation</a> process.
+					However it is constructed, the <a>shapes graph</a> used for validation MUST remain fixed during the <a>validation</a> process.
 					See <a href="#validation-definition"></a> for further details.
 				</p>
 				<p><em>The remainder of this section is non-normative.</em></p>


### PR DESCRIPTION
Closes #861.

### Motivation

The term "shapes graph" was used throughout the spec in subtly different senses (a reusable module/artifact, an input to a processor, and the fully expanded immutable graph used during validation) without these being explicitly distinguished. This change clarifies the definition without introducing new terminology or requiring changes across many documents.

### Changes

Rewrites the normative definition of "shapes graph" in Core to:

1. **Define it as a role** rather than as an intrinsic property of a graph, consistent with the definition of the new `sh:ShapesGraph`

2. **Explicitly acknowledge the potential for composition**: The final immutable shapes graph for a given validation _may_ result from combining multiple shapes graphs (e.g., via `owl:imports` or `sh:shapesGraph`).

3. **Explicitly acknowledge the validation shapes graph in the definition section**: Regardless of how the shapes graph for validation is constructed, it MUST remain immutable during validation. This was previously only stated normatively in the Validation section; it is now also established at the point of definition for clarity (with a reference to the Validation section for more detail).

Additionally, the non-normative sentence following the `owl:imports` resolution examples is simplified since the normative requirement is now stated in the definition.

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-861/shacl12-core/index.html)
