### PR TITLE
SHACL UI scoring follow-ups

### DIFF
--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -2929,7 +2929,7 @@ ex:Concept-prefLabel
           <h4>shui:BlankNodeViewer</h4>
             <b>Score:</b>
             <ul>
-              <li>`30` if the property indicates its preference for `shui:BlankNodeViewer` using a `shui:viewer` statement, and the value is a blank node.</li>
+              <li>`40` if the property indicates its preference for `shui:BlankNodeViewer` using a `shui:viewer` statement, and the value is a blank node.</li>
               <li>`1` if the value is a blank node.</li>
             </ul>
           <p>
@@ -2944,7 +2944,7 @@ ex:Concept-prefLabel
           <h4>shui:DetailsViewer</h4>
             <b>Score:</b>
             <ul>
-              <li>`30` if the property indicates its preference for `shui:DetailsViewer` using a `shui:viewer` statement, and the value is an IRI or a blank node.</li>
+              <li>`40` if the property indicates its preference for `shui:DetailsViewer` using a `shui:viewer` statement, and the value is an IRI or a blank node.</li>
               <li>`0` if the value is an IRI or a blank node.</li>
             </ul>
           <p>
@@ -2966,7 +2966,7 @@ ex:Concept-prefLabel
           <h4>shui:HTMLViewer</h4>
             <b>Score:</b>
             <ul>
-              <li>`30` if the property indicates its preference for `shui:HTMLViewer` using a `shui:viewer` statement, and the value is an `rdf:HTML` or `xsd:string` literal.</li>
+              <li>`40` if the property indicates its preference for `shui:HTMLViewer` using a `shui:viewer` statement, and the value is an `rdf:HTML` or `xsd:string` literal.</li>
               <li>`20` if the value is an `rdf:HTML` literal.</li>
             </ul>
           <p>
@@ -2980,7 +2980,7 @@ ex:Concept-prefLabel
           <h4>shui:HyperlinkViewer</h4>
             <b>Score:</b>
             <ul>
-              <li>`30` if the property indicates its preference for `shui:HyperlinkViewer` using a `shui:viewer` statement, and the value is an `xsd:anyURI` or `xsd:string` literal.</li>
+              <li>`40` if the property indicates its preference for `shui:HyperlinkViewer` using a `shui:viewer` statement, and the value is an `xsd:anyURI` or `xsd:string` literal.</li>
               <li>`20` if the value is an `xsd:anyURI` literal.</li>
               <li>`0` if the value is an `xsd:string` literal.</li>
             </ul>
@@ -2993,7 +2993,7 @@ ex:Concept-prefLabel
           <h4>shui:ImageViewer</h4>
             <b>Score:</b>
             <ul>
-              <li>`30` if the property indicates its preference for `shui:ImageViewer` using a `shui:viewer` statement.</li>
+              <li>`40` if the property indicates its preference for `shui:ImageViewer` using a `shui:viewer` statement.</li>
               <li>`20` if the value is an IRI or a literal that has a case-insensitive recognized image file extension ending such as `.png`, `.jpg`, `.jpeg`, `.gif`, or `.svg`.</li>
             </ul>
           <p>
@@ -3005,7 +3005,7 @@ ex:Concept-prefLabel
           <h4>shui:IRIViewer</h4>
             <b>Score:</b>
           <ul>
-            <li>`30` if the property indicates its preference for `shui:IRIViewer` using a `shui:viewer` statement, and the value is an IRI.</li>
+            <li>`40` if the property indicates its preference for `shui:IRIViewer` using a `shui:viewer` statement, and the value is an IRI.</li>
             <li>`1` if the value is an IRI.</li>
           </ul>
           <p>
@@ -3018,7 +3018,7 @@ ex:Concept-prefLabel
           <h4>shui:LabelViewer</h4>
             <b>Score:</b>
             <ul>
-              <li>`30` if the property indicates its preference for `shui:LabelViewer` using a `shui:viewer` statement, and the value is an IRI.</li>
+              <li>`40` if the property indicates its preference for `shui:LabelViewer` using a `shui:viewer` statement, and the value is an IRI.</li>
               <li>`10` if the value is an IRI.</li>
             </ul>
           <p>
@@ -3033,7 +3033,7 @@ ex:Concept-prefLabel
           <h4>shui:LangStringViewer</h4>
             <b>Score:</b>
             <ul>
-              <li>`30` if the property indicates its preference for `shui:LangStringViewer` using a `shui:viewer` statement.</li>
+              <li>`40` if the property indicates its preference for `shui:LangStringViewer` using a `shui:viewer` statement.</li>
               <li>`20` if the value is an `rdf:langString` literal.</li>
             </ul>
           <p>
@@ -3045,7 +3045,7 @@ ex:Concept-prefLabel
           <h4>shui:LiteralViewer</h4>
             <b>Score:</b>
             <ul>
-              <li>`30` if the property indicates its preference for `shui:LiteralViewer` using a `shui:viewer` statement.</li>
+              <li>`40` if the property indicates its preference for `shui:LiteralViewer` using a `shui:viewer` statement.</li>
               <li>`1` if the value is a literal.</li>
             </ul>
           <p>
@@ -3060,7 +3060,7 @@ ex:Concept-prefLabel
           </p>
             <b>Score:</b>
             <ul>
-              <li>`30` if the property indicates its preference for `shui:ValueTableViewer` using a `shui:viewer` statement.</li>
+              <li>`40` if the property indicates its preference for `shui:ValueTableViewer` using a `shui:viewer` statement.</li>
              </ul>
           <p>
             <b>Rendering:</b>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1255,6 +1255,80 @@ ex:PersonShapeNameGroup a sh:PropertyGroup ;
         </p>
       </section>
 
+      <section id="scoring-band-conventions">
+        <h3>Score Conventions</h3>
+        <p>
+          A `shui:score` is any `xsd:integer` or `xsd:decimal`; the <a href="#scoring-algorithm-score-function">score
+          function</a> simply orders widgets by descending score. The absolute value of a score has no meaning of its own.
+          The built-in widgets nevertheless follow a small set of conventional <em>bands</em>, described below, so that the
+          relative order of widgets is predictable. Third-party widget authors SHOULD reuse these bands so that their
+          widgets interleave with the built-in ones as intended: a widget that should win over a built-in in some situation
+          uses a score in the same band as, or a higher band than, that built-in.
+        </p>
+        <p>
+          Scores are compared <strong>globally</strong> across the whole scoring graph, not per widget. Two widgets whose
+          matching `shui:WidgetScore` instances carry the same score are ordered lexicographically by the Unicode code point
+          values of their `shui:widget` IRIs (see the <a href="#scoring-algorithm-score-function">score function</a>). A band
+          is therefore a shared frame of reference, not a guarantee of a unique position.
+        </p>
+        <table class="def">
+          <thead>
+            <tr><th>Band</th><th>Meaning</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>40</strong></td>
+              <td>The shape explicitly declares this widget with `shui:editor` or `shui:viewer`. This is also the default
+                value of `shui:defaultWidgetScore` used by <a href="#scoring-algorithm-scoring-graph-preparation">scoring
+                graph preparation</a> for a declared widget that has no `shui:WidgetScore` of its own, so a declared widget
+                always competes at the top of the ladder.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>30</strong></td>
+              <td>Native match: the value's datatype or node kind is exactly what the widget is designed for and the widget
+                is the canonical choice for such values — for example an `xsd:string` value for a text field, an `xsd:date`
+                value for a date picker, or a blank node for the blank-node viewer.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>20</strong></td>
+              <td>Strong but secondary match: a good fit for the value or shape that is not the single canonical widget for
+                it — for example a text area for an arbitrary string, or a widget selected from the value's datatype where a
+                more specific widget may also apply.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>10</strong></td>
+              <td>Shape-constraint match: the shape constrains the datatype or node kind (for example with `sh:datatype` or
+                `sh:nodeKind`) even though the value itself may be absent or not yet of that type.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>1</strong></td>
+              <td>Last-resort fallback: the widget can technically present or edit the value but is rarely the best choice.
+                It is offered so that some widget is always available.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>0</strong></td>
+              <td>Applicable but discouraged: the widget is included for completeness or manual override and should never be
+                chosen as the default.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="note">
+          The built-in widgets occasionally use an intermediate score, such as `5`, to break a tie between two widgets that
+          would otherwise share a band. Such values are fine-tuning between the bands above and are not themselves bands.
+        </p>
+        <p class="note">
+          To declare that a widget is <em>not</em> applicable under some condition, give the widget a
+          `shui:WidgetAcceptMatcher` whose shapes match the applicable case, rather than a `shui:WidgetScore` with a low or
+          negative score.
+        </p>
+      </section>
+
       <section id="scoring-algorithm-scoring-graph-preparation">
         <h3>Scoring Graph Preparation</h3>
         <p>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1293,9 +1293,11 @@ ex:PersonShapeNameGroup a sh:PropertyGroup ;
           </li>
           <li>For each property <code>P</code> in <code>shui:editor</code> and <code>shui:viewer</code>
             <ol>
-              <li>Collect the set of <a>values</a> <code>W</code> of the property <code>P</code> of the <a>shapes</a> in the
+              <li>Collect the set of IRI <a>values</a> <code>W</code> of the property <code>P</code> of the <a>shapes</a> in the
                 <strong>shapes graph</strong>. These are the widgets that are explicitly declared on a shape. A value of
-                <code>P</code> at a node that is not a shape does not declare a widget and is ignored.
+                <code>P</code> at a node that is not a shape does not declare a widget and is ignored. A value of
+                <code>P</code> that is not an IRI is also ignored: a widget is identified by an IRI, and a non-IRI value
+                such as a blank node cannot be matched reliably with `sh:hasValue` across graphs.
               </li>
               <li>For each <code>W</code>
                 <ol>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1609,8 +1609,21 @@ ex:PersonShapeName
       </section>
 
       <section id="scoring-algorithm-widget-score-validation">
-        <h3>Widget Score Validation</h3>
-        <p>Widget Scores are malformed if they fail to validate against this <a href="./widgets/score-validator.ttl">score validation shapes graph</a>.</p>
+        <h3>Widget Matcher Validation</h3>
+        <p>
+          Widget matchers are malformed if they fail to validate against the
+          <a href="./widgets/score-validator.ttl">matcher validation shapes graph</a>. That graph defines two shapes:
+        </p>
+        <ul>
+          <li>`shui:ScoreShape` targets `shui:WidgetScore`. A well-formed `shui:WidgetScore` has exactly one
+            `shui:widget` (an IRI), exactly one `shui:score` (an `xsd:decimal` or `xsd:integer`), and any
+            `shui:dataGraphShape` or `shui:shapesGraphShape` it declares references a valid node.
+          </li>
+          <li>`shui:AcceptMatcherShape` targets `shui:WidgetAcceptMatcher`. A well-formed
+            `shui:WidgetAcceptMatcher` has exactly one `shui:widget` (an IRI), no `shui:score`, and any
+            `shui:dataGraphShape` or `shui:shapesGraphShape` it declares references a valid node.
+          </li>
+        </ul>
       </section>
 
     </section>
@@ -2801,9 +2814,12 @@ ex:Drug-impactedCell
         </section>
         <section id="TextAreaEditor">
           <h4>shui:TextAreaEditor</h4>
+            <p>
+              <b>Accept matcher:</b> Offered only if the property does not have a `sh:singleLine true` constraint,
+              expressed with a `shui:WidgetAcceptMatcher`.
+            </p>
             <b>Score:</b>
             <ul>
-              <li>`-1` if the property has a `sh:singleLine true` constraint.</li>
               <li>`40` if the property indicates its preference for `shui:TextAreaEditor` using a `shui:editor` statement.</li>
               <li>`30` if the value is an `xsd:string` literal and the property has a `sh:singleLine false` constraint.</li>
               <li>`20` if the value is an `xsd:string` literal.</li>
@@ -2826,14 +2842,17 @@ ex:Country-description
         </section>
         <section id="TextAreaWithLangEditor">
           <h4>shui:TextAreaWithLangEditor</h4>
+            <p>
+              <b>Accept matcher:</b> Offered only if the property does not have a `sh:singleLine true` constraint,
+              expressed with a `shui:WidgetAcceptMatcher`.
+            </p>
             <b>Score:</b>
             <ul>
-              <li>`-1` if the property has a `sh:singleLine true` constraint.</li>
               <li>`40` if the property indicates its preference for `shui:TextAreaWithLangEditor` using a `shui:editor` statement.</li>
               <li>`30` if the value is an `rdf:langString` literal and the property has a `sh:singleLine false` constraint.</li>
               <li>`20` if the value is an `rdf:langString` literal.</li>
               <li>`5` if the property has `rdf:langString` among the permissible datatypes.</li>
-              <li>`1` if the property has `xsd:string` among the permissible datatypes.</li>
+              <li>`0` if the property has `xsd:string` among the permissible datatypes.</li>
             </ul>
           <p>
             <b>Rendering:</b>
@@ -2850,13 +2869,16 @@ ex:Country-description
         </section>
         <section id="TextFieldEditor">
           <h4>shui:TextFieldEditor</h4>
+            <p>
+              <b>Accept matcher:</b> Offered only if the property does not have a `sh:singleLine false` constraint,
+              expressed with a `shui:WidgetAcceptMatcher`.
+            </p>
             <b>Score:</b>
             <ul>
-              <li>`-1` if the property has a `sh:singleLine false` constraint.</li>
               <li>`40` if the property indicates its preference for `shui:TextFieldEditor` using a `shui:editor` statement.</li>
               <li>`30` if the value is an `xsd:string` literal.</li>
               <li>`10` if the property has `xsd:string` among the permissible datatypes.</li>
-              <li>`0` if the property has a custom datatype (not from `xsd` or `rdf` namespaces but for example `geo:wktLiteral`).</li>
+              <li>`0` if the property has a custom datatype (not from `xsd` or `rdf` namespaces but for example `geo:wktLiteral`), or if the property has a `sh:nodeKind sh:Literal` constraint.</li>
             </ul>
           <p>
             <b>Rendering:</b>
@@ -2872,9 +2894,12 @@ ex:Country-code
         </section>
         <section id="TextFieldWithLangEditor">
           <h4>shui:TextFieldWithLangEditor</h4>
+            <p>
+              <b>Accept matcher:</b> Offered only if the property does not have a `sh:singleLine false` constraint,
+              expressed with a `shui:WidgetAcceptMatcher`.
+            </p>
             <b>Score:</b>
             <ul>
-              <li>`-1` if the property has a `sh:singleLine false` constraint.</li>
               <li>`40` if the property indicates its preference for `shui:TextFieldWithLangEditor` using a `shui:editor` statement.</li>
               <li>`30` if the value is an `rdf:langString` literal.</li>
               <li>`10` if the property has `rdf:langString` among the permissible datatypes.</li>

--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1258,18 +1258,20 @@ ex:PersonShapeNameGroup a sh:PropertyGroup ;
       <section id="scoring-band-conventions">
         <h3>Score Conventions</h3>
         <p>
-          A `shui:score` is any `xsd:integer` or `xsd:decimal`; the <a href="#scoring-algorithm-score-function">score
+          A `shui:score` is any `xsd:integer` or `xsd:decimal`. The <a href="#scoring-algorithm-score-function">score
           function</a> simply orders widgets by descending score. The absolute value of a score has no meaning of its own.
+        </p>
+        <p>
           The built-in widgets nevertheless follow a small set of conventional <em>bands</em>, described below, so that the
           relative order of widgets is predictable. Third-party widget authors SHOULD reuse these bands so that their
-          widgets interleave with the built-in ones as intended: a widget that should win over a built-in in some situation
+          widgets interleave with the built-in ones as intended. A widget that should win over a built-in in some situation
           uses a score in the same band as, or a higher band than, that built-in.
         </p>
         <p>
           Scores are compared <strong>globally</strong> across the whole scoring graph, not per widget. Two widgets whose
           matching `shui:WidgetScore` instances carry the same score are ordered lexicographically by the Unicode code point
-          values of their `shui:widget` IRIs (see the <a href="#scoring-algorithm-score-function">score function</a>). A band
-          is therefore a shared frame of reference, not a guarantee of a unique position.
+          values of their `shui:widget` IRIs, as defined in the <a href="#scoring-algorithm-score-function">score function</a>.
+          A band is therefore a shared frame of reference, not a guarantee of a unique position.
         </p>
         <table class="def">
           <thead>

--- a/shacl12-ui/widgets/editors/date-picker-editor.ttl
+++ b/shacl12-ui/widgets/editors/date-picker-editor.ttl
@@ -5,7 +5,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 shui:datePickerEditorScore40
     a shui:WidgetScore ;
     shui:widget shui:DatePickerEditor ;
-    shui:score 20 ;
+    shui:score 40 ;
     shui:dataGraphShape shui:isDate ;
     shui:shapesGraphShape shui:prefersDatePickerEditor ;
 .
@@ -13,7 +13,7 @@ shui:datePickerEditorScore40
 shui:datePickerEditorScore20
     a shui:WidgetScore ;
     shui:widget shui:DatePickerEditor ;
-    shui:score 30 ;
+    shui:score 20 ;
     shui:dataGraphShape shui:isDate ;
 .
 

--- a/shacl12-ui/widgets/editors/text-area-editor.ttl
+++ b/shacl12-ui/widgets/editors/text-area-editor.ttl
@@ -4,7 +4,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 shui:textAreaEditorAcceptMatcher
     a shui:WidgetAcceptMatcher ;
-    shui:shapesGraphShape shui:isNotSingleLineTrue ;
+    shui:shapesGraphShape shui:noSingleLineTrue ;
     shui:widget shui:TextAreaEditor ;
 .
 

--- a/shacl12-ui/widgets/editors/text-area-editor.ttl
+++ b/shacl12-ui/widgets/editors/text-area-editor.ttl
@@ -2,10 +2,9 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-shui:textAreaEditorScoreMinus1
-    a shui:WidgetScore ;
-    shui:shapesGraphShape shui:isSingleLineTrue ;
-    shui:score -1 ;
+shui:textAreaEditorAcceptMatcher
+    a shui:WidgetAcceptMatcher ;
+    shui:shapesGraphShape shui:isNotSingleLineTrue ;
     shui:widget shui:TextAreaEditor ;
 .
 

--- a/shacl12-ui/widgets/editors/text-area-with-lang-editor.ttl
+++ b/shacl12-ui/widgets/editors/text-area-with-lang-editor.ttl
@@ -2,11 +2,10 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-shui:textAreaWithLangEditorScoreMinus1
-    a shui:WidgetScore ;
+shui:textAreaWithLangEditorAcceptMatcher
+    a shui:WidgetAcceptMatcher ;
     shui:widget shui:TextAreaWithLangEditor ;
-    shui:score -1 ;
-    shui:shapesGraphShape shui:isSingleLineTrue ;
+    shui:shapesGraphShape shui:isNotSingleLineTrue ;
 .
 
 shui:textAreaWithLangEditorScore40

--- a/shacl12-ui/widgets/editors/text-area-with-lang-editor.ttl
+++ b/shacl12-ui/widgets/editors/text-area-with-lang-editor.ttl
@@ -5,7 +5,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 shui:textAreaWithLangEditorAcceptMatcher
     a shui:WidgetAcceptMatcher ;
     shui:widget shui:TextAreaWithLangEditor ;
-    shui:shapesGraphShape shui:isNotSingleLineTrue ;
+    shui:shapesGraphShape shui:noSingleLineTrue ;
 .
 
 shui:textAreaWithLangEditorScore40

--- a/shacl12-ui/widgets/editors/text-field-editor.ttl
+++ b/shacl12-ui/widgets/editors/text-field-editor.ttl
@@ -2,11 +2,10 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-shui:textFieldEditorScoreMinus1
-    a shui:WidgetScore ;
+shui:textFieldEditorAcceptMatcher
+    a shui:WidgetAcceptMatcher ;
     shui:widget shui:TextFieldEditor ;
-    shui:score -1 ;
-    shui:shapesGraphShape shui:isSingleLineFalse ;
+    shui:shapesGraphShape shui:isNotSingleLineFalse ;
 .
 
 shui:textFieldEditorScore40

--- a/shacl12-ui/widgets/editors/text-field-editor.ttl
+++ b/shacl12-ui/widgets/editors/text-field-editor.ttl
@@ -5,7 +5,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 shui:textFieldEditorAcceptMatcher
     a shui:WidgetAcceptMatcher ;
     shui:widget shui:TextFieldEditor ;
-    shui:shapesGraphShape shui:isNotSingleLineFalse ;
+    shui:shapesGraphShape shui:noSingleLineFalse ;
 .
 
 shui:textFieldEditorScore40

--- a/shacl12-ui/widgets/editors/text-field-with-lang-editor.ttl
+++ b/shacl12-ui/widgets/editors/text-field-with-lang-editor.ttl
@@ -5,7 +5,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 shui:textFieldWithLangEditorAcceptMatcher
     a shui:WidgetAcceptMatcher ;
     shui:widget shui:TextFieldWithLangEditor ;
-    shui:shapesGraphShape shui:isNotSingleLineFalse ;
+    shui:shapesGraphShape shui:noSingleLineFalse ;
 .
 
 shui:textFieldWithLangEditorScore40

--- a/shacl12-ui/widgets/editors/text-field-with-lang-editor.ttl
+++ b/shacl12-ui/widgets/editors/text-field-with-lang-editor.ttl
@@ -2,11 +2,10 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-shui:textFieldWithLangEditorScoreMinus1
-    a shui:WidgetScore ;
+shui:textFieldWithLangEditorAcceptMatcher
+    a shui:WidgetAcceptMatcher ;
     shui:widget shui:TextFieldWithLangEditor ;
-    shui:score -1 ;
-    shui:shapesGraphShape shui:isSingleLineFalse ;
+    shui:shapesGraphShape shui:isNotSingleLineFalse ;
 .
 
 shui:textFieldWithLangEditorScore40

--- a/shacl12-ui/widgets/score-shapes.ttl
+++ b/shacl12-ui/widgets/score-shapes.ttl
@@ -149,6 +149,16 @@ shui:isSingleLineFalse
     ] ;
 .
 
+shui:isNotSingleLineTrue
+    a sh:NodeShape ;
+    sh:not shui:isSingleLineTrue ;
+.
+
+shui:isNotSingleLineFalse
+    a sh:NodeShape ;
+    sh:not shui:isSingleLineFalse ;
+.
+
 shui:hasInConstraint
     a sh:NodeShape ;
     sh:property [

--- a/shacl12-ui/widgets/score-shapes.ttl
+++ b/shacl12-ui/widgets/score-shapes.ttl
@@ -149,12 +149,12 @@ shui:isSingleLineFalse
     ] ;
 .
 
-shui:isNotSingleLineTrue
+shui:noSingleLineTrue
     a sh:NodeShape ;
     sh:not shui:isSingleLineTrue ;
 .
 
-shui:isNotSingleLineFalse
+shui:noSingleLineFalse
     a sh:NodeShape ;
     sh:not shui:isSingleLineFalse ;
 .

--- a/shacl12-ui/widgets/score-validator.ttl
+++ b/shacl12-ui/widgets/score-validator.ttl
@@ -8,7 +8,7 @@ shui:ScoreShape a sh:NodeShape ;
         sh:path shui:widget ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
-        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:nodeKind sh:IRI ;
         sh:message "A Widget Score must have exactly one shui:widget" ;
     ] ;
     sh:property [

--- a/shacl12-ui/widgets/score-validator.ttl
+++ b/shacl12-ui/widgets/score-validator.ttl
@@ -31,3 +31,28 @@ shui:ScoreShape a sh:NodeShape ;
         sh:nodeKind sh:BlankNodeOrIRI ;
         sh:message "A Widget Score's shapesGraphShape must reference a valid node" ;
     ] .
+
+shui:AcceptMatcherShape a sh:NodeShape ;
+    sh:targetClass shui:WidgetAcceptMatcher ;
+    sh:property [
+        sh:path shui:widget ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:message "A Widget Accept Matcher must have exactly one shui:widget" ;
+    ] ;
+    sh:property [
+        sh:path shui:score ;
+        sh:maxCount 0 ;
+        sh:message "A Widget Accept Matcher must not have a shui:score" ;
+    ] ;
+    sh:property [
+        sh:path shui:dataGraphShape ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:message "A Widget Accept Matcher's dataGraphShape must reference a valid node" ;
+    ] ;
+    sh:property [
+        sh:path shui:shapesGraphShape ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:message "A Widget Accept Matcher's shapesGraphShape must reference a valid node" ;
+    ] .

--- a/shacl12-ui/widgets/viewers/blank-node-viewer.ttl
+++ b/shacl12-ui/widgets/viewers/blank-node-viewer.ttl
@@ -2,10 +2,10 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-shui:blankNodeViewerScore30
+shui:blankNodeViewerScore40
     a shui:WidgetScore ;
     shui:widget shui:BlankNodeViewer ;
-    shui:score 30 ;
+    shui:score 40 ;
     shui:dataGraphShape shui:isBlankNode ;
     shui:shapesGraphShape shui:prefersBlankNodeViewer ;
 .

--- a/shacl12-ui/widgets/viewers/details-viewer.ttl
+++ b/shacl12-ui/widgets/viewers/details-viewer.ttl
@@ -2,10 +2,10 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-shui:detailsViewerScore30
+shui:detailsViewerScore40
     a shui:WidgetScore ;
     shui:widget shui:DetailsViewer ;
-    shui:score 30 ;
+    shui:score 40 ;
     shui:dataGraphShape shui:isIRIOrBlankNode ;
     shui:shapesGraphShape shui:prefersDetailsViewer ;
 .

--- a/shacl12-ui/widgets/viewers/html-viewer.ttl
+++ b/shacl12-ui/widgets/viewers/html-viewer.ttl
@@ -2,10 +2,10 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-shui:htmlViewerScore30
+shui:htmlViewerScore40
     a shui:WidgetScore ;
     shui:widget shui:HTMLViewer ;
-    shui:score 30 ;
+    shui:score 40 ;
     shui:dataGraphShape shui:isHTMLOrString ;
     shui:shapesGraphShape shui:prefersHTMLViewer ;
 .

--- a/shacl12-ui/widgets/viewers/hyperlink-viewer.ttl
+++ b/shacl12-ui/widgets/viewers/hyperlink-viewer.ttl
@@ -2,10 +2,10 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-shui:hyperlinkViewerScore30
+shui:hyperlinkViewerScore40
     a shui:WidgetScore ;
     shui:widget shui:HyperlinkViewer ;
-    shui:score 30 ;
+    shui:score 40 ;
     shui:dataGraphShape shui:isAnyURIOrString ;
     shui:shapesGraphShape shui:prefersHyperlinkViewer ;
 .

--- a/shacl12-ui/widgets/viewers/image-viewer.ttl
+++ b/shacl12-ui/widgets/viewers/image-viewer.ttl
@@ -2,10 +2,10 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-shui:imageViewerScore30
+shui:imageViewerScore40
     a shui:WidgetScore ;
     shui:widget shui:ImageViewer ;
-    shui:score 30 ;
+    shui:score 40 ;
     shui:shapesGraphShape shui:prefersImageViewer ;
 .
 

--- a/shacl12-ui/widgets/viewers/iri-viewer.ttl
+++ b/shacl12-ui/widgets/viewers/iri-viewer.ttl
@@ -2,10 +2,10 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-shui:iriViewerScore30
+shui:iriViewerScore40
     a shui:WidgetScore ;
     shui:widget shui:IRIViewer ;
-    shui:score 30 ;
+    shui:score 40 ;
     shui:dataGraphShape shui:isIRI ;
     shui:shapesGraphShape shui:prefersIRIViewer ;
 .

--- a/shacl12-ui/widgets/viewers/label-viewer.ttl
+++ b/shacl12-ui/widgets/viewers/label-viewer.ttl
@@ -2,10 +2,10 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-shui:labelViewerScore30
+shui:labelViewerScore40
     a shui:WidgetScore ;
     shui:widget shui:LabelViewer ;
-    shui:score 30 ;
+    shui:score 40 ;
     shui:dataGraphShape shui:isIRI ;
     shui:shapesGraphShape shui:prefersLabelViewer ;
 .

--- a/shacl12-ui/widgets/viewers/lang-string-viewer.ttl
+++ b/shacl12-ui/widgets/viewers/lang-string-viewer.ttl
@@ -2,10 +2,10 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-shui:langStringViewerScore30
+shui:langStringViewerScore40
     a shui:WidgetScore ;
     shui:widget shui:LangStringViewer ;
-    shui:score 30 ;
+    shui:score 40 ;
     shui:shapesGraphShape shui:prefersLangStringViewer ;
 .
 

--- a/shacl12-ui/widgets/viewers/literal-viewer.ttl
+++ b/shacl12-ui/widgets/viewers/literal-viewer.ttl
@@ -2,10 +2,10 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-shui:literalViewerScore30
+shui:literalViewerScore40
     a shui:WidgetScore ;
     shui:widget shui:LiteralViewer ;
-    shui:score 30 ;
+    shui:score 40 ;
     shui:shapesGraphShape shui:prefersLiteralViewer ;
 .
 

--- a/shacl12-ui/widgets/viewers/value-table-viewer.ttl
+++ b/shacl12-ui/widgets/viewers/value-table-viewer.ttl
@@ -2,10 +2,10 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX shui: <http://www.w3.org/ns/shacl-ui/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-shui:valueTableViewerScore30
+shui:valueTableViewerScore40
     a shui:WidgetScore ;
     shui:widget shui:ValueTableViewer ;
-    shui:score 30 ;
+    shui:score 40 ;
     shui:shapesGraphShape shui:prefersValueTableViewer ;
 .
 


### PR DESCRIPTION
## Summary

Follow-up work to #994, which restructured the widget scoring system (score function + accept function + mandatory scoring-graph preparation). The commits are independent and reviewable in isolation.

### Migrate `-1` widget scores to `shui:WidgetAcceptMatcher`
Replaces the `shui:score -1` "do not use" signal with `shui:WidgetAcceptMatcher` on the four text-field / text-area editors, inverting the `sh:singleLine` condition. Adds the negated shapes to `score-shapes.ttl`, a `shui:AcceptMatcherShape` to `score-validator.ttl`, and accept-matcher notes plus a validation section
covering both matcher kinds to the spec.

### Align built-in viewer scores with the default of 40
Raises the ten viewers' declared (`shui:viewer`) scores from 30 to 40, matching the editors and `shui:defaultWidgetScore` so a synthesised custom-viewer score no longer outranks a built-in viewer's declared score.

### Restrict widget declarations to IRIs
Tightens `shui:widget` in `ScoreShape` from `sh:BlankNodeOrIRI` to `sh:IRI` and limits scoring-graph preparation step 3.1 to IRI-valued declarations, since a blank node in `sh:hasValue` cannot match reliably across graphs.

### Fix `shui:DatePickerEditor` widget scores
Sets the declared entry to 40 (was 20, ranking below the native-date match) and the native-date entry to 20, so instance names match their scores.

### Document scoring band conventions
Adds a Score Conventions subsection describing the built-in widget bands (40/30/20/10/1/0), global comparison with lexicographic tie-breaking, and expressing non-applicability with a `shui:WidgetAcceptMatcher` rather than a
negative score.

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/ui/scoring-followups/shacl12-ui/index.html)
