### PR TITLE
Post-reorg tidy-up for SRL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ The WG is currently working on updated and new [SHACL](https://www.w3.org/TR/sha
 ##### Editor's drafts
 
 * [SHACL 1.2 Overview](https://w3c.github.io/data-shapes/shacl12-overview/)
-* [SHACL 1.2 Rules](https://w3c.github.io/data-shapes/shacl12-rules/)
 * [SHACL 1.2 UI](https://w3c.github.io/data-shapes/shacl12-ui/)
 * [SHACL 1.2 Compact Syntax](https://w3c.github.io/data-shapes/shacl12-cs/)
 * [SHACL 1.2 Profiling](https://w3c.github.io/data-shapes/shacl12-profiling/)
+* [SPARQL 1.2 RL](https://w3c.github.io/data-shapes/sparql12-rl/)
 
 All of the above specifications are drafts that are automatically rebuilt on pushes to this repository.
 

--- a/shacl12-test-suite/tests/sparql-rl/README.md
+++ b/shacl12-test-suite/tests/sparql-rl/README.md
@@ -20,8 +20,8 @@ The top level manifest is `manifest-sparql-rl.ttl`.
 * [Syntax tests](syntax/)
 * [Evaluation tests](eval/)
 * [Evaluation examples](eval2/)
-* [Starification tests](stratification/)
-* [Wellformed-ness tests](wellformed/)
+* [Stratification tests](stratification/)
+* [Well-formedness tests](wellformed/)
 
 ### Syntax tests
 
@@ -35,7 +35,7 @@ All the test are syntactically legal, i.e. conform to the SPARQL-RL Rules gramma
 additional parsing rules.
 
 To pass a test, the parser must accept or reject a rule set as stated by the test
-type. A negative well-formedness is a ruleset that violates oen or more well-formed
+type. A negative well-formedness is a ruleset that violates one or more well-formed
 conditions of the SPARQL-RL abstract rule syntax.
 
 ### Stratification

--- a/shacl12-test-suite/tests/sparql-rl/README.md
+++ b/shacl12-test-suite/tests/sparql-rl/README.md
@@ -15,7 +15,13 @@ tests from another manifest files.
 
 The top level manifest is `manifest-sparql-rl.ttl`.
 
-## Test types
+## Tests
+
+* [Syntax tests](syntax/)
+* [Evaluation tests](eval/)
+* [Evaluation examples](eval2/)
+* [Starification tests](stratification/)
+* [Wellformed-ness tests](wellformed/)
 
 ### Syntax tests
 
@@ -24,14 +30,15 @@ Good and bad syntax tests, regardless of well-formedness and stratification.
 ### Well-formedness tests
 
 These are test for well-formedness conditions. 
-All the test are syntactically legal, i.e. conform to the SHACL Rules grammar and any
-addition parsing rules.
+
+All the test are syntactically legal, i.e. conform to the SPARQL-RL Rules grammar and any
+additional parsing rules.
 
 To pass a test, the parser must accept or reject a rule set as stated by the test
-stype. A negative well-formedness is a ruleset that violates the well-formed
-conditions of the SHACL abstract rule syntax.
+type. A negative well-formedness is a ruleset that violates oen or more well-formed
+conditions of the SPARQL-RL abstract rule syntax.
 
-### Illegal stratification
+### Stratification
 
 These test rule sets to detect where the stratification condition is violated.
 
@@ -41,9 +48,5 @@ All the test are syntactically legal and well-formed.
 
 The result of an evaluation test is the inference graph. 
 
-There are two directories of evaluation tests. `eval/` has feature
-tests and `eval2/` has some larger tests.
-
-## Examples
-
-Some examples from the SPARQL-RL spec.
+There are two directories of evaluation tests. [`eval/`](eval/) has feature
+tests and [`eval2/`](eval2/)  has some larger tests.

--- a/sparql12-rl/index.html
+++ b/sparql12-rl/index.html
@@ -49,8 +49,8 @@
           "no-unused-dfns": false
         },
         //implementationReportURI: "http://w3c.github.io/data-shapes/sparql12-rl/tests/implementations",
-        testSuiteURI: "http://w3c.github.io/data-shapes/sparql12-rl/tests/",
-
+        //testSuiteURI: "https://w3c.github.io/data-shapes/shacl12-test-suite/tests/sparql12-rl/",
+        testSuiteURI: "https://github.com/w3c/data-shapes/tree/gh-pages/shacl12-test-suite/tests/sparql-rl",
         // No previous REC
         //previousPublishDate: "",
         //previousMaturity: "REC",


### PR DESCRIPTION
Minor changes after the reorganization for SPARQl-RL.

* Update Data Shape WG top-level README

* Update the SPARQL-RL test README

* Put in a working link to the SPARQL-RL test area in the document
