### PR TITLE
Accept rdf:dirLangString where rdf:langString is defined (#613)

### DIFF
--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -635,6 +635,15 @@
           SHACL Renderers implementing this specification MUST support RDF 1.1 and SHOULD support RDF 1.2. When RDF 1.2 is supported, and unless
           stated otherwise in this document, implementations SHOULD prefer RDF 1.2 syntax and data model features over their RDF 1.1 counterparts.
         </p>
+
+        <p>
+          When RDF 1.2 is supported, wherever this specification refers to <code>rdf:langString</code>, a SHACL Renderer also accepts an
+          <code>rdf:dirLangString</code> value in its place. This acceptance is a SHACL UI convenience that applies to widget selection and form
+          input only; it does not establish an RDF subtype relationship between the two datatypes, whose value spaces (and lexical spaces) are
+          disjoint. Validation via <code>sh:datatype</code> remains strict: the value a widget writes back MUST conform to the datatype declared
+          for the property, and a property shape that admits both datatypes for validation expresses this using a list of datatypes, for example
+          <code>sh:datatype ( rdf:langString rdf:dirLangString )</code>.
+        </p>
       </section>
     </section>
 
@@ -2927,14 +2936,15 @@ ex:Country-description
             <b>Score:</b>
             <ul>
               <li>`40` if the property indicates its preference for `shui:TextAreaWithLangEditor` using a `shui:editor` statement.</li>
-              <li>`30` if the value is an `rdf:langString` literal and the property has a `sh:singleLine false` constraint.</li>
-              <li>`20` if the value is an `rdf:langString` literal.</li>
-              <li>`5` if the property has `rdf:langString` among the permissible datatypes.</li>
+              <li>`30` if the value is an `rdf:langString` or `rdf:dirLangString` literal and the property has a `sh:singleLine false` constraint.</li>
+              <li>`20` if the value is an `rdf:langString` or `rdf:dirLangString` literal.</li>
+              <li>`5` if the property has `rdf:langString` or `rdf:dirLangString` among the permissible datatypes.</li>
               <li>`0` if the property has `xsd:string` among the permissible datatypes.</li>
             </ul>
           <p>
             <b>Rendering:</b>
             A multi-line text area to enter the value of a literal and a drop-down to select a language.
+            For an `rdf:dirLangString` value, it also provides a base-direction selector.
           </p>
           <img src="images/editors/TextAreaWithLangEditor.png" alt="Example of a rendered TextAreaWithLangEditor"/>
           <pre class="example">
@@ -2979,14 +2989,15 @@ ex:Country-code
             <b>Score:</b>
             <ul>
               <li>`40` if the property indicates its preference for `shui:TextFieldWithLangEditor` using a `shui:editor` statement.</li>
-              <li>`30` if the value is an `rdf:langString` literal.</li>
-              <li>`10` if the property has `rdf:langString` among the permissible datatypes.</li>
+              <li>`30` if the value is an `rdf:langString` or `rdf:dirLangString` literal.</li>
+              <li>`10` if the property has `rdf:langString` or `rdf:dirLangString` among the permissible datatypes.</li>
               <li>`1` if the property has `xsd:string` among the permissible datatypes.</li>
             </ul>
           <p>
             <b>Rendering:</b>
             A single-line input field to enter the value of a literal and a drop-down to select language,
             which is mandatory unless `xsd:string` is among the permissible datatypes.
+            For an `rdf:dirLangString` value, it also provides a base-direction selector.
           </p>
           <img src="images/editors/TextFieldWithLangEditor.png" alt="Example of a rendered TextFieldWithLangEditor"/>
           <pre class="example">
@@ -3112,11 +3123,12 @@ ex:Concept-prefLabel
             <b>Score:</b>
             <ul>
               <li>`40` if the property indicates its preference for `shui:LangStringViewer` using a `shui:viewer` statement.</li>
-              <li>`20` if the value is an `rdf:langString` literal.</li>
+              <li>`20` if the value is an `rdf:langString` or `rdf:dirLangString` literal.</li>
             </ul>
           <p>
             <b>Rendering:</b>
             As the text plus a language indicator (flag or language tag).
+            For an `rdf:dirLangString` value, the base direction is applied to the rendered text and indicated as well.
           </p>
         </section>
         <section id="LiteralViewer">
@@ -3199,7 +3211,7 @@ ex:ConceptTableShape-altLabel
     sh:path skos:altLabel ;
     sh:description "The third column shows the alternative labels." ;
     sh:name "alt labels" ;
-    sh:or ( [ sh:datatype xsd:string ] [ sh:datatype rdf:langString ] ) ;
+    sh:datatype ( xsd:string rdf:langString ) ;
     sh:order "2"^^xsd:decimal .</pre>
         </section>
       </section>

--- a/shacl12-ui/widgets/editors/text-area-with-lang-editor.ttl
+++ b/shacl12-ui/widgets/editors/text-area-with-lang-editor.ttl
@@ -37,6 +37,13 @@ shui:textAreaWithLangEditorScore5
     shui:shapesGraphShape shui:hasDatatypeLangStringConstraint ;
 .
 
+shui:textAreaWithLangEditorScore5DirLang
+    a shui:WidgetScore ;
+    shui:widget shui:TextAreaWithLangEditor ;
+    shui:score 5 ;
+    shui:shapesGraphShape shui:hasDatatypeDirLangStringConstraint ;
+.
+
 shui:textAreaWithLangEditorScore0
     a shui:WidgetScore ;
     shui:widget shui:TextAreaWithLangEditor ;

--- a/shacl12-ui/widgets/editors/text-field-with-lang-editor.ttl
+++ b/shacl12-ui/widgets/editors/text-field-with-lang-editor.ttl
@@ -29,6 +29,13 @@ shui:textFieldWithLangEditorScore10
     shui:shapesGraphShape shui:hasDatatypeLangStringConstraint ;
 .
 
+shui:textFieldWithLangEditorScore10DirLang
+    a shui:WidgetScore ;
+    shui:widget shui:TextFieldWithLangEditor ;
+    shui:score 10 ;
+    shui:shapesGraphShape shui:hasDatatypeDirLangStringConstraint ;
+.
+
 shui:textFieldWithLangEditorScore1
     a shui:WidgetScore ;
     shui:widget shui:TextFieldWithLangEditor ;

--- a/shacl12-ui/widgets/score-shapes.ttl
+++ b/shacl12-ui/widgets/score-shapes.ttl
@@ -69,7 +69,7 @@ shui:isString
 
 shui:isLangString
     a sh:NodeShape ;
-    sh:datatype rdf:langString ;
+    sh:datatype ( rdf:langString rdf:dirLangString ) ;
 .
 
 shui:isAnyURI
@@ -236,6 +236,15 @@ shui:hasDatatypeLangStringConstraint
         sh:path sh:datatype ;
         sh:minCount 1 ;
         sh:hasValue rdf:langString ;
+    ] ;
+.
+
+shui:hasDatatypeDirLangStringConstraint
+    a sh:NodeShape ;
+    sh:property [
+        sh:path sh:datatype ;
+        sh:minCount 1 ;
+        sh:hasValue rdf:dirLangString ;
     ] ;
 .
 


### PR DESCRIPTION
Closes #613

Following the WG discussion in #613 (resolved with @afs and @TallTed), this PR states that an `rdf:dirLangString` value is accepted wherever the SHACL 1.2 UI specification refers to `rdf:langString`.

This is a **SHACL UI convenience** (covariance / "casting") that applies to **widget selection and form input only** — it is **not** an RDF subtype relationship. The two datatypes have **disjoint value and lexical spaces** (pairs vs. 3-tuples), so no subtyping holds in either direction. Validation via `sh:datatype` remains **strict**: the value a widget writes back must conform to the declared datatype, and a shape that admits both datatypes for validation expresses this using `sh:or`. Acceptance is one-directional and conditional on RDF 1.2 support.

### Changes

**Prose (`shacl12-ui/index.html`)**
- Added a general statement in the *RDF Abstract Model Compatibility* section (`#compatibility`).
- Updated the widget scoring rule wording that named only `rdf:langString` to also name `rdf:dirLangString`, for `shui:TextAreaWithLangEditor`, `shui:TextFieldWithLangEditor`, and `shui:LangStringViewer`.
- Extended the rendering descriptions of those three widgets to cover `rdf:dirLangString`: the editors provide a base-direction selector, and the viewer applies and indicates the base direction.

**Machine-readable scoring graph (`shacl12-ui/widgets/`)**
- `score-shapes.ttl`: added shapes `shui:isDirLangString` and `shui:hasDatatypeDirLangStringConstraint`.
- Added parallel `shui:WidgetScore` instances — with the **same score values** — keyed on `sh:datatype rdf:dirLangString`:
  - `text-field-with-lang-editor.ttl`: scores 30, 10
  - `text-area-with-lang-editor.ttl`: scores 30, 20, 5
  - `viewers/lang-string-viewer.ttl`: score 20

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-613-accept-dirlangstring/shacl12-ui/index.html)
