### PR TITLE
GH#1184: Improve SHACL Rules layers example

### DIFF
--- a/shacl12-test-suite/tests/sparql/rules/layers-example.ttl
+++ b/shacl12-test-suite/tests/sparql/rules/layers-example.ttl
@@ -49,14 +49,14 @@ ex:Rule1
 
 ex:Rule2
     a sh:SPARQLRule ;
-    sh:layer 1 ;
+    sh:layer 0 ;
     sh:construct """
         CONSTRUCT { ?a :connected ?b .} WHERE { ?a :connected/:connected ?b }
     """ .
 
 ex:RuleQ3
     a sh:SPARQLRule ;
-    sh:layer 2 ;
+    sh:layer 1 ;
     sh:construct """
         CONSTRUCT { :x1 :status ":x1 not connected to :x4" } WHERE { FILTER NOT EXISTS { :x1 :connected :x4 } }
     """ .
@@ -70,7 +70,7 @@ ex:RuleQ4
 
 ex:RuleQ5
     a sh:SPARQLRule ;
-    sh:layer 2 ;
+    sh:layer 1 ;
     sh:construct """
         CONSTRUCT { :x1 :status ":x1 is not connected to :x5" } WHERE { FILTER NOT EXISTS { :x1 :connected :x5 } }
     """ .


### PR DESCRIPTION
Closes #1184

Updates the layers example so that `Rule1` and `Rule2` are in the same layer and `Q3` through `Q6` are grouped in the following layer. The expected results remain unchanged.