### PR TITLE
fix typo where `an` should be `a`

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -902,7 +902,7 @@
           a [=rule set=]. Together, these conditions ensure 
           that a [=variable=] in the
           [=head=] of a rule has a value defined in the [=body=] of the rule;
-          that each variable in an [=filter element=]
+          that each variable in a [=filter element=]
           or [=assignment expression=]
           has a value at the point of evaluation; 
           and that each


### PR DESCRIPTION
* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/TallTed-patch-2/shacl12-rules/index.html)
