### PR TITLE
Issue 1094 remaining items

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -2378,11 +2378,6 @@ define evalRuleElements(B, SEQ, G, GD):
             endfor
         endif
 
-        if SEQ1 is empty
-            SEQ = {}
-            return SEQ
-        endif
-
         SEQ = SEQ1
     endfor
 

--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -2215,6 +2215,14 @@ merge(S1, S2) = { <var>μ</var> |
               </p>
             </div>
           </dd>
+
+          <dt><dfn
+                data-cite="sparql12-query#ebv"
+                >Effective boolean value</dfn></dt>
+          <dd>
+            The function `EBV(x)` returns the effective boolean value
+            for an [=RDF term=].
+          </dd>
         </dl>
       </section>
 
@@ -2287,12 +2295,6 @@ enddefine
 
 </pre>
         </div>
-
-        <p>
-          The function `EBV(x)` returns the 
-          <a data-cite="sparql12-query#ebv">effective boolean value</a>
-          for an RDF term.
-        </p>
       </section>
 
       <section id="eval-rule">

--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -321,46 +321,6 @@
         processors handle non-conforming [=rule sets=].
       </p>
 
-      <section id="defined-version-labels">
-        <h3>Version Labels</h3>
-        <p>
-          A <dfn>version label</dfn> is a string that identifies the syntax and semantics conformance
-          for the Shape Rules Language.
-        </p>
-
-        <table id="tab-version-labels" class="simple">
-          <caption>Version Labels</caption>
-          <thead>
-            <tr>
-              <th style="text-align: center">Version Label</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>"1.2"</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <p>
-          The version announcement SHOULD be made early in the document.
-        </p>
-
-        <p>
-          Multiple version directives may appear in a [=Shape Rules Language Document=].
-          Each directive applies to the part of the document following the directive,
-          until another directive is encountered or the end of the document is reached.
-        </p>
-
-        <p>
-          [=Version labels=] can also be given by the `version` parameter of the 
-          <a href=#mediaType>Media Type</a>. In the absence of a current
-          version directive, the version specified as part of the Media Type is
-          considered.
-        </p>
-        
-      </section>
-
     </section>
 
     <section id="overview" class="informative">
@@ -2083,6 +2043,47 @@ PREFIX srl:    &lt;http://www.w3.org/ns/shacl-rules#&gt;
 
       </section>
 
+      <section id="version-announcement">
+        <h3>Version Announcement</h3>
+        <p>
+          A <dfn>version label</dfn> is a string that identifies the syntax and semantics conformance
+          for the Shape Rules Language.
+        </p>
+
+        <table id="tab-version-labels" class="simple">
+          <caption>Version Labels</caption>
+          <thead>
+            <tr>
+              <th style="text-align: center">Version Label</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>"1.2"</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>
+          The version announcement SHOULD be made early in the document.
+        </p>
+
+        <p>
+          Multiple <a href="#rVersionDecl"><code>VERSION</code></a> directives
+          may appear in a [=Shape Rules Language Document=].
+          Each directive applies to the part of the document following the directive,
+          until another directive is encountered or the end of the document is reached.
+        </p>
+
+        <p>
+          [=Version labels=] can also be given by the `version` parameter of the
+          <a href=#mediaType>Media Type</a>. In the absence of a current
+          <a href="#rVersionDecl"><code>VERSION</code></a> directive, the
+          version specified as part of the Media Type is considered.
+        </p>
+
+      </section>
+
     </section>
 
     <section id="rule-set-evaluation">
@@ -3285,7 +3286,7 @@ the result is GI
           <dd>
             This parameter is optional.
             If present, acceptable values of <code>version</code> are defined in
-            <a href="#defined-version-labels">Version Labels</a>.
+            <a href="#tab-version-labels">Version Labels</a>.
           </dd>
           <dt><code>profile</code></dt>
           <dd>


### PR DESCRIPTION
[See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-1094-remaining-items/shacl12-rules/index.html)

The three remaining editorial items from #1094; the fourth (dark mode
contrast) was merged in #1125.

- **Version Labels** moved out of Conformance into section 5, as 5.3
  "Version Announcement". SPARQL 1.2 places the equivalent material in its 
  syntax section (4.3), not in Conformance. "version directive" now reads 
  "VERSION directive", linked to the VersionDecl production, similar to how
 BASE is written in 7.3.

- **EBV** description moved from the end of 6.3 into the 6.1 definition list,
  alongside the other helpers the 6.4 algorithm uses. It was the only one
  defined outside 6.1, and it trailed an algorithm that does not use it.

- **`if SEQ1 is empty`** early return removed from evalRuleElements. It is an
  optimization rather than a semantic condition.

All three are editorial; behaviour and normative content are unchanged. More 
details on alternatives considered in the commit messages - 1 per issue above.

Closes #1094
