### PR TITLE
Issue 897: Remove sh:value from sh:uniqueValuesFor

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5782,10 +5782,6 @@ ex:Zoo
 						Also note that <code>sh:uniqueValuesFor</code> does not prescribe the existence of these values, and is therefore
 						often combined with a <code>sh:minCount 1</code> constraint.
 					</p>
-					<p>
-						Implementations can use <code>sh:detail</code> to provide references to the other nodes
-						that share the same values for the constrained properties.
-					</p>
 					<aside class="example" title="Example of sh:uniqueValuesFor on a single property">
 						<div class="shapes-graph">
 							<div class="turtle">

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5782,6 +5782,10 @@ ex:Zoo
 						Also note that <code>sh:uniqueValuesFor</code> does not prescribe the existence of these values, and is therefore
 						often combined with a <code>sh:minCount 1</code> constraint.
 					</p>
+					<p>
+						Implementations can use <code>sh:detail</code> to provide references to the other nodes
+						that share the same values for the constrained properties.
+					</p>
 					<aside class="example" title="Example of sh:uniqueValuesFor on a single property">
 						<div class="shapes-graph">
 							<div class="turtle">

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5770,9 +5770,9 @@ ex:Zoo
 							If <code>$uniqueValuesFor</code> is a <a>SHACL list</a>, then <code>$properties</code> is the set of the <a>members</a> of that list.
 							Let <code>$targetNodes</code> be the <a>target</a> nodes of <code>S</code>.
 							<br />
-							For each <a>value node</a> <code>V</code> for which there exists another <a>node</a> <code>Other</code> in <code>$targetNodes</code>
+							For each <a>value node</a> <code>V</code> for which there exists another <a>node</a> in <code>$targetNodes</code>
 							that has exactly the same <a>values</a> for all properties in <code>$properties</code> as <code>V</code>
-							there is a <a>validation result</a> with <code>Other</code> as <code>sh:value</code>.
+							there is a <a>validation result</a>.
 							No result is produced if <code>V</code> has no <a>values</a> for any of the properties in <code>$properties</code>.
 						</div>
 					</div>

--- a/shacl12-test-suite/tests/core/node/manifest.ttl
+++ b/shacl12-test-suite/tests/core/node/manifest.ttl
@@ -47,6 +47,7 @@
 	mf:include <uniqueValuesFor-002.ttl> ;
 	mf:include <uniqueValuesFor-003.ttl> ;
 	mf:include <uniqueValuesFor-004.ttl> ;
+	mf:include <uniqueValuesFor-005.ttl> ;
 	mf:include <xone-001.ttl> ;
 	mf:include <xone-duplicate.ttl> ;
 	mf:include <qualified-001.ttl> ;

--- a/shacl12-test-suite/tests/core/node/uniqueValuesFor-001.ttl
+++ b/shacl12-test-suite/tests/core/node/uniqueValuesFor-001.ttl
@@ -52,7 +52,6 @@ ex:InvalidInstance2
           sh:resultSeverity sh:Violation ;
           sh:sourceConstraintComponent sh:UniqueValuesForConstraintComponent ;
           sh:sourceShape ex:TestShape ;
-          sh:value ex:InvalidInstance2 ;
         ] ;
       sh:result [
           rdf:type sh:ValidationResult ;
@@ -60,7 +59,6 @@ ex:InvalidInstance2
           sh:resultSeverity sh:Violation ;
           sh:sourceConstraintComponent sh:UniqueValuesForConstraintComponent ;
           sh:sourceShape ex:TestShape ;
-          sh:value ex:InvalidInstance1 ;
         ] ;
     ] ;
   mf:status sht:approved ;

--- a/shacl12-test-suite/tests/core/node/uniqueValuesFor-002.ttl
+++ b/shacl12-test-suite/tests/core/node/uniqueValuesFor-002.ttl
@@ -54,7 +54,6 @@ ex:InvalidInstance2
           sh:resultSeverity sh:Violation ;
           sh:sourceConstraintComponent sh:UniqueValuesForConstraintComponent ;
           sh:sourceShape ex:TestShape ;
-          sh:value ex:InvalidInstance2 ;
         ] ;
       sh:result [
           rdf:type sh:ValidationResult ;
@@ -62,7 +61,6 @@ ex:InvalidInstance2
           sh:resultSeverity sh:Violation ;
           sh:sourceConstraintComponent sh:UniqueValuesForConstraintComponent ;
           sh:sourceShape ex:TestShape ;
-          sh:value ex:InvalidInstance1 ;
         ] ;
     ] ;
   mf:status sht:approved ;

--- a/shacl12-test-suite/tests/core/node/uniqueValuesFor-005.ttl
+++ b/shacl12-test-suite/tests/core/node/uniqueValuesFor-005.ttl
@@ -8,30 +8,30 @@
 
 ex:TestShape
   rdf:type sh:NodeShape ;
-  sh:targetSubjectsOf ex:id ;
+  sh:targetClass ex:TestShape ;
   sh:uniqueValuesFor ex:id ;
 .
-ex:ValidInstance1
-  ex:id "001" ;
-.
-ex:ValidInstance2
-  ex:id "002" ;
-.
 ex:InvalidInstance1
+  rdf:type ex:TestShape ;
   ex:id "DUP" ;
 .
 ex:InvalidInstance2
+  rdf:type ex:TestShape ;
+  ex:id "DUP" ;
+.
+ex:InvalidInstance3
+  rdf:type ex:TestShape ;
   ex:id "DUP" ;
 .
 <>
   rdf:type mf:Manifest ;
   mf:entries (
-      <uniqueValuesFor-003>
+      <uniqueValuesFor-005>
     ) ;
 .
-<uniqueValuesFor-003>
+<uniqueValuesFor-005>
   rdf:type sht:Validate ;
-  rdfs:label "Test of sh:uniqueValuesFor at node shape 003 (targetSubjectsOf, global uniqueness)" ;
+  rdfs:label "Test of sh:uniqueValuesFor at node shape 005 (three instances sharing the same value)" ;
   mf:action [
       sht:dataGraph <> ;
       sht:shapesGraph <> ;
@@ -49,6 +49,13 @@ ex:InvalidInstance2
       sh:result [
           rdf:type sh:ValidationResult ;
           sh:focusNode ex:InvalidInstance2 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:UniqueValuesForConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance3 ;
           sh:resultSeverity sh:Violation ;
           sh:sourceConstraintComponent sh:UniqueValuesForConstraintComponent ;
           sh:sourceShape ex:TestShape ;


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #897 
* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/{BRANCH_NAME}/{FOLDER}/index.html)

This PR contains two commits:                                                                                                                    
                                                                                                                                                   
  1. Remove `sh:value` from `sh:uniqueValuesFor` validation results and add a test for three nodes sharing the same values.                            
  2. Add a non-normative note that `sh:detail` can be used to provide references to the other duplicate nodes.                                       
                                                                                                                                                   
  Please leave a comment if the second commit should be dropped.  
