### PR TITLE
#1094: Fix dark mode contrast of algorithm blocks

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -129,8 +129,8 @@
           padding-right:     0.5em;
       }
       .darkmode .algorithm {
-          background:        #808080 ;
-          border-color:      #aaaaaa ;
+          background:        #2b2b2b ;
+          border-color:      #55595f ;
       }
 
       /* Block to go inside <aside> "example" */


### PR DESCRIPTION
Editorial item from #1094: the algorithm pseudocode is unreadable in dark mode.
Was able to reproduce the issue with system dark mode.

I'm not familiar with css for darkmode. A two line LLM change seems to resolve this. Tested on chrome and firefox.

`.darkmode .algorithm` set a `#808080` background. The highlight.js dark palette
is designed for a near-black background, so its text sits at 1.85:1 against
mid-grey; WCAG AA requires 4.5:1.

Darkened to `#2b2b2b` — the dark background already used by `.syntax` — with the
border adjusted to match. Measured after: 6.6:1. Affects all seven algorithm
blocks; light mode unchanged.

Does not close issue #1094; the other three items are untouched.
