### PR TITLE
Editorial: clarify that sh:order may have semantics elsewhere

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -6129,11 +6129,15 @@ ex:Fridge-price
 					Property shapes may have one <a>value</a> for the property <code>sh:order</code>
 					to indicate the relative order of the property shape for purposes such as form building.
 					The values of <code>sh:order</code> are <a>literals</a> with <a>datatype</a> <code>xsd:decimal</code> or <code>xsd:integer</code>.
-					<code>sh:order</code> is not used for validation purposes
-					and may be used with any type of subjects.
+					<code>sh:order</code> is not used for validation purposes.
 					If present at property shapes, the recommended use of <code>sh:order</code> is to sort the
-					property shapes in an ascending order, for example so that properties with smaller order are
+					property shapes in an ascending order in user interfaces, for example so that properties with smaller order are
 					placed above or to the start (left in left-to-right languages) of properties with larger order.
+				</p>
+				<p class="note">
+					<code>sh:order</code> provides a general mechanism to specify the relative order of elements in a list.
+					Although <code>sh:order</code> does not impact SHACL validation, it may be used with any type of
+					subjects and carry stronger semantics in other specifications.
 				</p>
 			</section>
 			<section id="group">


### PR DESCRIPTION
This is in response to https://github.com/w3c/data-shapes/issues/766#issuecomment-4387494964
