### PR TITLE
Remove redundant dfn attributes in shacl12-ui

### DIFF
--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -258,11 +258,11 @@
         </dl>
         <p>
           The SHACL &amp; RDF terms include:
-          <dfn data-lt="bindings">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-binding">binding</a>
           </dfn>
           ,
-          <dfn data-lt="blank nodes">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-blank-node">blank node</a>
           </dfn>
           ,
@@ -270,29 +270,29 @@
             <a href="https://www.w3.org/TR/shacl/#dfn-conforms">conformance</a>
           </dfn>
           ,
-          <dfn data-lt="constraints">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-constraint">constraint</a>
           </dfn>
           ,
-          <dfn data-lt="constraint components">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-constraint-component"
               >constraint component</a
             >
           </dfn>
           ,
-          <dfn data-lt="data graphs">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-data-graph">data graph</a>
           </dfn>
           ,
-          <dfn data-lt="datatypes">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-datatype">datatype</a>
           </dfn>
           ,
-          <dfn data-lt="failures">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-failure">failure</a>
           </dfn>
           ,
-          <dfn data-lt="focus nodes">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-focus-node">focus node</a>
           </dfn>
           ,
@@ -306,19 +306,19 @@
             ></dfn
           >
           ,
-          <dfn data-lt="IRIs"
+          <dfn
             ><a href="https://www.w3.org/TR/shacl/#dfn-iri">IRI</a></dfn
           >
           ,
-          <dfn data-lt="literals">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-literal">literal</a>
           </dfn>
           ,
-          <dfn data-lt="local names">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-local-name">local name</a>
           </dfn>
           ,
-          <dfn data-lt="members">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-members">member</a>
           </dfn>
           ,
@@ -326,15 +326,15 @@
             <a href="https://www.w3.org/TR/shacl/#dfn-node">node</a>
           </dfn>
           ,
-          <dfn data-lt="node shapes">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-node-shape">node shape</a>
           </dfn>
           ,
-          <dfn data-lt="objects">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-object">object</a>
           </dfn>
           ,
-          <dfn data-lt="parameters">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-parameters">parameter</a>
           </dfn>
           ,
@@ -342,17 +342,17 @@
             <a href="https://www.w3.org/TR/shacl/#pre-binding">pre-binding</a>
           </dfn>
           ,
-          <dfn data-lt="predicates">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-predicate">predicate</a>
           </dfn>
           ,
-          <dfn data-lt="property paths">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-shacl-property-path"
               >property path</a
             >
           </dfn>
           ,
-          <dfn data-lt="property shapes">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-property-shape"
               >property shape</a
             >
@@ -362,45 +362,45 @@
             <a href="https://www.w3.org/TR/shacl/#dfn-rdf-term">RDF term</a>
           </dfn>
           ,
-          <dfn data-lt="SHACL instances">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-shacl-instance"
               >SHACL instance</a
             >
           </dfn>
           ,
-          <dfn data-lt="SHACL lists">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-shacl-list">SHACL list</a>
           </dfn>
           ,
-          <dfn data-lt="SHACL subclasses">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-shacl-subclass"
               >SHACL subclass</a
             >
           </dfn>
           ,
-          <dfn data-lt="shapes">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-shape">shape</a>
           </dfn>
           ,
-          <dfn data-lt="shapes graphs">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-shapes-graph"
               >shapes graph</a
             >
           </dfn>
           ,
-          <dfn data-lt="solutions">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-solution">solution</a>
           </dfn>
           ,
-          <dfn data-lt="subjects">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-subject">subject</a>
           </dfn>
           ,
-          <dfn data-lt="targets">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-target">target</a>
           </dfn>
           ,
-          <dfn data-lt="triples">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-rdf-triple">triple</a>
           </dfn>
           ,
@@ -410,27 +410,27 @@
             ></dfn
           >
           ,
-          <dfn data-lt="validation reports">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-validation-report"
               >validation report</a
             >
           </dfn>
           ,
-          <dfn data-lt="validation results">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-validation-results"
               >validation result</a
             >
           </dfn>
           ,
-          <dfn data-lt="validators">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-validators">validator</a>
           </dfn>
           ,
-          <dfn data-lt="values">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-value">value</a>
           </dfn>
           ,
-          <dfn data-lt="value nodes">
+          <dfn>
             <a href="https://www.w3.org/TR/shacl/#dfn-value-nodes"
               >value node</a
             >
@@ -440,7 +440,7 @@
         <div class="def">
           <div class="term-def-header">Language Resolution</div>
           <div>
-            <dfn data-lt="language resolution">Language Resolution</dfn> is the process of determining and ordering the
+            <dfn>Language Resolution</dfn> is the process of determining and ordering the
             values associated with a given subject-predicate pair, prioritizing the preferred or most relevant language
             value for display.
           </div>
@@ -448,7 +448,7 @@
         <div class="def">
           <div class="term-def-header">Label Resolution</div>
           <div>
-            <dfn data-lt="label resolution">Label Resolution</dfn> is the process of selecting the most appropriate
+            <dfn>Label Resolution</dfn> is the process of selecting the most appropriate
             display label for an RDF resource, or generating a fallback value when no suitable value exists. It
             applies to both value nodes and properties identified by <code>sh:path</code>, the latter of which is commonly used to label form elements.
 
@@ -1152,7 +1152,7 @@ ex:PersonShapeNameGroup a sh:PropertyGroup ;
       <section id="renderer">
         <h3>SHACL Renderer</h3>
         <p>
-          A <dfn data-plurals="SHACL Renderers" id="dfn-shacl-renderer" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">SHACL Renderer</dfn>
+          A <dfn>SHACL Renderer</dfn>
           is software that processes SHACL
             <a>shapes</a> and data and dynamically generates a user-interface using one
             or more <a>node UI components</a>. Implementations may add supplementary UI elements, such as a submit
@@ -1183,7 +1183,7 @@ ex:PersonShapeNameGroup a sh:PropertyGroup ;
         <h3>Node UI Component</h3>
 
         <div>
-          A <dfn data-plurals="Node UI Components" id="dfn-node-ui-component" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Node UI Component</dfn> is generated from a single <a>focus node</a>,
+          A <dfn>Node UI Component</dfn> is generated from a single <a>focus node</a>,
           typically containing one or more <a>property UI components</a>. It is often derived from one or more
           <a>node shapes</a> that apply to the <a>focus node</a>.
         </div>
@@ -1193,7 +1193,7 @@ ex:PersonShapeNameGroup a sh:PropertyGroup ;
         <h3>Property UI Component</h3>
 
         <div>
-            A <dfn data-plurals="Property UI Components" id="dfn-property-ui-component" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Property UI Component</dfn> is a combination of <a>constraints</a>
+            A <dfn>Property UI Component</dfn> is a combination of <a>constraints</a>
             across multiple <a>property shapes</a> that share the same <a>focus node</a> and <a>property path</a>.
           </div>
       </section>
@@ -2308,7 +2308,7 @@ ex:book1 a ex:Book ;
       </p>
 
       <p>
-        The <dfn data-lt="effective orders">effective order</dfn> of a <a>property shape</a> or
+        The <dfn>effective order</dfn> of a <a>property shape</a> or
         property group is the value of its <code>sh:order</code>. Where <code>sh:order</code> is not
         specified, the <a>effective order</a> is the value of <code>shui:defaultOrder</code> in the
         <a>global configuration</a>, if present. Otherwise the property shape or property group has


### PR DESCRIPTION
Respec automatically generates the plural linking text, so data-lt values that were just the term with an "s" appended are dropped. The data-plurals, id, tabindex, aria-haspopup, and data-dfn-type attributes on the SHACL Renderer, Node UI Component, and Property UI Component dfns were leftover copies from the render version and are not needed here.

<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/ui/dfn-cleanup/shacl12-ui/index.html)
