### PR TITLE
#975: Switched sh:memberShape syntax prose to plural

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -3793,7 +3793,7 @@ ex:Alice
 								<td><code>sh:memberShape</code></td>
 								<td>
 									The shape that all members of the <a href="#syntax-rule-SHACL-list">SHACL list</a> must conform to.
-									<span data-syntax-rule="memberShape-node">The value of <code>sh:memberShape</code> must be a <a>well-formed</a> <a>node shape</a>.</span>
+									<span data-syntax-rule="memberShape-node">The values of <code>sh:memberShape</code> must be <a>well-formed</a> <a>node shapes</a>.</span>
 								</td>
 							</tr>
 						</tbody>


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #975

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-975/shacl12-core/index.html)
