### PR TITLE
Fix wording in well-formedness definition

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -911,7 +911,7 @@
         </p>
         <p>
           We define <em>well-formedness</em> for a sequence of [=rule elements=]
-          given an initial starting set of variables.  
+          given an initial set of variables.  
         </p>
         <p>
           Let <var>elt<sub>i</sub></var> be the i-th element of a sequence of [=rule elements=].


### PR DESCRIPTION
`initial starting` is redundant

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/TallTed-patch-3/shacl12-rules/index.html)
