### PR TITLE
#1110: Add `sh:expectedPredicate` to link rules to `sh:defaultValue`/`sh:values`

### DIFF
--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2196,7 +2196,7 @@ ex:Granddaughter
 				<p>
 					It is sometimes useful for inference rules to produce triples that are only visible during the execution
 					of other rules but do not end up in the final inferences.
-					A <dfn>temporary triple</dfn> is an inferred <a>triple</a> for which the inferences graph contains a
+					A <dfn>temporary triple</dfn> is an inferred <a>triple</a> for which the inference graph contains a
 					<a>reifier</a> with the <a>value</a> <code>sh:tempTriple true</code>.
 					Rules can produce such triples as illustrated in the following example:
 				</p>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2261,8 +2261,10 @@ ex:SmallRectangle ex:isSmall true .
 						</div>
 					</aside>
 					<p>
-						Unless told otherwise, a SHACL rules engine will remove the derived triples from
-						the inferences at the end of the execution process.
+						A SHACL rules engine will remove the derived triples from the inferences at the end of
+						processing each layer, except those triples that have also been inferred by rules.
+						Some engines may have a setting to keep all derived triples, for example
+						when data is exported to systems that do not support SHACL.
 					</p>
 				</section>
 			</section>
@@ -2411,7 +2413,8 @@ ex:SetYoungestOffspringsRule
 							do
 								Execute one <a>iteration</a> over all <a>iterating rules</a> in the layer
 							while the iteration has produced newly inferred triples
-							Delete the <a>derived triples</a> and their <a>reifiers</a>
+							Delete the <a>derived triples</a> (except those that were also inferred by rules)
+							  and their <a>reifiers</a>
 
 						Delete the <a>temporary triples</a> and their <a>reifiers</a>
 					</pre>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2161,7 +2161,7 @@ ex:Granddaughter
 					<ul>
 						<li>
 							<a data-cite="shacl12-core#syntax-rule-path-defaultValue"><code>sh:defaultValue</code></a> defines what values should be used
-							when no other other values are present for a property.
+							when no other values are present for a property.
 							For example, the default value of <code>ex:childCount</code> could be <code>0</code>.
 						</li>
 						<li>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2191,67 +2191,6 @@ ex:Granddaughter
 					<a href="#rules-execution">rules execution instructions</a> prior to performing the actual validation. 
 				</p>
 			</section>
-			<section id="rules-execution">
-				<h3>General Execution Instructions for SHACL Rules</h3>
-				<p>
-					A <dfn data-lt="rules engine">SHACL rules engine</dfn> is a computer procedure that takes as input
-					a <a>data graph</a> and a <a>shapes graph</a> and is capable of adding <a>triples</a> to the <a>data graph</a>.
-					The new <a>triples</a> that are produced by a rules engine are called the <dfn data-lt="inferring|infer">inferred</dfn> triples.
-				</p>
-				<p>
-					Note that, from a logical perspective, the <a>data graph</a> will be <em>modified</em> if <a>triples</a> get inferred.
-					This means that rules can trigger after other triples have been inferred.
-					However, in cases where the original data should not be modified, implementations may construct a logical <a>data graph</a>
-					that has the original data as one subgraph and a dedicated inferences graph as another subgraph, and where
-					the inferred triples get added to the inferences graph only.
-				</p>
-				<p>
-					An <dfn>execution</dfn> of a <a>rule</a> is the process that produces <a>inferred</a> triples from the <a>rule</a>
-					based on the <a>execution instructions</a> of its <a>rule types</a>.
-					If the <a>rule</a> is a <a>shape rule</a> (i.e., it is linked to at least one <a>shape</a> via <code>sh:rule</code>),
-					then the rule is executed for each <a>target node</a> of each of the linked and <a data-cite="shacl12-core#deactivated">non-deactivated</a>
-					<a>shapes</a> that <a>conform</a> to all <a data-cite="shacl12-core#deactivated">non-deactivated</a> <a href="#condition">conditions</a> of the <a>rule</a>.
-					These <a>target nodes</a> become the <a>focus nodes</a> of the executing <a>shape rule</a>.
-				</p>
-				<p>
-					For a given set of <a>rules</a> in the <a>shapes graph</a>
-					an <dfn data-lt="iterate">iteration</dfn> is a single <a>execution</a> of each individual rule in the order as
-					specified by <a href="#rule-order"></a>, skipping the rules that are <a href="#deactivated-rules">deactivated</a>.
-					Within an iteration, the inferred triples of one rule become immediately visible to the next rule.
-				</p>
-				<p>
-					The <dfn>execution of a rule set</dfn> is defined as follows:
-				</p>
-				<div class="algorithm">
-					<pre class="text">
-						For all <a>layers</a> in the rule set (in ascending order):
-							Execute one <a>iteration</a> over all <a>run-once rules</a> in the layer
-							do
-								Execute one <a>iteration</a> over all <a>iterating rules</a> in the layer
-							while the iteration has produced newly inferred triples
-
-						Delete the <a>temporary triples</a> and their <a>reifiers</a>
-					</pre>
-				</div>
-				<p>
-					If any of the <a>rules</a> reports a <a>failure</a> during <a>execution</a>,
-					then the <a>execution of a rule set</a> also produces a <a>failure</a>.
-				</p>
-				<p>
-					If a <a>rules engine</a> is not able to execute a given <a>rule</a>
-					because it does not support any of the <a>rule types</a> of the <a>rule</a>,
-					then it reports a <a>failure</a>.
-				</p>
-				<p>
-					Rule engines MAY also report a failure after a pre-configured maximum iteration count has been exceeded or
-					a pre-configured maximum number of inferred triples has been produced.
-					This can help as a guard to avoid out-of-memory problems and infinite loops.
-				</p>
-				<p>
-					At no time are inferred triples visible to the <a>shapes graph</a>, i.e. it is impossible for rules
-					to modify the definitions of rules or shapes.
-				</p>
-			</section>
 			<section id="tempTriple">
 				<h3>Temporary Triples</h3>
 				<p>
@@ -2314,12 +2253,75 @@ ex:SetYoungestOffspringsRule
 						of each Person.
 						The final inferences only include the <code>ex:youngestOffspring</code> triples.
 					</p>
-					<p>
-						Note the example is for illustration purposes only.
-						The same result could be achieved with a single rule that does everything in one go.
-Creating temporary triples can be helpful when a computation is too complex to be carried out by a single rule. The complex computation can then be decomposed into _multiple_ rules: some rules infer _partial_ results, from which other rules derive the _final_ results. The partial results are only functional to the computation of the final results and are no longer needed once the latter have been obtained. By marking these partial results as temporary triples, they can be automatically removed after the final results have been computed.
-					</p>
 				</aside>
+				<p>
+					Creating temporary triples can be helpful when a computation is too complex to be carried out by a single rule.
+					The complex computation can then be decomposed into <em>multiple</em> rules:
+					some rules infer <em>partial</em> results, from which other rules derive the <em>final</em> results.
+					The partial results are only functional to the computation of the final results and are no longer needed once the latter have been obtained.
+					By marking these partial results as temporary triples, they can be automatically removed after the final results have been computed.
+				</p>
+			</section>
+			<section id="rules-execution">
+				<h3>General Execution Instructions for SHACL Rules</h3>
+				<p>
+					A <dfn data-lt="rules engine">SHACL rules engine</dfn> is a computer procedure that takes as input
+					a <a>data graph</a> and a <a>shapes graph</a> and is capable of adding <a>triples</a> to the <a>data graph</a>.
+					The new <a>triples</a> that are produced by a rules engine are called the <dfn data-lt="inferring|infer">inferred</dfn> triples.
+				</p>
+				<p>
+					Note that, from a logical perspective, the <a>data graph</a> will be <em>modified</em> if <a>triples</a> get inferred.
+					This means that rules can trigger after other triples have been inferred.
+					However, in cases where the original data should not be modified, implementations may construct a logical <a>data graph</a>
+					that has the original data as one subgraph and a dedicated inferences graph as another subgraph, and where
+					the inferred triples get added to the inferences graph only.
+				</p>
+				<p>
+					An <dfn>execution</dfn> of a <a>rule</a> is the process that produces <a>inferred</a> triples from the <a>rule</a>
+					based on the <a>execution instructions</a> of its <a>rule types</a>.
+					If the <a>rule</a> is a <a>shape rule</a> (i.e., it is linked to at least one <a>shape</a> via <code>sh:rule</code>),
+					then the rule is executed for each <a>target node</a> of each of the linked and <a data-cite="shacl12-core#deactivated">non-deactivated</a>
+					<a>shapes</a> that <a>conform</a> to all <a data-cite="shacl12-core#deactivated">non-deactivated</a> <a href="#condition">conditions</a> of the <a>rule</a>.
+					These <a>target nodes</a> become the <a>focus nodes</a> of the executing <a>shape rule</a>.
+				</p>
+				<p>
+					For a given set of <a>rules</a> in the <a>shapes graph</a>
+					an <dfn data-lt="iterate">iteration</dfn> is a single <a>execution</a> of each individual rule in the order as
+					specified by <a href="#rule-order"></a>, skipping the rules that are <a href="#deactivated-rules">deactivated</a>.
+					Within an iteration, the inferred triples of one rule become immediately visible to the next rule.
+				</p>
+				<p>
+					The <dfn>execution of a rule set</dfn> is defined as follows:
+				</p>
+				<div class="algorithm">
+					<pre class="text">
+						For all <a>layers</a> in the rule set (in ascending order):
+							Execute one <a>iteration</a> over all <a>run-once rules</a> in the layer
+							do
+								Execute one <a>iteration</a> over all <a>iterating rules</a> in the layer
+							while the iteration has produced newly inferred triples
+
+						Delete the <a>temporary triples</a> and their <a>reifiers</a>
+					</pre>
+				</div>
+				<p>
+					If any of the <a>rules</a> reports a <a>failure</a> during <a>execution</a>,
+					then the <a>execution of a rule set</a> also produces a <a>failure</a>.
+				</p>
+				<p>
+					If a <a>rules engine</a> is not able to execute a given <a>rule</a>
+					because it does not support any of the <a>rule types</a> of the <a>rule</a>,
+					then it reports a <a>failure</a>.
+				</p>
+				<p>
+					Rule engines MAY also report a failure after a pre-configured maximum iteration count has been exceeded or
+					a pre-configured maximum number of inferred triples has been produced.
+					This can help as a guard to avoid out-of-memory problems and infinite loops.
+				</p>
+				<p>
+					At no time are inferred triples visible to the <a>shapes graph</a>, i.e. it is impossible for rules
+					to modify the definitions of rules or shapes.
+				</p>
 			</section>
 			<section id="sourceRule">
 				<h3>Tracking the Rule that has produced a Triple (sh:sourceRule)</h3>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2173,7 +2173,7 @@ ex:Granddaughter
 					<p>
 						Both properties can use <a>node expressions</a> including those defined in <a data-cite="shacl12-node-expr"></a>.
 						Both properties can only be used to compute the <a>objects</a> of a given <a>predicate</a> for the
-						<a>subjects</a> that are targetted by <a>shapes</a>.
+						<a>subjects</a> that are targeted by <a>shapes</a>.
 						This means that <code>sh:defaultValue</code> and <code>sh:values</code> describe implicit triples
 						that are similar to inferences produced by rules.
 					</p>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2310,7 +2310,7 @@ ex:SetYoungestOffspringsRule
 					<p>
 						The first rule computes <code>ex:offspring</code> triples as the (transitive)
 						children of each Person.
-						The second rule uses the <code>ex:offspring</code> triples to infer the <code>ex:oldestOffspring</code>
+						The second rule uses the <code>ex:offspring</code> triples to infer the <code>ex:youngestOffspring</code>
 						of each Person.
 						The final inferences only include the <code>ex:youngestOffspring</code> triples.
 					</p>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -1872,10 +1872,11 @@ ex:InvalidRectangle    # Lacks a value for ex:color, so sh:condition is not met
 	ex:height 6 .
 						</div>
 					</div>
-					<p>
-						Inferred triples:
-					</p>
-					<pre class="example-inferences">	ex:ExampleRectangle ex:area 56 .</pre>
+					<div class="inferences-graph">
+						<div class="turtle">
+ex:ExampleRectangle ex:area 56 .
+						</div>
+					</div>
 				</aside>
 			</section>
 	
@@ -2128,10 +2129,8 @@ ex:RunAfterRule
 		""" .
 							</div>
 						</div>
-						<p>
-							Inferred triples:
-						</p>
-						<pre class="example-inferences">
+						<div class="inferences-graph">
+							<div class="turtle">
 ex:Grandma
 	a ex:Person ;
 	ex:child ex:Son ;
@@ -2150,8 +2149,118 @@ ex:Grandson
 
 ex:Granddaughter
 	a ex:Person .
-						</pre>
+							</div>
+						</div>
 					</aside>
+				</section>
+				<section id="expectedPredicate">
+					<h3>Expected Derived Triples (sh:expectedPredicate)</h3>
+					<p>
+						SHACL Core includes the following properties to <em>derive</em> property values that are not necessarily asserted in the <a>data graph</a>:
+					</p>
+					<ul>
+						<li>
+							<a data-cite="shacl12-core#syntax-rule-path-defaultValue"><code>sh:defaultValue</code></a> defines what values should be used
+							when no other other values are present for a property.
+							For example, the default value of <code>ex:childCount</code> could be <code>0</code>.
+						</li>
+						<li>
+							<a data-cite="shacl12-core#syntax-rule-path-defaultValue"><code>sh:values</code></a> defines general instructions for computing
+							derived values for a property.
+							For example, the <code>ex:area</code> of a rectangle may be derived by multiplying its <code>ex:width</code> and <code>ex:height</code>.
+						</li>
+					</ul>
+					<p>
+						Both properties can use <a>node expressions</a> as defined in <a data-cite="shacl12-node-expr"></a>.
+						Both properties can only be used to compute the <a>objects</a> of a given <a>predicate</a> for the
+						<a>subjects</a> that are targetted by <a>shapes</a>.
+						This means that <code>sh:defaultValue</code> and <code>sh:values</code> describe implicit triples
+						that are similar to inferences produced by rules.
+					</p>
+					<p>
+						When a <a>rule</a> refers to a certain property, it is reasonable for the rule to expect that these
+						implicit triples are present.
+						This section explains how <a>rules</a> can make sure that such derived triples are present before the rule executes.
+					</p>
+					<p>
+						For a given <a>predicate</a> <code>p</code>, the <dfn>derived value nodes</dfn> are all <a>value nodes</a>
+						that can be computed using <code>sh:defaultValue</code> and <code>sh:values</code>
+						as defined by <a data-cite="shacl12-core#value-nodes"></a> in any (non-deactivated)
+						<a>property shape</a> that uses <code>p</code> as <code>sh:path</code> in the <a>shapes graph</a>.
+						For these <a>derived value nodes</a> <code>v</code> the <dfn>derived triples</dfn> are the <a>triples</a>
+						where <code>v</code> is the <a>object</a>, <code>p</code> is the <a>predicate</a> and the <a>subjects</a>
+						are the <a>target nodes</a> of the property shapes.
+					</p>
+					<p>
+						The <dfn>expected derived triples</dfn> of a <a>rule</a> are the <a>derived triples</a> for all <a>values</a>
+						of the property <code>sh:expectedPredicate</code> at the <a>rule</a>.
+						All this is best explained by an example:
+					</p>
+					<aside class="example" title="Example of expected derived triples">
+						<div class="shapes-graph">
+							<div class="turtle">
+ex:RectangleShape
+	a sh:NodeShape ;
+	sh:targetClass ex:Rectangle ;
+	sh:property ex:RectangleShape-area ;
+	sh:rule ex:Rectangle-computeSmall .
+
+ex:RectangleShape-area
+	a sh:PropertyShape ;
+	sh:path ex:area ;
+	sh:defaultValue 1 ;
+	sh:values [
+		sparql:multiply ( [ shnex:pathValues ex:width ] [ shnex:pathValues ex:height ] )
+	] .
+
+ex:Rectangle-computeSmall
+	a sh:SPARQLRule ;
+	rdfs:comment "This rule expects that the values of ex:area have been derived." ;
+	sh:expectedPredicate ex:area ;
+	sh:construct """
+		CONSTRUCT {
+			$this ex:isSmall true .
+		}
+		WHERE {
+			$this ex:area ?area .
+			FILTER (?area &lt; 100) .
+		}
+	""" .
+							</div>
+						</div>
+						<p>
+							The following <a>data graph</a> defines some rectangle instances:
+						</p>
+						<div class="data-graph">
+							<div class="turtle">
+ex:IncompleteRectangle
+	a ex:Rectangle .
+
+ex:SmallRectangle
+	a ex:Rectangle ;
+	ex:width 4 ;
+	ex:height 5 .
+
+ex:LargeRectangle
+	a ex:Rectangle ;
+	ex:width 11 ;
+	ex:height 10 .
+							</div>
+						</div>
+						<div class="inferences-graph">
+							<div class="turtle">
+# IncompleteRectangle has default area of 1 which makes it small
+ex:IncompleteRectangle ex:isSmall true .
+
+# SmallRectangle has area computed via sh:values as 20
+ex:SmallRectangle ex:isSmall true .
+							</div>
+						</div>
+					</aside>
+					<p>
+						Unless told otherwise, a SHACL rules engine will remove the derived triples from
+						the inferences at the end of the execution process.
+					</p>
 				</section>
 			</section>
 			<section id="rules-graph">
@@ -2294,12 +2403,14 @@ ex:SetYoungestOffspringsRule
 				<div class="algorithm">
 					<pre class="text">
 						For all <a>layers</a> in the rule set (in ascending order):
+							Compute the <a>expected derived triples</a> of the layer
 							Execute one <a>iteration</a> over all <a>run-once rules</a> in the layer
 							do
 								Execute one <a>iteration</a> over all <a>iterating rules</a> in the layer
 							while the iteration has produced newly inferred triples
 
 						Delete the <a>temporary triples</a> and their <a>reifiers</a>
+						Delete the <a>derived triples</a> and their <a>reifiers</a>
 					</pre>
 				</div>
 				<p>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2229,6 +2229,8 @@ ex:Granddaughter
 							do
 								Execute one <a>iteration</a> over all <a>iterating rules</a> in the layer
 							while the iteration has produced newly inferred triples
+
+						Delete the <a>temporary triples</a> and their <a>reifiers</a>
 					</pre>
 				</div>
 				<p>
@@ -2249,6 +2251,76 @@ ex:Granddaughter
 					At no time are inferred triples visible to the <a>shapes graph</a>, i.e. it is impossible for rules
 					to modify the definitions of rules or shapes.
 				</p>
+			</section>
+			<section id="tempTriple">
+				<h3>Temporary Triples</h3>
+				<p>
+					It is sometimes useful for inference rules to produce triples that are only visible during the execution
+					of other rules but do not end up in the final inferences.
+					A <dfn>temporary triple</dfn> is an inferred <a>triple</a> for which the inferences graph contains a
+					<a>reifier</a> with the <a>value</a> <code>sh:tempTriple true</code>.
+					Rules can produce such triples as illustrated in the following example:
+				</p>
+				<aside class="example" title="An example rule that produces temporary triples" id="tempTriple-example">
+					<div class="shapes-graph">
+						<div class="turtle">
+ex:Person
+	a sh:ShapeClass ;
+	sh:rule ex:CollectOffspringsRule ;
+	sh:rule ex:SetYoungestOffspringsRule .
+
+ex:CollectOffspringsRule
+	a sh:SPARQLRule ;
+	sh:layer 0 ;
+	sh:runOnce true ;
+	sh:construct """
+		CONSTRUCT {
+			$this ex:offspring ?offspring .
+			?reifier sh:tempTriple true .
+			?reifier rdf:reifies ?tt .
+		}
+		WHERE {
+			$this ex:child+ ?offspring .
+			BIND (BNODE() AS ?reifier) .
+			BIND (TRIPLE($this, ex:offspring, ?offspring) AS ?tt) .
+		}
+	""" .
+
+ex:SetYoungestOffspringsRule
+	a sh:SPARQLRule ;
+	sh:layer 1 ;
+	sh:construct """
+		CONSTRUCT {
+			$this ex:youngestOffspring ?o .
+		}
+		WHERE {
+			{
+				SELECT $this ?o
+				WHERE {
+					$this ex:offspring ?o .
+					?o ex:age ?age .
+				}
+				ORDER BY ?age
+				LIMIT 1
+			}
+		}
+	""" .
+						</div>
+					</div>
+					<p>
+						The first rule computes <code>ex:offspring</code> triples as the (transitive)
+						children of each Person.
+						The second rule uses the <code>ex:offspring</code> triples to infer the <code>ex:oldestOffspring</code>
+						of each Person.
+						The final inferences only include the <code>ex:oldestOffspring</code> triples.
+					</p>
+					<p>
+						Note the example is for illustration purposes only.
+						The same result could be achieved with a single rule that does everything in one go.
+						Creating temporary triples can be helpful if it avoids repetitive computations that are
+						needed by multiple rules down the road.
+					</p>
+				</aside>
 			</section>
 			<section id="sourceRule">
 				<h3>Tracking the Rule that has produced a Triple (sh:sourceRule)</h3>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2411,9 +2411,9 @@ ex:SetYoungestOffspringsRule
 							do
 								Execute one <a>iteration</a> over all <a>iterating rules</a> in the layer
 							while the iteration has produced newly inferred triples
+							Delete the <a>derived triples</a> and their <a>reifiers</a>
 
 						Delete the <a>temporary triples</a> and their <a>reifiers</a>
-						Delete the <a>derived triples</a> and their <a>reifiers</a>
 					</pre>
 				</div>
 				<p>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2257,7 +2257,7 @@ ex:SetYoungestOffspringsRule
 					The complex computation can then be decomposed into <em>multiple</em> rules:
 					some rules infer <em>partial</em> results, from which other rules derive the <em>final</em> results.
 					The partial results are only functional to the computation of the final results and are no longer needed once the latter have been obtained.
-					By marking these partial results as temporary triples, they can be automatically removed after the final results have been computed.
+					By marking these partial results as temporary triples, they are automatically removed after the final results have been computed.
 				</p>
 			</section>
 			<section id="rules-execution">

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2312,7 +2312,7 @@ ex:SetYoungestOffspringsRule
 						children of each Person.
 						The second rule uses the <code>ex:offspring</code> triples to infer the <code>ex:oldestOffspring</code>
 						of each Person.
-						The final inferences only include the <code>ex:oldestOffspring</code> triples.
+						The final inferences only include the <code>ex:youngestOffspring</code> triples.
 					</p>
 					<p>
 						Note the example is for illustration purposes only.

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2406,7 +2406,7 @@ ex:SetYoungestOffspringsRule
 				<div class="algorithm">
 					<pre class="text">
 						For all <a>layers</a> in the rule set (in ascending order):
-							Compute the <a>expected derived triples</a> of the layer
+							Compute the <a>expected derived triples</a> for all rules in the layer
 							Execute one <a>iteration</a> over all <a>run-once rules</a> in the layer
 							do
 								Execute one <a>iteration</a> over all <a>iterating rules</a> in the layer

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2214,14 +2214,10 @@ ex:CollectOffspringsRule
 	sh:runOnce true ;
 	sh:construct """
 		CONSTRUCT {
-			$this ex:offspring ?offspring .
-			?reifier sh:tempTriple true .
-			?reifier rdf:reifies ?tt .
+			$this ex:offspring ?offspring {| sh:tempTriple true |} .
 		}
 		WHERE {
 			$this ex:child+ ?offspring .
-			BIND (BNODE() AS ?reifier) .
-			BIND (TRIPLE($this, ex:offspring, ?offspring) AS ?tt) .
 		}
 	""" .
 

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2317,8 +2317,7 @@ ex:SetYoungestOffspringsRule
 					<p>
 						Note the example is for illustration purposes only.
 						The same result could be achieved with a single rule that does everything in one go.
-						Creating temporary triples can be helpful if it avoids repetitive computations that are
-						needed by multiple rules down the road.
+Creating temporary triples can be helpful when a computation is too complex to be carried out by a single rule. The complex computation can then be decomposed into _multiple_ rules: some rules infer _partial_ results, from which other rules derive the _final_ results. The partial results are only functional to the computation of the final results and are no longer needed once the latter have been obtained. By marking these partial results as temporary triples, they can be automatically removed after the final results have been computed.
 					</p>
 				</aside>
 			</section>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2171,7 +2171,7 @@ ex:Granddaughter
 						</li>
 					</ul>
 					<p>
-						Both properties can use <a>node expressions</a> as defined in <a data-cite="shacl12-node-expr"></a>.
+						Both properties can use <a>node expressions</a> including those defined in <a data-cite="shacl12-node-expr"></a>.
 						Both properties can only be used to compute the <a>objects</a> of a given <a>predicate</a> for the
 						<a>subjects</a> that are targetted by <a>shapes</a>.
 						This means that <code>sh:defaultValue</code> and <code>sh:values</code> describe implicit triples
@@ -2249,10 +2249,13 @@ ex:LargeRectangle
 						</div>
 						<div class="inferences-graph">
 							<div class="turtle">
-# IncompleteRectangle has default area of 1 which makes it small
-ex:IncompleteRectangle ex:isSmall true .
+# Derived triples, visible only while rules execute:
+# ex:IncompleteRectangle ex:area 1 .
+# ex:SmallRectangle ex:area 20 .
+# ex:LargeRectangle ex:area 110 .
 
-# SmallRectangle has area computed via sh:values as 20
+# Inferred triples:
+ex:IncompleteRectangle ex:isSmall true .
 ex:SmallRectangle ex:isSmall true .
 							</div>
 						</div>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2252,6 +2252,8 @@ ex:SetYoungestOffspringsRule
 						The second rule uses the <code>ex:offspring</code> triples to infer the <code>ex:youngestOffspring</code>
 						of each Person.
 						The final inferences only include the <code>ex:youngestOffspring</code> triples.
+						All temporary triples, i.e., triples whose reifier is marked with <code>sh:tempTriple true</code>,
+						are automatically deleted by the SHACL engine at the end of the inference process.
 					</p>
 				</aside>
 				<p>

--- a/shacl12-sparql/style.css
+++ b/shacl12-sparql/style.css
@@ -38,6 +38,19 @@ td {
     border-color:      #aaaaaa ;
 }
 
+.inferences-graph {
+    background: #edb;
+    border: 1px solid #bbb;
+    margin-top: 0.3em;
+    color: black;
+}
+
+.inferences-graph:before {
+    color: #997;
+    content: "Inferred triples";
+    padding-left: 0.4em;
+}
+
 .arg {
     font-weight: bold;
     color: #000080;

--- a/shacl12-test-suite/tests/sparql/rules/expectedPredicate-example.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/expectedPredicate-example.ttl
@@ -1,0 +1,79 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix shnex: <http://www.w3.org/ns/shacl-node-expr#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix sparql: <http://www.w3.org/ns/sparql#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:
+  a sh:ShapesGraph ;
+  sh:declare [
+      sh:namespace "http://example.com/ns#" ;
+      sh:prefix "ex" ;
+    ] .
+
+ex:RectangleShape
+	a sh:NodeShape ;
+	sh:targetClass ex:Rectangle ;
+	sh:property ex:RectangleShape-area ;
+	sh:rule ex:Rectangle-computeSmall .
+
+ex:RectangleShape-area
+	a sh:PropertyShape ;
+	sh:path ex:area ;
+	sh:defaultValue 1 ;
+	sh:values [
+		sparql:multiply ( [ shnex:pathValues ex:width ] [ shnex:pathValues ex:height ] )
+	] .
+
+ex:Rectangle-computeSmall
+	a sh:SPARQLRule ;
+	rdfs:comment "This rule expects that the values of ex:area have been derived." ;
+	sh:expectedPredicate ex:area ;
+	sh:construct """
+		CONSTRUCT {
+			$this ex:isSmall true .
+		}
+		WHERE {
+			$this ex:area ?area .
+			FILTER (?area < 100) .
+		}
+	""" .
+
+ex:IncompleteRectangle
+	a ex:Rectangle .
+
+ex:SmallRectangle
+	a ex:Rectangle ;
+	ex:width 4 ;
+	ex:height 5 .
+
+ex:LargeRectangle
+	a ex:Rectangle ;
+	ex:width 11 ;
+	ex:height 10 .
+
+
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <expectedPredicate-example>
+    ) .
+
+<expectedPredicate-example>
+  rdf:type sht:Infer ;
+  rdfs:label "Test of sh:expectedPredicate as used in the spec" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result (
+    ( ex:IncompleteRectangle ex:isSmall true )
+	( ex:SmallRectangle ex:isSmall true )
+  ) ;
+  mf:status sht:approved ;
+.

--- a/shacl12-test-suite/tests/sparql/rules/expectedPredicate-example.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/expectedPredicate-example.ttl
@@ -76,4 +76,8 @@ ex:LargeRectangle
 	( ex:SmallRectangle ex:isSmall true )
   ) ;
   mf:status sht:approved ;
+  # This test requires a full NodeExpr implementation,
+  # which is not required to pass the SPARQL rules compliance
+  # TODO: Simpler tests that only rely on constant node expressions (Core)
+  sht:compliance sht:SPARQL, sht:NodeExpr ;  
 .

--- a/shacl12-test-suite/tests/sparql/rules/manifest.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/manifest.ttl
@@ -12,5 +12,6 @@
 	mf:include <rectangle-prefixes.ttl> ;
 	mf:include <rectangle-simple.ttl> ;
 	mf:include <run-once-example.ttl> ;
+	mf:include <temp-triples-example.ttl> ;
 	mf:include <rdfs/manifest.ttl> ;
 	.

--- a/shacl12-test-suite/tests/sparql/rules/manifest.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/manifest.ttl
@@ -4,6 +4,7 @@
 
 <>
 	a mf:Manifest ;
+	mf:include <expectedPredicate-example.ttl> ;
 	mf:include <global-symmetric.ttl> ;
 	mf:include <layers-example.ttl> ;
 	mf:include <rectangle-condition.ttl> ;

--- a/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
@@ -1,0 +1,106 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# This example also appears in the SHACL 1.2 SPARQL spec
+
+ex:
+  a sh:ShapesGraph ;
+  sh:declare [
+      sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#" ;
+      sh:prefix "rdf" ;
+  ] ;
+  sh:declare [
+      sh:namespace "http://www.w3.org/ns/shacl#" ;
+      sh:prefix "sh" ;
+  ] ;
+  sh:declare [
+      sh:namespace "http://example.com/ns#" ;
+      sh:prefix "ex" ;
+    ] .
+
+ex:Person
+	a sh:ShapeClass ;
+	sh:rule ex:CollectOffspringsRule ;
+	sh:rule ex:SetYoungestOffspringsRule .
+
+ex:CollectOffspringsRule
+	a sh:SPARQLRule ;
+	sh:layer 0 ;
+	sh:runOnce true ;
+	sh:construct """
+		CONSTRUCT {
+			$this ex:offspring ?offspring .
+			?reifier sh:tempTriple true .
+			?reifier rdf:reifies ?tt .
+		}
+		WHERE {
+			$this ex:child+ ?offspring .
+			BIND (BNODE() AS ?reifier) .
+			BIND (TRIPLE($this, ex:offspring, ?offspring) AS ?tt) .
+		}
+	""" .
+
+ex:SetYoungestOffspringsRule
+	a sh:SPARQLRule ;
+	sh:layer 1 ;
+	sh:construct """
+		CONSTRUCT {
+			$this ex:youngestOffspring ?o .
+		}
+		WHERE {
+			{
+				SELECT $this ?o
+				WHERE {
+					$this ex:offspring ?o .
+					?o ex:age ?age .
+				}
+				ORDER BY ?age
+				LIMIT 1
+			}
+		}
+	""" .
+
+ex:Grandma
+	a ex:Person ; 
+	ex:age 80 ;
+	ex:child ex:Son .
+
+ex:Son
+	a ex:Person ;
+	ex:age 40 ;
+	ex:child ex:Grandson, ex:Granddaughter .
+
+ex:Grandson
+	a ex:Person ;
+	ex:age 22 .
+
+ex:Granddaughter
+	a ex:Person ;
+	ex:age 19 .
+
+
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <temp-triples-example>
+    ) .
+
+<temp-triples-example>
+  rdf:type sht:Infer ;
+  rdfs:label "Test of sh:tempTriple from the spec" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result (
+	( ex:Grandma ex:youngestOffspring ex:Granddaughter )
+	( ex:Son ex:youngestOffspring ex:Granddaughter )
+	) ;
+  mf:status sht:approved ;
+.

--- a/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
@@ -35,14 +35,10 @@ ex:CollectOffspringsRule
 	sh:runOnce true ;
 	sh:construct """
 		CONSTRUCT {
-			$this ex:offspring ?offspring .
-			?reifier sh:tempTriple true .
-			?reifier rdf:reifies ?tt .
+			$this ex:offspring ?offspring {| sh:tempTriple true |} .
 		}
 		WHERE {
 			$this ex:child+ ?offspring .
-			BIND (BNODE() AS ?reifier) .
-			BIND (TRIPLE($this, ex:offspring, ?offspring) AS ?tt) .
 		}
 	""" .
 

--- a/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
@@ -7,7 +7,7 @@
 @prefix sht: <http://www.w3.org/ns/shacl-test#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-# This example also appears in the SHACL 1.2 SPARQL spec
+# A variation of this example also appears in the SHACL 1.2 SPARQL spec
 
 ex:
   a sh:ShapesGraph ;
@@ -93,7 +93,7 @@ ex:Granddaughter
 
 <temp-triples-example>
   rdf:type sht:Infer ;
-  rdfs:label "Test of sh:tempTriple from the spec" ;
+  rdfs:label "Test of sh:tempTriple similar to the one from the spec" ;
   mf:action [
       sht:dataGraph <> ;
       sht:shapesGraph <> ;

--- a/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/temp-triples-example.ttl
@@ -35,10 +35,14 @@ ex:CollectOffspringsRule
 	sh:runOnce true ;
 	sh:construct """
 		CONSTRUCT {
-			$this ex:offspring ?offspring {| sh:tempTriple true |} .
+			$this ex:offspring ?offspring .
+			?reifier sh:tempTriple true .
+			?reifier rdf:reifies ?tt .
 		}
 		WHERE {
 			$this ex:child+ ?offspring .
+			BIND (BNODE() AS ?reifier) .
+			BIND (TRIPLE($this, ex:offspring, ?offspring) AS ?tt) .
 		}
 	""" .
 

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1976,6 +1976,13 @@ sh:sourceRule
 	rdfs:range sh:Rule ;
 	rdfs:isDefinedBy sh: .
 
+sh:tempTriple
+	a rdf:Property ;
+	rdfs:label "temp triple"@en ;
+	rdfs:comment "Can be used in reifiers to mark inferred triples that shall be removed at the end of execution."@en ;
+	rdfs:range xsd:boolean ;
+	rdfs:isDefinedBy sh: .
+
 
 # -----------------------------------------------------------------------------
 # SHACL ADVANCED FEATURES (will likely be marked deprecated with 1.2)

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1953,6 +1953,14 @@ sh:condition
 	rdfs:range sh:Shape ;
 	rdfs:isDefinedBy sh: .
 
+sh:expectedPredicate
+	a rdf:Property ;
+	rdfs:label "expected predicate"@en ;
+	rdfs:comment "Links a rule with predicates for which the derived values (via sh:defaultValue and sh:values) are expected to be present as inferred triples."@en ;
+	rdfs:domain sh:Rule ;
+	rdfs:range rdf:Property ;
+	rdfs:isDefinedBy sh: .
+
 sh:layer
 	a rdf:Property ;
 	rdfs:label "layer"@en ;


### PR DESCRIPTION
Closes #1110

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-1110/shacl12-sparql/index.html#expectedPredicate)

This is a draft PR for now because this branch is based on the sh:tempTriple branch which isn't merged into main yet. Apart from that I believe it's good to be reviewed and I have implemented the algorithm.