### PR TITLE
Fix conformsToShape empty-input test to use an actually-unbound variable

### DIFF
--- a/shacl12-test-suite/tests/node-expr/shnex/conformsToShape.ttl
+++ b/shacl12-test-suite/tests/node-expr/shnex/conformsToShape.ttl
@@ -58,7 +58,7 @@ ex:ValidInstance
   rdfs:label "Test of shnex:conformsToShape where the node argument is empty (no focus node bound)" ;
   mf:action [
     sht:nodeExpr [
-      shnex:conformsToShape ( [ shnex:var "focusNode" ] ex:Shape ) ;
+      shnex:conformsToShape ( [ shnex:var "unbound" ] ex:Shape ) ;
     ] ;
   ] ;         
   mf:result () ;       


### PR DESCRIPTION
The conformsToShape-empty-input test used `shnex:var "focusNode"` to produce an empty `node` argument for shnex:conformsToShape. But "focusNode" is a reserved variable name that evalExpr always resolves to the current focus node (see shacl12-node-expr/index.html, the var node expression algorithm, and the var-focusNode test in var.ttl) - so it can never be unbound/empty, and the test didn't exercise the case it claimed to.

Use `shnex:var "unbound"` instead, matching the var-unbound test in var.ttl.

<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->
