### PR TITLE
#176: Generalized to any known subclass of owl:Ontology (including owl:Ontology itself)

### DIFF
--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -512,7 +512,8 @@ ex:
 			</p>
 			<p id="no-prefixes">
 				If a SPARQL query has no <a>value</a> for <code>sh:prefixes</code> then the system will use those <a>prefix declarations</a>
-				from the <a>shapes graph</a> that are <a>values</a> of <code>sh:declare</code> at a <a>SHACL instance</a> of <code>sh:ShapesGraph</code>
+				from the <a>shapes graph</a> that are <a>values</a> of <code>sh:declare</code> at a <a>SHACL instance</a> of
+				<code>owl:Ontology</code>, <code>sh:DataGraph</code>, <code>sh:ShapesGraph</code>,
 				or <code>sh:RulesGraph</code> (which is a subclass of <code>sh:ShapesGraph</code>).
 			</p>
 			<p>


### PR DESCRIPTION
Closes #176

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-176-2/shacl12-sparql/index.html#sparql-prefixes)

Motivation: https://github.com/w3c/data-shapes/issues/176#issuecomment-5100445051

Does anyone see problems with these changes?