### PR TITLE
#995: Added support for sh:tempTriple

### DIFF
--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2196,7 +2196,7 @@ ex:Granddaughter
 				<p>
 					It is sometimes useful for inference rules to produce triples that are only visible during the execution
 					of other rules but do not end up in the final inferences.
-					A <dfn>temporary triple</dfn> is an inferred <a>triple</a> for which the inferences graph contains a
+					A <dfn>temporary triple</dfn> is an inferred <a>triple</a> for which the inference graph contains a
 					<a>reifier</a> with the <a>value</a> <code>sh:tempTriple true</code>.
 					Rules can produce such triples as illustrated in the following example:
 				</p>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2191,67 +2191,6 @@ ex:Granddaughter
 					<a href="#rules-execution">rules execution instructions</a> prior to performing the actual validation. 
 				</p>
 			</section>
-			<section id="rules-execution">
-				<h3>General Execution Instructions for SHACL Rules</h3>
-				<p>
-					A <dfn data-lt="rules engine">SHACL rules engine</dfn> is a computer procedure that takes as input
-					a <a>data graph</a> and a <a>shapes graph</a> and is capable of adding <a>triples</a> to the <a>data graph</a>.
-					The new <a>triples</a> that are produced by a rules engine are called the <dfn data-lt="inferring|infer">inferred</dfn> triples.
-				</p>
-				<p>
-					Note that, from a logical perspective, the <a>data graph</a> will be <em>modified</em> if <a>triples</a> get inferred.
-					This means that rules can trigger after other triples have been inferred.
-					However, in cases where the original data should not be modified, implementations may construct a logical <a>data graph</a>
-					that has the original data as one subgraph and a dedicated inferences graph as another subgraph, and where
-					the inferred triples get added to the inferences graph only.
-				</p>
-				<p>
-					An <dfn>execution</dfn> of a <a>rule</a> is the process that produces <a>inferred</a> triples from the <a>rule</a>
-					based on the <a>execution instructions</a> of its <a>rule types</a>.
-					If the <a>rule</a> is a <a>shape rule</a> (i.e., it is linked to at least one <a>shape</a> via <code>sh:rule</code>),
-					then the rule is executed for each <a>target node</a> of each of the linked and <a data-cite="shacl12-core#deactivated">non-deactivated</a>
-					<a>shapes</a> that <a>conform</a> to all <a data-cite="shacl12-core#deactivated">non-deactivated</a> <a href="#condition">conditions</a> of the <a>rule</a>.
-					These <a>target nodes</a> become the <a>focus nodes</a> of the executing <a>shape rule</a>.
-				</p>
-				<p>
-					For a given set of <a>rules</a> in the <a>shapes graph</a>
-					an <dfn data-lt="iterate">iteration</dfn> is a single <a>execution</a> of each individual rule in the order as
-					specified by <a href="#rule-order"></a>, skipping the rules that are <a href="#deactivated-rules">deactivated</a>.
-					Within an iteration, the inferred triples of one rule become immediately visible to the next rule.
-				</p>
-				<p>
-					The <dfn>execution of a rule set</dfn> is defined as follows:
-				</p>
-				<div class="algorithm">
-					<pre class="text">
-						For all <a>layers</a> in the rule set (in ascending order):
-							Execute one <a>iteration</a> over all <a>run-once rules</a> in the layer
-							do
-								Execute one <a>iteration</a> over all <a>iterating rules</a> in the layer
-							while the iteration has produced newly inferred triples
-
-						Delete the <a>temporary triples</a> and their <a>reifiers</a>
-					</pre>
-				</div>
-				<p>
-					If any of the <a>rules</a> reports a <a>failure</a> during <a>execution</a>,
-					then the <a>execution of a rule set</a> also produces a <a>failure</a>.
-				</p>
-				<p>
-					If a <a>rules engine</a> is not able to execute a given <a>rule</a>
-					because it does not support any of the <a>rule types</a> of the <a>rule</a>,
-					then it reports a <a>failure</a>.
-				</p>
-				<p>
-					Rule engines MAY also report a failure after a pre-configured maximum iteration count has been exceeded or
-					a pre-configured maximum number of inferred triples has been produced.
-					This can help as a guard to avoid out-of-memory problems and infinite loops.
-				</p>
-				<p>
-					At no time are inferred triples visible to the <a>shapes graph</a>, i.e. it is impossible for rules
-					to modify the definitions of rules or shapes.
-				</p>
-			</section>
 			<section id="tempTriple">
 				<h3>Temporary Triples</h3>
 				<p>
@@ -2314,12 +2253,75 @@ ex:SetYoungestOffspringsRule
 						of each Person.
 						The final inferences only include the <code>ex:youngestOffspring</code> triples.
 					</p>
-					<p>
-						Note the example is for illustration purposes only.
-						The same result could be achieved with a single rule that does everything in one go.
-Creating temporary triples can be helpful when a computation is too complex to be carried out by a single rule. The complex computation can then be decomposed into _multiple_ rules: some rules infer _partial_ results, from which other rules derive the _final_ results. The partial results are only functional to the computation of the final results and are no longer needed once the latter have been obtained. By marking these partial results as temporary triples, they can be automatically removed after the final results have been computed.
-					</p>
 				</aside>
+				<p>
+					Creating temporary triples can be helpful when a computation is too complex to be carried out by a single rule.
+					The complex computation can then be decomposed into <em>multiple</em> rules:
+					some rules infer <em>partial</em> results, from which other rules derive the <em>final</em> results.
+					The partial results are only functional to the computation of the final results and are no longer needed once the latter have been obtained.
+					By marking these partial results as temporary triples, they can be automatically removed after the final results have been computed.
+				</p>
+			</section>
+			<section id="rules-execution">
+				<h3>General Execution Instructions for SHACL Rules</h3>
+				<p>
+					A <dfn data-lt="rules engine">SHACL rules engine</dfn> is a computer procedure that takes as input
+					a <a>data graph</a> and a <a>shapes graph</a> and is capable of adding <a>triples</a> to the <a>data graph</a>.
+					The new <a>triples</a> that are produced by a rules engine are called the <dfn data-lt="inferring|infer">inferred</dfn> triples.
+				</p>
+				<p>
+					Note that, from a logical perspective, the <a>data graph</a> will be <em>modified</em> if <a>triples</a> get inferred.
+					This means that rules can trigger after other triples have been inferred.
+					However, in cases where the original data should not be modified, implementations may construct a logical <a>data graph</a>
+					that has the original data as one subgraph and a dedicated inferences graph as another subgraph, and where
+					the inferred triples get added to the inferences graph only.
+				</p>
+				<p>
+					An <dfn>execution</dfn> of a <a>rule</a> is the process that produces <a>inferred</a> triples from the <a>rule</a>
+					based on the <a>execution instructions</a> of its <a>rule types</a>.
+					If the <a>rule</a> is a <a>shape rule</a> (i.e., it is linked to at least one <a>shape</a> via <code>sh:rule</code>),
+					then the rule is executed for each <a>target node</a> of each of the linked and <a data-cite="shacl12-core#deactivated">non-deactivated</a>
+					<a>shapes</a> that <a>conform</a> to all <a data-cite="shacl12-core#deactivated">non-deactivated</a> <a href="#condition">conditions</a> of the <a>rule</a>.
+					These <a>target nodes</a> become the <a>focus nodes</a> of the executing <a>shape rule</a>.
+				</p>
+				<p>
+					For a given set of <a>rules</a> in the <a>shapes graph</a>
+					an <dfn data-lt="iterate">iteration</dfn> is a single <a>execution</a> of each individual rule in the order as
+					specified by <a href="#rule-order"></a>, skipping the rules that are <a href="#deactivated-rules">deactivated</a>.
+					Within an iteration, the inferred triples of one rule become immediately visible to the next rule.
+				</p>
+				<p>
+					The <dfn>execution of a rule set</dfn> is defined as follows:
+				</p>
+				<div class="algorithm">
+					<pre class="text">
+						For all <a>layers</a> in the rule set (in ascending order):
+							Execute one <a>iteration</a> over all <a>run-once rules</a> in the layer
+							do
+								Execute one <a>iteration</a> over all <a>iterating rules</a> in the layer
+							while the iteration has produced newly inferred triples
+
+						Delete the <a>temporary triples</a> and their <a>reifiers</a>
+					</pre>
+				</div>
+				<p>
+					If any of the <a>rules</a> reports a <a>failure</a> during <a>execution</a>,
+					then the <a>execution of a rule set</a> also produces a <a>failure</a>.
+				</p>
+				<p>
+					If a <a>rules engine</a> is not able to execute a given <a>rule</a>
+					because it does not support any of the <a>rule types</a> of the <a>rule</a>,
+					then it reports a <a>failure</a>.
+				</p>
+				<p>
+					Rule engines MAY also report a failure after a pre-configured maximum iteration count has been exceeded or
+					a pre-configured maximum number of inferred triples has been produced.
+					This can help as a guard to avoid out-of-memory problems and infinite loops.
+				</p>
+				<p>
+					At no time are inferred triples visible to the <a>shapes graph</a>, i.e. it is impossible for rules
+					to modify the definitions of rules or shapes.
+				</p>
 			</section>
 			<section id="sourceRule">
 				<h3>Tracking the Rule that has produced a Triple (sh:sourceRule)</h3>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2310,7 +2310,7 @@ ex:SetYoungestOffspringsRule
 					<p>
 						The first rule computes <code>ex:offspring</code> triples as the (transitive)
 						children of each Person.
-						The second rule uses the <code>ex:offspring</code> triples to infer the <code>ex:oldestOffspring</code>
+						The second rule uses the <code>ex:offspring</code> triples to infer the <code>ex:youngestOffspring</code>
 						of each Person.
 						The final inferences only include the <code>ex:youngestOffspring</code> triples.
 					</p>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2198,6 +2198,7 @@ ex:Granddaughter
 					of other rules but do not end up in the final inferences.
 					A <dfn>temporary triple</dfn> is an inferred <a>triple</a> for which the inference graph contains a
 					<a>reifier</a> with the <a>value</a> <code>sh:tempTriple true</code>.
+					<a>Temporary triples</a> and their <a>reifiers</a> are visible to executing rules.
 					Rules can produce such triples as illustrated in the following example:
 				</p>
 				<aside class="example" title="An example rule that produces temporary triples" id="tempTriple-example">

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2229,6 +2229,8 @@ ex:Granddaughter
 							do
 								Execute one <a>iteration</a> over all <a>iterating rules</a> in the layer
 							while the iteration has produced newly inferred triples
+
+						Delete the <a>temporary triples</a> and their <a>reifiers</a>
 					</pre>
 				</div>
 				<p>
@@ -2249,6 +2251,76 @@ ex:Granddaughter
 					At no time are inferred triples visible to the <a>shapes graph</a>, i.e. it is impossible for rules
 					to modify the definitions of rules or shapes.
 				</p>
+			</section>
+			<section id="tempTriple">
+				<h3>Temporary Triples</h3>
+				<p>
+					It is sometimes useful for inference rules to produce triples that are only visible during the execution
+					of other rules but do not end up in the final inferences.
+					A <dfn>temporary triple</dfn> is an inferred <a>triple</a> for which the inferences graph contains a
+					<a>reifier</a> with the <a>value</a> <code>sh:tempTriple true</code>.
+					Rules can produce such triples as illustrated in the following example:
+				</p>
+				<aside class="example" title="An example rule that produces temporary triples" id="tempTriple-example">
+					<div class="shapes-graph">
+						<div class="turtle">
+ex:Person
+	a sh:ShapeClass ;
+	sh:rule ex:CollectOffspringsRule ;
+	sh:rule ex:SetYoungestOffspringsRule .
+
+ex:CollectOffspringsRule
+	a sh:SPARQLRule ;
+	sh:layer 0 ;
+	sh:runOnce true ;
+	sh:construct """
+		CONSTRUCT {
+			$this ex:offspring ?offspring .
+			?reifier sh:tempTriple true .
+			?reifier rdf:reifies ?tt .
+		}
+		WHERE {
+			$this ex:child+ ?offspring .
+			BIND (BNODE() AS ?reifier) .
+			BIND (TRIPLE($this, ex:offspring, ?offspring) AS ?tt) .
+		}
+	""" .
+
+ex:SetYoungestOffspringsRule
+	a sh:SPARQLRule ;
+	sh:layer 1 ;
+	sh:construct """
+		CONSTRUCT {
+			$this ex:youngestOffspring ?o .
+		}
+		WHERE {
+			{
+				SELECT $this ?o
+				WHERE {
+					$this ex:offspring ?o .
+					?o ex:age ?age .
+				}
+				ORDER BY ?age
+				LIMIT 1
+			}
+		}
+	""" .
+						</div>
+					</div>
+					<p>
+						The first rule computes <code>ex:offspring</code> triples as the (transitive)
+						children of each Person.
+						The second rule uses the <code>ex:offspring</code> triples to infer the <code>ex:oldestOffspring</code>
+						of each Person.
+						The final inferences only include the <code>ex:oldestOffspring</code> triples.
+					</p>
+					<p>
+						Note the example is for illustration purposes only.
+						The same result could be achieved with a single rule that does everything in one go.
+						Creating temporary triples can be helpful if it avoids repetitive computations that are
+						needed by multiple rules down the road.
+					</p>
+				</aside>
 			</section>
 			<section id="sourceRule">
 				<h3>Tracking the Rule that has produced a Triple (sh:sourceRule)</h3>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2257,7 +2257,7 @@ ex:SetYoungestOffspringsRule
 					The complex computation can then be decomposed into <em>multiple</em> rules:
 					some rules infer <em>partial</em> results, from which other rules derive the <em>final</em> results.
 					The partial results are only functional to the computation of the final results and are no longer needed once the latter have been obtained.
-					By marking these partial results as temporary triples, they can be automatically removed after the final results have been computed.
+					By marking these partial results as temporary triples, they are automatically removed after the final results have been computed.
 				</p>
 			</section>
 			<section id="rules-execution">

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2312,7 +2312,7 @@ ex:SetYoungestOffspringsRule
 						children of each Person.
 						The second rule uses the <code>ex:offspring</code> triples to infer the <code>ex:oldestOffspring</code>
 						of each Person.
-						The final inferences only include the <code>ex:oldestOffspring</code> triples.
+						The final inferences only include the <code>ex:youngestOffspring</code> triples.
 					</p>
 					<p>
 						Note the example is for illustration purposes only.

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2214,14 +2214,10 @@ ex:CollectOffspringsRule
 	sh:runOnce true ;
 	sh:construct """
 		CONSTRUCT {
-			$this ex:offspring ?offspring .
-			?reifier sh:tempTriple true .
-			?reifier rdf:reifies ?tt .
+			$this ex:offspring ?offspring {| sh:tempTriple true |} .
 		}
 		WHERE {
 			$this ex:child+ ?offspring .
-			BIND (BNODE() AS ?reifier) .
-			BIND (TRIPLE($this, ex:offspring, ?offspring) AS ?tt) .
 		}
 	""" .
 

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2317,8 +2317,7 @@ ex:SetYoungestOffspringsRule
 					<p>
 						Note the example is for illustration purposes only.
 						The same result could be achieved with a single rule that does everything in one go.
-						Creating temporary triples can be helpful if it avoids repetitive computations that are
-						needed by multiple rules down the road.
+Creating temporary triples can be helpful when a computation is too complex to be carried out by a single rule. The complex computation can then be decomposed into _multiple_ rules: some rules infer _partial_ results, from which other rules derive the _final_ results. The partial results are only functional to the computation of the final results and are no longer needed once the latter have been obtained. By marking these partial results as temporary triples, they can be automatically removed after the final results have been computed.
 					</p>
 				</aside>
 			</section>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2252,6 +2252,8 @@ ex:SetYoungestOffspringsRule
 						The second rule uses the <code>ex:offspring</code> triples to infer the <code>ex:youngestOffspring</code>
 						of each Person.
 						The final inferences only include the <code>ex:youngestOffspring</code> triples.
+						All temporary triples, i.e., triples whose reifier is marked with <code>sh:tempTriple true</code>,
+						are automatically deleted by the SHACL engine at the end of the inference process.
 					</p>
 				</aside>
 				<p>

--- a/shacl12-test-suite/tests/sparql/rules/manifest.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/manifest.ttl
@@ -12,5 +12,6 @@
 	mf:include <rectangle-prefixes.ttl> ;
 	mf:include <rectangle-simple.ttl> ;
 	mf:include <run-once-example.ttl> ;
+	mf:include <temp-triples-example.ttl> ;
 	mf:include <rdfs/manifest.ttl> ;
 	.

--- a/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
@@ -1,0 +1,106 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# This example also appears in the SHACL 1.2 SPARQL spec
+
+ex:
+  a sh:ShapesGraph ;
+  sh:declare [
+      sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#" ;
+      sh:prefix "rdf" ;
+  ] ;
+  sh:declare [
+      sh:namespace "http://www.w3.org/ns/shacl#" ;
+      sh:prefix "sh" ;
+  ] ;
+  sh:declare [
+      sh:namespace "http://example.com/ns#" ;
+      sh:prefix "ex" ;
+    ] .
+
+ex:Person
+	a sh:ShapeClass ;
+	sh:rule ex:CollectOffspringsRule ;
+	sh:rule ex:SetYoungestOffspringsRule .
+
+ex:CollectOffspringsRule
+	a sh:SPARQLRule ;
+	sh:layer 0 ;
+	sh:runOnce true ;
+	sh:construct """
+		CONSTRUCT {
+			$this ex:offspring ?offspring .
+			?reifier sh:tempTriple true .
+			?reifier rdf:reifies ?tt .
+		}
+		WHERE {
+			$this ex:child+ ?offspring .
+			BIND (BNODE() AS ?reifier) .
+			BIND (TRIPLE($this, ex:offspring, ?offspring) AS ?tt) .
+		}
+	""" .
+
+ex:SetYoungestOffspringsRule
+	a sh:SPARQLRule ;
+	sh:layer 1 ;
+	sh:construct """
+		CONSTRUCT {
+			$this ex:youngestOffspring ?o .
+		}
+		WHERE {
+			{
+				SELECT $this ?o
+				WHERE {
+					$this ex:offspring ?o .
+					?o ex:age ?age .
+				}
+				ORDER BY ?age
+				LIMIT 1
+			}
+		}
+	""" .
+
+ex:Grandma
+	a ex:Person ; 
+	ex:age 80 ;
+	ex:child ex:Son .
+
+ex:Son
+	a ex:Person ;
+	ex:age 40 ;
+	ex:child ex:Grandson, ex:Granddaughter .
+
+ex:Grandson
+	a ex:Person ;
+	ex:age 22 .
+
+ex:Granddaughter
+	a ex:Person ;
+	ex:age 19 .
+
+
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <temp-triples-example>
+    ) .
+
+<temp-triples-example>
+  rdf:type sht:Infer ;
+  rdfs:label "Test of sh:tempTriple from the spec" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result (
+	( ex:Grandma ex:youngestOffspring ex:Granddaughter )
+	( ex:Son ex:youngestOffspring ex:Granddaughter )
+	) ;
+  mf:status sht:approved ;
+.

--- a/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
@@ -35,14 +35,10 @@ ex:CollectOffspringsRule
 	sh:runOnce true ;
 	sh:construct """
 		CONSTRUCT {
-			$this ex:offspring ?offspring .
-			?reifier sh:tempTriple true .
-			?reifier rdf:reifies ?tt .
+			$this ex:offspring ?offspring {| sh:tempTriple true |} .
 		}
 		WHERE {
 			$this ex:child+ ?offspring .
-			BIND (BNODE() AS ?reifier) .
-			BIND (TRIPLE($this, ex:offspring, ?offspring) AS ?tt) .
 		}
 	""" .
 

--- a/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
@@ -7,7 +7,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-# This example also appears in the SHACL 1.2 SPARQL spec
+# A variation of this example also appears in the SHACL 1.2 SPARQL spec
 
 ex:
   a sh:ShapesGraph ;
@@ -93,7 +93,7 @@ ex:Granddaughter
 
 <temp-triples-example>
   rdf:type sht:Infer ;
-  rdfs:label "Test of sh:tempTriple from the spec" ;
+  rdfs:label "Test of sh:tempTriple similar to the one from the spec" ;
   mf:action [
       sht:dataGraph <> ;
       sht:shapesGraph <> ;

--- a/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
@@ -35,10 +35,14 @@ ex:CollectOffspringsRule
 	sh:runOnce true ;
 	sh:construct """
 		CONSTRUCT {
-			$this ex:offspring ?offspring {| sh:tempTriple true |} .
+			$this ex:offspring ?offspring .
+			?reifier sh:tempTriple true .
+			?reifier rdf:reifies ?tt .
 		}
 		WHERE {
 			$this ex:child+ ?offspring .
+			BIND (BNODE() AS ?reifier) .
+			BIND (TRIPLE($this, ex:offspring, ?offspring) AS ?tt) .
 		}
 	""" .
 

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1976,6 +1976,13 @@ sh:sourceRule
 	rdfs:range sh:Rule ;
 	rdfs:isDefinedBy sh: .
 
+sh:tempTriple
+	a rdf:Property ;
+	rdfs:label "temp triple"@en ;
+	rdfs:comment "Can be used in reifiers to mark inferred triples that shall be removed at the end of execution."@en ;
+	rdfs:range xsd:boolean ;
+	rdfs:isDefinedBy sh: .
+
 
 # -----------------------------------------------------------------------------
 # SHACL ADVANCED FEATURES (will likely be marked deprecated with 1.2)


### PR DESCRIPTION
Closes #995

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-995-tempTriple/shacl12-sparql/index.html#tempTriple)
