### PR TITLE
Define SPARQL-RL processor

### DIFF
--- a/sparql12-rl/index.html
+++ b/sparql12-rl/index.html
@@ -299,8 +299,7 @@
       </p>
 
       <p class="note">
-        This specification does not define how SPARQL-RL
-        processors handle non-conforming [=rule sets=].
+        This specification does not define how a [=SPARQL-RL processor=] handles non-conforming [=rule sets=].
       </p>
     </section>
 
@@ -830,7 +829,7 @@ This condition ensures that such rules do not loop back to themselves and cause 
             and an <a>expression</a>, called the <dfn>assignment expression</dfn>.
           </dd>
 
-          <!-- Pending
+          <!-- Postponed
                <dt><dfn>aggregation element</dfn></dt>
           <dd>
             An [=aggregation element=] is a [=rule element=] that ..@@.. .
@@ -922,7 +921,6 @@ This condition ensures that such rules do not loop back to themselves and cause 
             or is a new inferred triple.
             During [=rule set evaluation=], a rule may be evaluated more than once.
           </dd>
-
         </dl>
         <p>
           SPARQL-RL provides two operations, [=infer=] and [=query=].
@@ -945,9 +943,15 @@ This condition ensures that such rules do not loop back to themselves and cause 
             </p>
             <p>
               [=Query=] is equivalent to performing an [=infer=] operation
-              followed by matching the goal pattern to the combined [=base
-              graph=] and [=inference graph=].
+              followed by matching the goal pattern to the combined 
+              [=base graph=] and [=inference graph=].
             </p>
+          </dd>
+          <dt><dfn>SPARQL-RL processor</dfn></dt>
+          <dd>
+            A [=SPARQL-RL processor=] is a system that implements the SPARQL-RL
+            specification, can evaluate [=rule sets=], and provides one or both
+            of the operations [=infer=] and [=query=].
           </dd>
         </dl>
 


### PR DESCRIPTION
Small PR that defines "SPARQL-RL Processor" and nudges auto-publishing.
auto-publishing should pick up PR #1192 as well.