### PR TITLE
Security, Privacy and Acknowledgements sections

### DIFF
--- a/sparql12-rl/index.html
+++ b/sparql12-rl/index.html
@@ -3051,9 +3051,9 @@ result is imports(RS, V)
 
     <section id="security-considerations" class="appendix informative">
       <h2>Security Considerations</h2>
-      <p class="todo">TODO</p>
       <p>
-        SRL documents can contain `IMPORTS` statements that reference other [=SRL documents=].
+        SPARQL-RL documents may contain `IMPORTS` statements that reference other
+        [=SPARQL-RL documents=] and import their contents into the current document.
         If an imported document itself contains its own `IMPORTS` statements,
         those documents are also imported. 
       </p>
@@ -3064,29 +3064,59 @@ result is imports(RS, V)
         causing excessive computation, whether maliciously or accidental, while being evaluated;
         and HTTP requests being intercepted and a different document being returned,
         including out-of-date copies.
-      </p>        
+      </p>
       <p>
-        See <a href="#process-imports"></a>.
+        Applying a SPARQL-RL rule set to a data graph can result in
+        significant computation and memory usage, which may be exploited
+        to cause denial of service.
+        Applications should take care to limit the amount of computation and 
+        memory usage that can be caused by applying a SPARQL-RL rule set.
       </p>
-      <p class="ednote">
-        Need input on the security considerations.
+      <p>
+        The SPARQL-RL syntax is encoded in UTF-8 [[!RFC3629]] and allows 
+        the use of unescaped control characters in string data.
+        Although this specification does not directly expose this content to an end user,
+        it might be presented through a user agent, which may cause the presented text to 
+        be obfuscated due to presentation of such characters.
       </p>
-
+      <p>SPARQL-RL can be used to process and create arbitrary application data;
+        security considerations will vary by domain of use.
+        Security tools and protocols applicable to text
+        (for example, PGP encryption, checksum validation, password-protected compression)
+        may also be used on [=SPARQL-RL document=].
+        Security/privacy protocols must be imposed which reflect the sensitivity of the
+        information in the outcome of SPARQL-RL rule set evaluation.
+      </p>
+      <p>The security considerations of SPARQL-RL include those of
+        <a data-cite="RDF12-CONCEPTS#security">RDF data</a> and formats such as
+        <a data-cite="RDF12-TURTLE#security">RDF Turtle</a>.
+      </p>
     </section>
 
     <section id="privacy" class="appendix informative">
       <h2>Privacy Considerations</h2>
-      <p class="todo">TODO</p>
-    </section>
-
-    <section id="internationalization" class="appendix informative">
-      <h2>Internationalization Considerations</h2>
-      <p class="todo">TODO</p>
+        <p>A SPARQL-RL document can contain additional application data
+        which may include the expression of personally identifiable information (PII)
+        or other information which could be considered sensitive.
+        Authors publishing rule sets with such information are advised to carefully
+        consider the needs and use of publishing such information,
+        as well as the applicable regulations for the regions where the data is
+        expected to be consumed and potentially revealed (e.g., 
+        <a href="https://gdpr.eu/">GDPR</a>, 
+        <a href="https://oag.ca.gov/privacy/ccpa">CCPA</a>,
+        <a href="https://termly.io/resources/infographics/privacy-laws-around-the-world/">others</a>),
+        particularly whether authorization measures are needed for access to the data.
+      </p>
     </section>
 
     <section id="ack" class="appendix informative">
       <h2>Acknowledgements</h2>
-      <p class="todo">TODO</p>
+      <p>
+        The following people contributed to the development of SPARQL-RL in the rule task force of the Data Shapes Working Group:
+        Robert David, David Habgood, Livio Robaldo, Ognjen Savkovic, Simon Steyskal, Ted Thibodeau Jr, and Andy Seaborne.
+      </p>
+      <p>Members of the Data Shapes Working Group included @@.</p>
+
     </section>
 
     <section id="index"></section>


### PR DESCRIPTION
Complete the security privacy sections.
Add acknowledgements.

Much of the material is taken from RDF Concepts and, for syntax, RDF Turtle. All the considerations of data on the web and Turtle/SPARQL syntax apply to SPARQL-RL. 

In addition, SPARQL-RL evaluation is computation, requiring care over processor and memory consumption.

The optional `IMPORTS` feature bring with it considerations about the authenticity and correctness of 3rd party documents.

* [See these sections rendered online here](https://raw.githack.com/w3c/data-shapes/prep-wide-review/sparql-rl/index.html#security)

I believe this PR makes the document ready for wide-review #893.

That does not mean the document is finished.
