### PR TITLE
Fix wording and punctuation in rules-sparql-relationship

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -806,7 +806,7 @@
           <li>
             The syntax of a rule body is similar to a SPARQL `CONSTRUCT` query, but has
             restrictions such as not having `UNION` or `OPTIONAL` syntax.
-            These ensure that variables are always bound, whereas in SPARQL, some
+            These restrictions ensure that variables are always bound, whereas in SPARQL, some
             variables might not be bound in all pattern solutions.
             The effect of these can be achieved using [=well-formed rules=]
             so that the [=rule set=] can be analysed.
@@ -822,8 +822,8 @@
           </li>
           <li>
             The syntax of `NOT`,
-            unlike SPARQL `EXISTS` and `NOT EXISTS`
-            has an inner body limited to triple patterns and filters,
+            unlike SPARQL `EXISTS` and `NOT EXISTS`,
+            limits the inner body to triple patterns and filters,
             and does not allow nested patterns.
           <li>
             Property path syntax only covers paths that can be expanded into triple patterns.


### PR DESCRIPTION
No issue. Applies to text inserted in #1084.

Changes are very simple, so I have not taken the time to puzzle out a preview link.