### PR TITLE
Syntax differences between SRL and SPARQL Query

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -695,52 +695,6 @@
         </p>
       </section>
       
-      <section id="rules-sparql-relationship" class="informative">
-        <h3>Relationship between SHACL Rules and SPARQL</h3>
-        <p>
-          SHACL Rules and SPARQL have a close relationship. SHACL Rules are designed to be compatible
-          with SPARQL, and many of the constructs in SHACL Rules are inspired by SPARQL.
-          However, there are some differences:
-        </p>  
-        <ul>
-          <li>
-            Rules have additional well-formedness conditions that ensure
-            variables are always bound before use.
-          </li>
-          <li>
-            A rule body is similar to a SPARQL `CONSTRUCT` query, 
-            but has restrictions such as not having `OPTIONAL`.  
-            These ensure that variables are always bound, whereas in SPARQL, some
-            variables might not be bound in all pattern solutions.
-          </li>
-          <li>
-            The rule `SET` form and SPARQL `BIND` form have different error handling behaviors. An
-            error encountered in `SET` causes the current solution to be filtered out, whereas 
-            `BIND` does not set the variable in the current solution.
-            <code>SET(?var := <i>expr</i>)</code> would be the same as
-            SPARQL with 
-            <code>BIND(<i>expr</i> AS ?var)</code> followed by 
-            <code>FILTER(BOUND(?var))</code>.
-          </li>
-          <li>
-            Rules `NOT`, unlike SPARQL `EXISTS` and `NOT EXISTS`, has a body restricted to
-            triple patterns and filters. It does not allow nested patterns.
-          <li>
-            Property path syntax only covers paths that can be expanded into triple patterns.
-            It does not allow arbitrary length operators `*` and `+`.
-          </li>
-          <li>
-            Some functions are not included in the SRL syntax.
-            There is no `COALESCE`, nor `BOUND`.
-            There are no hash functions. 
-            There is no `RAND`, which has different results each time
-            it is called; `NOW()` is permitted and is defined to return
-            the same point in time throughout a rule set evaluation, similar
-            to the behavior in SPARQL.
-          </li>
-        </ul> 
-      </section>
-
       <section id="ground-data">
         <h3>Matching Ground Data</h3>
         <div class="issue" data-number="960">
@@ -835,6 +789,58 @@
           <p>
             <a href="https://github.com/w3c/data-shapes/issues/1074">Full proposal</a>
           </p>
+      </section>
+
+      <section id="rules-sparql-relationship" class="informative">
+        <h3>Relationship between SHACL Rules and SPARQL</h3>
+        <p>
+          SHACL Rules and SPARQL have a close relationship. SHACL Rules are designed to be compatible
+          with SPARQL, and many of the constructs in SHACL Rules are inspired by SPARQL.
+          However, there are some differences:
+        </p>  
+        <ul>
+          <li>
+            Rules have additional well-formedness conditions that ensure
+            variables are always bound before use.
+          </li>
+          <li>
+            The syntax of a rule body is similar to a SPARQL `CONSTRUCT` query, but has
+            restrictions such as not having `UNION` or `OPTIONAL` syntax.
+            These ensure that variables are always bound, whereas in SPARQL, some
+            variables might not be bound in all pattern solutions.
+            The effect of these can be achieved using [=well-formed rules=]
+            so that the [=rule set=] can be analysed.
+          </li>
+          <li>
+            The rule `SET` form and SPARQL `BIND` form have different error handling behaviors.
+            An error encountered in `SET` causes the current solution to be filtered out, 
+            whereas `BIND` does not set the variable in the current solution.
+            <code>SET(?var := <i>expr</i>)</code> would be the same as
+            SPARQL with 
+            <code>BIND(<i>expr</i> AS ?var)</code> followed by 
+            <code>FILTER(BOUND(?var))</code>.
+          </li>
+          <li>
+            The syntax of `NOT`,
+            unlike SPARQL `EXISTS` and `NOT EXISTS`
+            has an inner body limited to triple patterns and filters,
+            and does not allow nested patterns.
+          <li>
+            Property path syntax only covers paths that can be expanded into triple patterns.
+            It does not allow arbitrary length operators `*` and `+`.
+            Arbitrary length paths can be expressed in SHACL Rules 
+            with recursion as a more general approach.
+          </li>
+          <li>
+            Some functions are not included in the SRL syntax.
+            There is no `COALESCE`, nor `BOUND`.
+            There are no hash functions. 
+            There is no `RAND`, which has different results each time
+            it is called. `NOW()` is permitted and is defined to return
+            the same point in time throughout a rule set evaluation, similar
+            to the behavior in SPARQL.
+          </li>
+        </ul> 
       </section>
 
     </section>


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/srl-syntax/shacl12-rules/index.html)
