### PR TITLE
Enable auto publish for SPARQL-RL

### DIFF
--- a/.github/workflows/auto-publish-sparql12-rl.yml
+++ b/.github/workflows/auto-publish-sparql12-rl.yml
@@ -1,0 +1,24 @@
+#  Autopublish configuration for sparql12-rl
+name: CI (sparql12-rl)
+on:
+  push:
+    branches: [gh-pages]
+    paths: ["sparql12-rl/**"]
+
+jobs:
+  main:
+    name: Build, Validate and Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: w3c/spec-prod@v2
+        with:
+          TOOLCHAIN: respec
+          SOURCE: sparql12-rl/index.html
+          W3C_ECHIDNA_TOKEN: ${{ secrets.SHACL_RULES }}
+          W3C_WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-shacl/2025May/0026.html"
+          W3C_BUILD_OVERRIDE: |
+            specStatus: WD
+            shortName: sparql12-rl


### PR DESCRIPTION
This PR puts back the auto-publish under the new name.
