### PR TITLE
#1116: Renamed SHACL-SPARQL to "SHACL 1.2 SPARQL-Related Features"

### DIFF
--- a/shacl12-common/specifications.html
+++ b/shacl12-common/specifications.html
@@ -19,7 +19,7 @@
           <dd>defines expressions used to derive focus nodes and value nodes in SHACL</dd>
           <dt><a href="https://w3c.github.io/data-shapes/shacl12-profiling/">SHACL 1.2 Profiling</a></dt>
           <dd>defines the use of SHACL for profiling data, including SHACL data</dd>
-          <dt><a href="https://www.w3.org/TR/shacl12-sparql/">SHACL 1.2 SPARQL Extensions</a></dt>
+          <dt><a href="https://www.w3.org/TR/shacl12-sparql/">SHACL 1.2 SPARQL-Related Features</a></dt>
           <dd>defines SPARQL-related extensions of SHACL</dd>
           <dt><a href="https://w3c.github.io/data-shapes/shacl12-ui/">SHACL 1.2 UI</a></dt>
           <dd>defines SHACL's use for User Interface generation</dd>

--- a/shacl12-overview/index.html
+++ b/shacl12-overview/index.html
@@ -84,16 +84,16 @@
         <dl>
           <dt><a href="https://www.w3.org/TR/shacl12-core/">SHACL 1.2 Core</a></dt>
           <dd>defines the Core of SHACL</dd>
-          <dt><a href="https://www.w3.org/TR/shacl12-sparql/">SHACL 1.2 SPARQL Extensions</a></dt>
-          <dd>defines SPARQL-related extensions of SHACL</dd>
+          <dt><a href="https://www.w3.org/TR/shacl12-inference-rules/">SHACL 1.2 Inference Rules</a></dt>
+          <dd>defines SHACL's framework of rule-based inference</dd>
           <dt><a href="https://www.w3.org/TR/shacl12-node-expr/">SHACL 1.2 Node Expressions</a></dt>
           <dd>defines expressions used to derive focus nodes and value nodes in SHACL</dd>
-          <dt><a href="https://www.w3.org/TR/shacl12-rules/">SHACL 1.2 Rules</a></dt>
-          <dd>defines SHACL's methods of rule-based inference</dd>
-          <dt><a href="https://w3c.github.io/data-shapes/shacl12-ui/">SHACL 1.2 UI</a></dt>
-          <dd>defines SHACL's use for User Interface generation</dd>
           <dt><a href="https://w3c.github.io/data-shapes/shacl12-profiling/">SHACL 1.2 Profiling</a></dt>
           <dd>defines the use of SHACL for profiling data, including SHACL data</dd>
+          <dt><a href="https://www.w3.org/TR/shacl12-sparql/">SHACL 1.2 SPARQL-Related Features</a></dt>
+          <dd>defines SPARQL-related extensions of SHACL</dd>
+          <dt><a href="https://w3c.github.io/data-shapes/shacl12-ui/">SHACL 1.2 UI</a></dt>
+          <dd>defines SHACL's use for User Interface generation</dd>
         </dl>
         <p>
           <strong>

--- a/shacl12-sparql/index.html
+++ b/shacl12-sparql/index.html
@@ -3,7 +3,7 @@
 	<head>
     <meta charset="utf-8" />
     <meta name="color-scheme" content="light dark">
-		<title>SHACL 1.2 SPARQL Extensions</title>
+		<title>SHACL 1.2 SPARQL-Related Features</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
 		<script class="remove">
 
@@ -166,10 +166,9 @@
 	<body>
 		<section id="abstract">
 			<p>
-				This document defines SPARQL-related extensions of the SHACL Shapes Constraint Language.
+				This document defines SPARQL-related features of the SHACL Shapes Constraint Language.
 				While the Core part of SHACL defines the basic syntax of shapes and the most common constraint components
-				supported by SHACL, the SPARQL-related extensions cover features that extend the expressiveness of Core
-				by means of SPARQL.
+				supported by SHACL, the SPARQL-related features extend the expressiveness of Core by means of SPARQL.
 				In particular, this document defines how constraints and constraint components can be defined using SPARQL.
 				Furthermore, this document introduces SPARQL-based node expressions that can be used to derive lists of nodes.
 				Finally, this document defines a declarative mechanism to define new SPARQL functions based on SHACL node expressions.
@@ -192,7 +191,7 @@
 					Throughout this document, the following terminology is used.
 				</p>
 				<p>
-					The SHACL SPARQL Extensions defined in this document are sometimes called SHACL-SPARQL.
+					The SPARQL-related features of SHACL defined in this document are sometimes called SHACL-SPARQL.
 				</p>
 				<p>
 					Terminology that is linked to portions of RDF 1.2 Concepts and Abstract Syntax is used in SHACL-SPARQL as defined there.
@@ -415,6 +414,9 @@
 				</ul>
 				<p>
 					Also see the discussion of well-formedness in the <a data-cite="shacl12-core#conformance">Conformance section of SHACL Core</a>.
+				</p>
+				<p class="note">
+					The SHACL 1.2 Inference Rules specification [[shacl12-inference-rules]] defines additional SPARQL-based features for SHACL.
 				</p>
 			</section>
 		</section>


### PR DESCRIPTION
I prefer to use Features over Extensions because the SHACL-SPARQL Functions do not extend SHACL but rather use an extension point of SPARQL.

On this occasion I also noticed the overview was using the old SHACL Rules link.

Closes #1116

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-1116/shacl12-sparql/index.html)

CC @afs 