### PR TITLE
[SRL] Fix reSpec validation errors

### DIFF
--- a/shacl12-rules/index.html
+++ b/shacl12-rules/index.html
@@ -298,23 +298,20 @@
 
       <p>This specification defines conformance criteria for:</p>
       <ul>
-        <li><a href="#rule-set-evaluation">SHACL Rule Set evaluation</a></li>
-        <li><a href="#shape-rules-syntax">Shape Rules Language</a></li>
+        <li><a href="#rule-set-evaluation">SRL Rule Set evaluation</a></li>
+        <li><a href="#shape-rules-syntax">Shape Rules language syntax</a></li>
       </ul>
 
-      <p>A conforming 
-        <dfn 
-          data-lt="shape rules document|ruleset document"
-          >Shape Rules Language Document</dfn> is an
+      <p>A conforming [=SRL document=] is an
         <a data-cite="RDF12-CONCEPTS#dfn-rdf-string">RDF string</a> that
-        conforms to the grammar, starting with the
+        conforms to the <a href="#grammar">grammar</a> starting with the
         <a href="#rRuleSet"><code>RuleSet</code></a>
-        production, and conforming to the additional constraints defined in
-        <a href="#shapes-rules-grammar" class="sectionRef"></a>
+        production as defined in
+        <a href="#shapes-rules-grammar" class="sectionRef"></a>.
       </p>
 
       <p class="note">
-        This specification does not define how SHACL Rules
+        This specification does not define how SPARQL-RL
         processors handle non-conforming [=rule sets=].
       </p>
     </section>
@@ -2088,7 +2085,7 @@ PREFIX srl:    &lt;http://www.w3.org/ns/shacl-rules#&gt;
 
         <p>
           Multiple <a href="#rVersionDecl"><code>VERSION</code></a> directives
-          may appear in a [=Shape Rules Language Document=].
+          may appear in a [=SPARQL-RL Document=].
           Each directive applies to the part of the document following the directive,
           until another directive is encountered or the end of the document is reached.
         </p>
@@ -2131,8 +2128,7 @@ Output: an RDF graph GI of inferred triples
                 data-lt="solution mapping|solution"
                 >Solution mapping</dfn></dt>
           <dd> 
-            A <a data-lt="sparql12-query#defn_sparqlSolutionMapping">Solution mapping</a>, 
-            <var>μ</var>, is a partial function 
+            A [=solution mapping=], <var>μ</var>, is a partial function 
             <code><var>μ</var> : <var>V</var> → <var>T</var></code>,
             where <var>V</var> is the set of all variables 
             and <var>T</var> is the set of all [=RDF terms=].
@@ -2938,9 +2934,12 @@ the result is GI
       <h2>Shape Rules Language Grammar</h2>
 
       <p>
-        A <dfn data-lt="SRL document">Shape Rules Language document</dfn>
+        A <dfn data-lt="SRL document">SPARQL-RL Document</dfn>
         is an <a data-cite="RDF12-CONCEPTS#dfn-rdf-string">RDF string</a>
-        encoded in UTF-8 [[!RFC3629]].
+        encoded in UTF-8 [[!RFC3629]] and starting with the
+        <a href="#rRuleSet"><code>RuleSet</code></a>
+        production and conforming to the additional constraints defined in
+        <a href="#grammar" class="sectionRef"></a>.
         Only <a data-cite="I18N-GLOSSARY#dfn-scalar-value" class="lint-ignore">Unicode scalar values</a>,
         in the ranges <code class="codepoint">U+0000</code> to <code class="codepoint">U+D7FF</code> 
         and <code class="codepoint">U+E000</code> to <code class="codepoint">U+10FFFF</code>,
@@ -3004,8 +3003,9 @@ the result is GI
           defines how the In-Scope Base IRI may come from an encapsulating document,
           such as a SOAP envelope with an `xml:base` directive or a MIME multipart document with a
           `Content-Location` header.
-          The "Retrieval URI" identified in <a data-cite="RFC3986#section-5.1.3">5.1.3, Base "URI from the Retrieval URI"</a>,
-          is the URL from which a particular <a>Shape Rules Language document</a> was retrieved.
+          The "Retrieval URI" identified in <a data-cite="RFC3986#section-5.1.3"
+                                               >5.1.3, Base "URI from the Retrieval URI"</a>,
+          is the URL from which a particular <a>SPARQL-RL document</a> was retrieved.
           If none of the above specifies the Base URI, the default
           Base URI (<a data-cite="RFC3986#section-5.1.4">section 5.1.4, "Default Base URI"</a>) is used.
           Each <a href="#rBaseDecl"><code>BASE</code></a> directive sets a new In-Scope Base URI,
@@ -3017,8 +3017,8 @@ the result is GI
         <h3>Escape Sequences</h3>
 
         <p>
-          There are three forms of escapes used in 
-          <a href="#dfn-shape-rules-document">Shape Rules documents</a>:
+          There are three forms of escapes used in
+          <a href="#dfn-srl-document">SRL documents</a>:
         </p>
 
         <ul>


### PR DESCRIPTION
Fix errors in valifation from the GH action

"Duplicate definition(s) of 'shape rules language document'"

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/srl-validation/shacl12-rules/index.html)
