### PR TITLE
#954 and #962: Added example for sh:deactivated and srl:text

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -253,6 +253,10 @@
             <td><code>http://www.w3.org/2000/01/rdf-schema#</code></td>
           </tr>
           <tr>
+            <td><code>sh:</code></td>
+            <td><code>http://www.w3.org/ns/shacl#</code></td>
+          </tr>
+          <tr>
             <td><code>srl:</code></td>
             <td><code>http://www.w3.org/ns/shacl-rules#</code></td>
           </tr>
@@ -1765,7 +1769,31 @@ PREFIX srl:    &lt;http://www.w3.org/ns/shacl-rules#&gt;
         [ srl:subject [ srl:varName "x" ] ; srl:predicate :q ; srl:object [ srl:varName "o" ] ; ]
       )
     ]
+    :ExampleDeactivatedRuleWithURLAndTextSyntax
   ) .
+
+:ExampleDeactivatedRuleWithURIAndTextSyntax
+  rdf:type srl:Rule ;
+  rdfs:label "Example deactivated rule" ;
+  rdfs:comment "This rule illustrates the alternative srl:text syntax." ;
+  sh:deactivated true ;
+  sh:prefixes :Graph ;   # Triple is optional because :Graph is a sh:ShapesGraph
+  srl:text """
+    RULE {
+      ?x :q :o 
+    } 
+    WHERE {
+      ?x :p ?o .
+      FILTER (?o &gt;= 18) 
+    }
+  """ .
+
+:Graph
+  rdf:type sh:ShapesGraph ;
+  sh:declare [
+    sh:prefix "" ;
+    sh:namespace "http://example/" ;
+  ] .
 
 </pre>
 

--- a/shacl12-rules/rules-rdf-syntax/rdf-syntax-shapes.ttl
+++ b/shacl12-rules/rules-rdf-syntax/rdf-syntax-shapes.ttl
@@ -219,11 +219,35 @@ srl-sh:ruleBodyShape rdf:type sh:NodeShape ;
         sh:maxCount 1;
         sh:minCount 1;
       ] .
+      
+srl-sh:ruleTextShape rdf:type sh:NodeShape ;
+    sh:property
+      [ sh:path sh:prefixes ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+      ] ;
+    sh:property
+      [ sh:path srl:text ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1;
+        sh:minCount 1;
+      ] .
+      
+srl-sh:ruleDeactivatedShape rdf:type sh:NodeShape ;
+    sh:property
+      [ sh:path sh:deactivated ;
+        sh:datatype xsd:boolean ;
+        sh:maxCount 1;
+      ] .
     
 srl-sh:ruleShape rdf:type sh:NodeShape ;
-    sh:node srl-sh:ruleHeadShape ;
-    sh:node srl-sh:ruleBodyShape ;
-    .
+    sh:xone (
+      [
+        sh:node srl-sh:ruleHeadShape ;
+        sh:node srl-sh:ruleBodyShape ;
+      ]
+      srl-sh:ruleTextShape
+    ) ;
+    sh:node srl-sh:ruleDeactivatedShape .
 
 #### Rule Set
 

--- a/shacl12-rules/rules-rdf-syntax/rdf-syntax-vocab.ttl
+++ b/shacl12-rules/rules-rdf-syntax/rdf-syntax-vocab.ttl
@@ -61,6 +61,13 @@ srl:body rdf:type rdf:Property ;
     rdfs:isDefinedBy <https://www.w3.org/TR/shacl12-rules/#dfn-rule-body> ;
     rdfs:label "Rule body" ;
     rdfs:comment "The antecedent of a rule." .
+    
+srl:text rdf:type rdf:Property ;
+    rdfs:domain srl:Rule ;
+    rdfs:range xsd:string ;
+    rdfs:isDefinedBy srl: ;
+    rdfs:label "Rule text" ;
+    rdfs:comment "The text of a rule in Shape Rules Language syntax." .
 
 ## -- Rule Body
 


### PR DESCRIPTION
This PR replaces https://github.com/w3c/data-shapes/pull/977 with better base branch

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-954-962/shacl12-rules/index.html#rdf-rules-syntax)
