### PR TITLE
#1210: Renamed sh:Rules to sh:RulesEntailment, added to shacl.ttl

### DIFF
--- a/shacl12-inference-rules/index.html
+++ b/shacl12-inference-rules/index.html
@@ -803,7 +803,7 @@ ex:RunAfterRule
 	sh:construct """
 		CONSTRUCT {
 			?reifier rdf:reifies ?triple .
-			?reifier ex:source sh:Rules .
+			?reifier ex:source sh:RulesEntailment .
 		}
 		WHERE {
 			$this ex:offspring ?offspring .
@@ -818,15 +818,15 @@ ex:RunAfterRule
 ex:Grandma
 	a ex:Person ;
 	ex:child ex:Son ;
-	ex:offspring ex:Son {| ex:source sh:Rules |} ;
-	ex:offspring ex:Grandson {| ex:source sh:Rules |} ;
-	ex:offspring ex:Granddaughter {| ex:source sh:Rules |} .
+	ex:offspring ex:Son {| ex:source sh:RulesEntailment |} ;
+	ex:offspring ex:Grandson {| ex:source sh:RulesEntailment |} ;
+	ex:offspring ex:Granddaughter {| ex:source sh:RulesEntailment |} .
 
 ex:Son
 	a ex:Person ;
 	ex:child ex:Grandson, ex:Granddaughter ;
-	ex:offspring ex:Grandson {| ex:source sh:Rules |} ;
-	ex:offspring ex:Granddaughter {| ex:source sh:Rules |} .
+	ex:offspring ex:Grandson {| ex:source sh:RulesEntailment |} ;
+	ex:offspring ex:Granddaughter {| ex:source sh:RulesEntailment |} .
 
 ex:Grandson
 	a ex:Person .
@@ -1013,12 +1013,12 @@ ex:RuleSet2
 			</p>
 		</section>
 
-		<section id="Rules">
-			<h2>The sh:Rules Entailment Regime</h2>
+		<section id="RulesEntailment">
+			<h2>The sh:RulesEntailment Regime</h2>
 			<p>
 				SHACL defines the property <code>sh:entailment</code>
 				to link a <a>shapes graph</a> with <em>entailment regimes</em>.
-				The <a>IRI</a> <code>sh:Rules</code> represents the <dfn>SHACL rules entailment regime</dfn>.
+				The <a>IRI</a> <code>sh:RulesEntailment</code> represents the <dfn>SHACL rules entailment regime</dfn>.
 				In the following example, the shapes graph indicates to a SHACL validation engine that the SHACL rules
 				inside of the <a>shapes graph</a> need to be executed prior to starting the validation.
 			</p>
@@ -1027,7 +1027,7 @@ ex:RuleSet2
 					<div class="turtle">
 &lt;http://example.org/my-shapes&gt;
 	a owl:Ontology ;
-	sh:entailment sh:Rules .
+	sh:entailment sh:RulesEntailment .
 					</div>
 				</div>
 			</aside>

--- a/shacl12-inference-rules/index.html
+++ b/shacl12-inference-rules/index.html
@@ -1299,7 +1299,7 @@ _:id sh:sourceRule ex:SymmetricPropertyRule .</pre>
 				</div>
 				<p class="note">
 					For <a>SPARQL rules</a> that are <a>shape rules</a> (i.e., linked to a shape with <code>sh:rule</code>),
-					a <a>SHACL rule engine</a> also counts as a SHACL-SPARQL processor
+					a <a>SHACL rules engine</a> also counts as a SHACL-SPARQL processor
 					and the syntax limitations required by <a>pre-binding</a> do apply to shape rules.
 					Since <a>global</a> SPARQL rules do not use <a>pre-binding</a>, the syntax limitations
 					required by <a>pre-binding</a> do not apply to them.

--- a/shacl12-test-suite/tests/inference-rules/run-once-example.ttl
+++ b/shacl12-test-suite/tests/inference-rules/run-once-example.ttl
@@ -65,7 +65,7 @@ ex:RunAfterRule
 	sh:construct """
 		CONSTRUCT {
 			?reifier rdf:reifies ?triple .
-			?reifier ex:source sh:Rules .
+			?reifier ex:source sh:RulesEntailment .
 		}
 		WHERE {
 			$this ex:offspring ?offspring .
@@ -92,23 +92,23 @@ ex:RunAfterRule
 	( ex:Grandma ex:child ex:Son )
 	( ex:Grandma ex:offspring ex:Son )
 		( _:b1 rdf:reifies <<( ex:Grandma ex:offspring ex:Son )>> )
-		( _:b1 ex:source sh:Rules )
+		( _:b1 ex:source sh:RulesEntailment )
 	( ex:Grandma ex:offspring ex:Grandson )
 		( _:b2 rdf:reifies <<( ex:Grandma ex:offspring ex:Grandson )>> )
-		( _:b2 ex:source sh:Rules )
+		( _:b2 ex:source sh:RulesEntailment )
 	( ex:Grandma ex:offspring ex:Granddaughter )
 		( _:b3 rdf:reifies <<( ex:Grandma ex:offspring ex:Granddaughter )>> )
-		( _:b3 ex:source sh:Rules )
+		( _:b3 ex:source sh:RulesEntailment )
 
 	( ex:Son rdf:type ex:Person )
 	( ex:Son ex:child ex:Grandson )
 	( ex:Son ex:child ex:Granddaughter )
 	( ex:Son ex:offspring ex:Grandson )
 		( _:b4 rdf:reifies <<( ex:Son ex:offspring ex:Grandson )>> )
-		( _:b4 ex:source sh:Rules )
+		( _:b4 ex:source sh:RulesEntailment )
 	( ex:Son ex:offspring ex:Granddaughter )
 		( _:b5 rdf:reifies <<( ex:Son ex:offspring ex:Granddaughter )>> )
-		( _:b5 ex:source sh:Rules )
+		( _:b5 ex:source sh:RulesEntailment )
 
 	( ex:Grandson rdf:type ex:Person )
 

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1929,12 +1929,10 @@ sh:Rule
 	rdfs:subClassOf rdfs:Resource ;
 	rdfs:isDefinedBy sh: .
 
-sh:SPARQLRule
-	a rdfs:Class ;
-	rdfs:label "SPARQL rule"@en ;
-	rdfs:comment "The class of SHACL rules based on SPARQL CONSTRUCT queries."@en ;
-	rdfs:subClassOf sh:Rule ;
-	rdfs:subClassOf sh:SPARQLConstructExecutable ;
+sh:RulesEntailment
+	a rdfs:Resource ;
+	rdfs:label "SHACL rules entailment"@en ;
+	rdfs:comment "A value for sh:entailment, activating SHACL Inference Rules entailment."@en ;
 	rdfs:isDefinedBy sh: .
 
 sh:rule
@@ -2012,6 +2010,14 @@ sh:tempTriple
 	rdfs:label "temp triple"@en ;
 	rdfs:comment "Can be used in reifiers to mark inferred triples that shall be removed at the end of execution."@en ;
 	rdfs:range xsd:boolean ;
+	rdfs:isDefinedBy sh: .
+
+sh:SPARQLRule
+	a rdfs:Class ;
+	rdfs:label "SPARQL rule"@en ;
+	rdfs:comment "The class of SHACL rules based on SPARQL CONSTRUCT queries."@en ;
+	rdfs:subClassOf sh:Rule ;
+	rdfs:subClassOf sh:SPARQLConstructExecutable ;
 	rdfs:isDefinedBy sh: .
 
 sh:TripleRule


### PR DESCRIPTION
Closes #1210

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-1210/shacl12-inference-rules/index.html#RulesEntailment)
