### PR TITLE
#1159: Added definition of sh:TripleRule

### DIFF
--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2018,7 +2018,7 @@ ex:Cougar
 			<p>
 				The <a>SHACL rules</a> feature defined in this section includes a general framework using the properties
 				such as <code>sh:rule</code> and <code>sh:condition</code>, plus an extension mechanism for specific <a>rule types</a>.
-				This document defines one such rule type: <a>SPARQL rules</a>.
+				This document defines two such rule types: <a>SPARQL rules</a> and <a>triple rules</a>.
 			</p>
 			
 			<section id="rules-examples" class="informative">
@@ -2779,6 +2779,159 @@ _:id sh:sourceRule ex:SymmetricPropertyRule .</pre>
 					Since <a>global</a> SPARQL rules do not use <a>pre-binding</a>, the syntax limitations
 					mentioned in <a href="#pre-binding"></a> do not apply to them.
 				</p>
+			</section>
+			<section id="TripleRule">
+				<h3>Triple Rules</h3>
+				<p>
+					This section defines a <a>rule type</a> called <dfn data-lt="triple rule">triple rules</dfn>, identified by
+					the <a>IRI</a> <code>sh:TripleRule</code>.
+					<a>Triple rules</a> have the following properties:
+				</p>
+				<table class="term-table">
+					<tr>
+						<th>Property</th>
+						<th>Summary and Syntax Rules</th>
+					</tr>
+					<tr>
+						<td><code>sh:subject</code></td>
+						<td>
+							The <a>node expression</a> used to compute the <a>subjects</a> of the <a>triples</a>.
+							<span data-syntax-rule="TripleRule-subject">Each <a>triple rule</a> must have at most one
+							<a>value</a> of the property <code>sh:subject</code> (which must be a well-formed <a>node expression</a>).
+							</span>
+						</td>
+					</tr>
+					<tr>
+						<td><code>sh:predicate</code></td>
+						<td>
+							The <a>node expression</a> used to compute the <a>predicates</a> of the <a>triples</a>.
+							<span data-syntax-rule="TripleRule-predicate">Each <a>triple rule</a> must have at most one
+							<a>value</a> of the property <code>sh:predicate</code> (which must be a well-formed <a>node expression</a>).
+							</span>
+						</td>
+					</tr>
+					<tr>
+						<td><code>sh:object</code></td>
+						<td>
+							The <a>node expression</a> used to compute the <a>objects</a> of the <a>triples</a>.
+							<span data-syntax-rule="TripleRule-object">Each <a>triple rule</a> must have at most one
+							<a>value</a> of the property <code>sh:object</code> (which must be a well-formed <a>node expression</a>).
+							</span>
+						</td>
+					</tr>
+				</table>
+				<div class="def def-text">
+					<div class="def-header">EXECUTION OF TRIPLE RULES</div>
+					<div class="def-text-body">
+						Let <code>S</code>, <code>P</code> and <code>O</code> be the sets of <a>nodes</a> produced by evaluating
+						the <a>node expressions</a> that are the values of <code>sh:subject</code>, <code>sh:predicate</code>
+						and <code>sh:object</code> respectively at the <a>triple rule</a>.
+						Where <code>sh:subject</code>, <code>sh:predicate</code>, or <code>sh:object</code> are absent, use
+						the list consisting of the current <a>focus node</a>.
+						For each combination of members <code>s</code> of <code>S</code>, <code>p</code> of <code>P</code> and
+						<code>o</code> of <code>O</code>, <a>infer</a> a <a>triple</a> with <a>subject</a> <code>s</code>,
+						<a>predicate</a> <code>p</code> and <a>object</a> <code>o</code>.
+						Skip ill-formed <a>triples</a>, for example when a <a>blank node</a> is used as <a>predicate</a>.
+					</div>
+				</div>
+				<aside class="example" title="An example triple rule computing instances of Square" id="TripleRule-Rectangle-example">
+					<p>
+						In this example, any instance of `ex:Rectangle` where the width equals the height
+						will receive an extra `rdf:type ex:Square` triple.
+					</p>
+					<div class="shapes-graph">
+						<div class="turtle">
+ex:Rectangle
+	a sh:ShapeClass ;
+	rdfs:label "Rectangle" ;
+	sh:property [
+		sh:path ex:height ;
+		sh:datatype xsd:integer ;
+		sh:maxCount 1 ;
+		sh:minCount 1 ;
+		sh:name "height" ;
+	] ;
+	sh:property [
+		sh:path ex:width ;
+		sh:datatype xsd:integer ;
+		sh:maxCount 1 ;
+		sh:minCount 1 ;
+		sh:name "width" ;
+	] ;
+	sh:rule [
+		a sh:TripleRule ;
+		# sh:subject defaults to the current focus node
+		sh:predicate rdf:type ;
+		sh:object ex:Square ;
+		sh:condition ex:Rectangle ;
+		sh:condition [
+			sh:property [
+				sh:path ex:width ;
+				sh:equals ex:height ;
+			] ;
+		] ;
+	] .							
+						</div>
+					</div>
+					<div class="data-graph">
+						<div class="turtle">
+ex:InvalidRectangle
+	a ex:Rectangle .
+
+ex:NonSquareRectangle
+	a ex:Rectangle ;
+	ex:height 2 ;
+	ex:width 3 .
+
+ex:SquareRectangle
+	a ex:Rectangle ;
+	ex:height 4 ;
+	ex:width 4 .
+						</div>
+					</div>
+					<div class="inferences-graph">
+						<div class="turtle">
+ex:SquareRectangle rdf:type ex:Square .
+						</div>
+					</div>
+				</aside>
+				<aside class="example" title="An example triple rule computing the number of children of a Person" id="TripleRule-childCount-example">
+					<p>
+						In this example, a SHACL rules engine will infer a `ex:childCount` triple for any instance of `ex:Person`
+						using a node expression combining `shnex:count` and `shnex:pathValues`.
+					</p>
+					<div class="shapes-graph">
+						<div class="turtle">
+ex:PersonShape
+	a sh:NodeShape ;
+	sh:targetClass ex:Person ;
+	sh:rule ex:PersonShape-childCount-rule .
+
+ex:PersonShape-childCount-rule
+	a sh:TripleRule ;
+	sh:runOnce true ;
+	sh:predicate ex:childCount ;
+	sh:object [
+		shnex:count [
+			shnex:pathValues ex:child
+		]
+	] .
+						</div>
+					</div>
+					<div class="data-graph">
+						<div class="turtle">
+ex:Dad
+	a ex:Person ;
+	ex:child ex:SomeDaughter ;
+	ex:child ex:SomeSon .
+						</div>
+					</div>
+					<div class="inferences-graph">
+						<div class="turtle">
+ex:Dad ex:childCount 2 .
+						</div>
+					</div>
+				</aside>
 			</section>
 		</section>
 

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2827,7 +2827,7 @@ _:id sh:sourceRule ex:SymmetricPropertyRule .</pre>
 						the <a>node expressions</a> that are the values of <code>sh:subject</code>, <code>sh:predicate</code>
 						and <code>sh:object</code> respectively at the <a>triple rule</a>.
 						Where <code>sh:subject</code>, <code>sh:predicate</code>, or <code>sh:object</code> are absent, use
-						the list consisting of the current <a>focus node</a>.
+						the list consisting of the current <a>focus node</a> (which is empty for <a>global rules</a>).
 						For each combination of members <code>s</code> of <code>S</code>, <code>p</code> of <code>P</code> and
 						<code>o</code> of <code>O</code>, <a>infer</a> a <a>triple</a> with <a>subject</a> <code>s</code>,
 						<a>predicate</a> <code>p</code> and <a>object</a> <code>o</code>.

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -2110,10 +2110,10 @@ ex:ExampleRectangle ex:area 56 .
 			<section id="rules-definition">
 				<h2>General Definition of SHACL Rules</h2>
 				<p>
-					The <a>SHACL instances</a> of <code>sh:Rule</code> and its subclass, <code>sh:SPARQLRule</code>,
+					The <a>SHACL instances</a> of <code>sh:Rule</code>, including its subclasses <code>sh:SPARQLRule</code> and <code>sh:TripleRule</code>,
 					are called <dfn data-lt="rule|rules|SHACL rule">SHACL rules</dfn>.
 					SHACL has a flexible, extensible design in which multiple types of rules can be supported,
-					but this document only defines <a>SPARQL rules</a>.
+					but this document only defines two of them: <a>SPARQL rules</a> and <a>triple rules</a>
 					Each <dfn data-lt="rule types">rule type</dfn> is identified by an <a>IRI</a> that is used as
 					their <code>rdf:type</code>.
 					Each rule type also defines <dfn>execution instructions</dfn> that can be implemented by rule engines.

--- a/shacl12-test-suite/tests/sparql/rules/TripleRule-example-childCount.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/TripleRule-example-childCount.ttl
@@ -1,0 +1,50 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix shnex: <http://www.w3.org/ns/shacl-node-expr#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# This example also appears in the SHACL 1.2 SPARQL spec
+
+ex:PersonShape
+	a sh:NodeShape ;
+	sh:targetClass ex:Person ;
+	sh:rule ex:PersonShape-childCount-rule .
+
+ex:PersonShape-childCount-rule
+	a sh:TripleRule ;
+	sh:runOnce true ;
+	sh:predicate ex:childCount ;
+	sh:object [
+		shnex:count [
+			shnex:pathValues ex:child
+		]
+	] .
+
+ex:Dad
+	a ex:Person ;
+	ex:child ex:SomeDaughter ;
+	ex:child ex:SomeSon .
+
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <TripleRule-example-childCount>
+    ) .
+
+<TripleRule-example-childCount>
+  rdf:type sht:Infer ;
+  rdfs:label "Test of a TripleRule to compute childCount from the spec" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result (
+	( ex:Dad ex:childCount 2 )
+	) ;
+  mf:status sht:approved ;
+.

--- a/shacl12-test-suite/tests/sparql/rules/TripleRule-example-squares.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/TripleRule-example-squares.ttl
@@ -1,0 +1,74 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix shnex: <http://www.w3.org/ns/shacl-node-expr#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# This example also appears in the SHACL 1.2 SPARQL spec
+
+ex:Rectangle
+	a sh:ShapeClass ;
+	rdfs:label "Rectangle" ;
+	sh:property [
+		sh:path ex:height ;
+		sh:datatype xsd:integer ;
+		sh:maxCount 1 ;
+		sh:minCount 1 ;
+		sh:name "height" ;
+	] ;
+	sh:property [
+		sh:path ex:width ;
+		sh:datatype xsd:integer ;
+		sh:maxCount 1 ;
+		sh:minCount 1 ;
+		sh:name "width" ;
+	] ;
+	sh:rule [
+		a sh:TripleRule ;
+		# sh:subject defaults to the current focus node
+		sh:predicate rdf:type ;
+		sh:object ex:Square ;
+		sh:condition ex:Rectangle ;
+		sh:condition [
+			sh:property [
+				sh:path ex:width ;
+				sh:equals ex:height ;
+			] ;
+		] ;
+	] .
+
+ex:InvalidRectangle
+	a ex:Rectangle .
+
+ex:NonSquareRectangle
+	a ex:Rectangle ;
+	ex:height 2 ;
+	ex:width 3 .
+
+ex:SquareRectangle
+	a ex:Rectangle ;
+	ex:height 4 ;
+	ex:width 4 .
+
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <TripleRule-example-squares>
+    ) .
+
+<TripleRule-example-squares>
+  rdf:type sht:Infer ;
+  rdfs:label "Test of a TripleRule to classify square rectangles from the spec" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result (
+	( ex:SquareRectangle rdf:type ex:Square )
+	) ;
+  mf:status sht:approved ;
+.

--- a/shacl12-test-suite/tests/sparql/rules/manifest.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/manifest.ttl
@@ -14,5 +14,7 @@
 	mf:include <rectangle-simple.ttl> ;
 	mf:include <run-once-example.ttl> ;
 	mf:include <temp-triples-example.ttl> ;
+	mf:include <TripleRule-example-childCount.ttl> ;
+	mf:include <TripleRule-example-squares.ttl> ;
 	mf:include <rdfs/manifest.ttl> ;
 	.

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1991,6 +1991,34 @@ sh:tempTriple
 	rdfs:range xsd:boolean ;
 	rdfs:isDefinedBy sh: .
 
+sh:TripleRule
+	a rdfs:Class ;
+	rdfs:label "Triple rule"@en ;
+	rdfs:comment "A rule based on triple (subject, predicate, object) pattern."@en ;
+	rdfs:subClassOf sh:Rule ;
+	rdfs:isDefinedBy sh: .
+
+sh:subject
+	a rdf:Property ;
+	rdfs:label "subject"@en ;
+	rdfs:comment "An expression producing the nodes that shall be inferred as subjects. Defaults to the focus node only."@en ;
+	rdfs:domain sh:TripleRule ;
+	rdfs:isDefinedBy sh: .
+
+sh:predicate
+	a rdf:Property ;
+	rdfs:label "predicate"@en ;
+	rdfs:comment "An expression producing the nodes that shall be inferred as predicates. Defaults to the focus node only."@en ;
+	rdfs:domain sh:TripleRule ;
+	rdfs:isDefinedBy sh: .
+
+sh:object
+	a rdf:Property ;
+	rdfs:label "object"@en ;
+	rdfs:comment "An expression producing the nodes that shall be inferred as objects. Defaults to the focus node only."@en ;
+	rdfs:domain sh:TripleRule ;
+	rdfs:isDefinedBy sh: .
+
 
 # -----------------------------------------------------------------------------
 # SHACL ADVANCED FEATURES (will likely be marked deprecated with 1.2)
@@ -2087,31 +2115,3 @@ sh:union
 
 sh:minus
 	rdfs:comment "Deprecated with SHACL 1.2: replaced by shnex:remove."@en .
-
-sh:TripleRule
-	a rdfs:Class ;
-	rdfs:label "Triple rule"@en ;
-	rdfs:comment "A rule based on triple (subject, predicate, object) pattern. Note this is currently not part of a SHACL 1.2 spec but was defined in SHACL-AF 1.1."@en ;
-	rdfs:subClassOf sh:Rule ;
-	rdfs:isDefinedBy sh: .
-
-sh:subject
-	a rdf:Property ;
-	rdfs:label "subject"@en ;
-	rdfs:comment "An expression producing the resources that shall be inferred as subjects."@en ;
-	rdfs:domain sh:TripleRule ;
-	rdfs:isDefinedBy sh: .
-
-sh:predicate
-	a rdf:Property ;
-	rdfs:label "predicate"@en ;
-	rdfs:comment "An expression producing the properties that shall be inferred as predicates."@en ;
-	rdfs:domain sh:TripleRule ;
-	rdfs:isDefinedBy sh: .
-
-sh:object
-	a rdf:Property ;
-	rdfs:label "object"@en ;
-	rdfs:comment "An expression producing the nodes that shall be inferred as objects."@en ;
-	rdfs:domain sh:TripleRule ;
-	rdfs:isDefinedBy sh: .


### PR DESCRIPTION
Closes #1159

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-1159/shacl12-sparql/index.html#TripleRule)

I am aware that more is needed here, including test cases, but that will be much easier once the rules section was moved into its own document, as discussed. Until then, I suggest we put this here so that the document is reasonably feature-complete before the end of the month and the clean up that follows.