### PR TITLE
Extend shui:hasDatatypeNumericConstraint with more numeric datatypes

### DIFF
--- a/shacl12-ui/widgets/score-shapes.ttl
+++ b/shacl12-ui/widgets/score-shapes.ttl
@@ -293,6 +293,33 @@ shui:hasDatatypeNumericConstraint
             [
                 sh:hasValue xsd:float ;
             ]
+            [
+                sh:hasValue xsd:short ; # -32768 - 32767
+            ]
+            [
+                sh:hasValue xsd:byte ; # -128 - 127
+            ]
+            [
+                sh:hasValue xsd:nonNegativeInteger ;
+            ]
+            [
+                sh:hasValue xsd:long ; # -9223372036854775808 - 9223372036854775807
+            ]
+            [
+                sh:hasValue xsd:int ; # -2147483648 - 2147483647
+            ]
+            [
+                sh:hasValue xsd:unsignedShort ; # 0 - 65535
+            ]
+            [
+                sh:hasValue xsd:unsignedByte ; # 0 - 255
+            ]
+            [
+                sh:hasValue xsd:unsignedInt ; # 0 - 4294967295
+            ]
+            [
+                sh:hasValue xsd:unsignedLong ; # 0 - 18446744073709551615
+            ]
         ) ;
     ] ;
 .


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #1145 

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/{BRANCH_NAME}/{FOLDER}/index.html)