### PR TITLE
#996: Clarified that individual rule failures are propagated into the engine

### DIFF
--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2231,6 +2231,10 @@ ex:Granddaughter
 					</pre>
 				</div>
 				<p>
+					If any of the <a>rules</a> reports a <a>failure</a> during <a>execution</a>,
+					then the <a>execution of a rule set</a> also produces a <a>failure</a>.
+				</p>
+				<p>
 					If a <a>rules engine</a> is not able to execute a given <a>rule</a>
 					because it does not support any of the <a>rule types</a> of the <a>rule</a>,
 					then it reports a <a>failure</a>.

--- a/shacl12-test-suite/tests/sparql/node/prefixes-002.ttl
+++ b/shacl12-test-suite/tests/sparql/node/prefixes-002.ttl
@@ -18,8 +18,8 @@ ex:UnusedPrefixDeclaration
   sh:namespace "http://example.com/ns2#" ;
   sh:prefix "ex" ;
 .
-ex:SomeOntology
-  rdf:type owl:Ontology ;
+ex:SomeNonOntology
+  rdf:type rdfs:Resource ;
   sh:declare ex:UnusedPrefixDeclaration ;
 .
 ex:InvalidResource1


### PR DESCRIPTION
Closes #996

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-996/shacl12-sparql/index.html#rules-execution)
