### PR TITLE
#1212: Updated use of terms "base graph", "inference graph" and "evaluation graph"

### DIFF
--- a/shacl12-inference-rules/index.html
+++ b/shacl12-inference-rules/index.html
@@ -1044,7 +1044,7 @@ ex:RuleSet2
 			<p>
 				It is sometimes useful for inference rules to produce triples that are only visible during the execution
 				of other rules but do not end up in the final inferences.
-				A <dfn>temporary triple</dfn> is an inferred <a>triple</a> for which the inference graph contains a
+				A <dfn>temporary triple</dfn> is an inferred <a>triple</a> for which the <a>inference graph</a> contains a
 				<a>reifier</a> with the <a>value</a> <code>sh:tempTriple true</code>.
 				<a>Temporary triples</a> and their <a>reifiers</a> are visible to executing rules.
 				Rules can produce such triples as illustrated in the following example:
@@ -1109,20 +1109,16 @@ ex:SetYoungestOffspringsRule
 				By marking these partial results as temporary triples, they are automatically removed after the final results have been computed.
 			</p>
 		</section>
+
 		<section id="rules-execution">
 			<h2>General Execution Instructions for SHACL Rules</h2>
 			<p>
 				A <dfn data-lt="rules engine">SHACL rules engine</dfn> is a computer procedure that takes as input
-				a <a>data graph</a>, a <a>shapes graph</a> and an optional <a>rule set</a> (defaulting to the <a>default rule set</a> of the <a>shapes graph</a>)
-				and is capable of adding <a>triples</a> to the <a>data graph</a>.
+				a <a>data graph</a> called the <dfn>base graph</dfn>, a <a>shapes graph</a>, and an optional <a>rule set</a> (defaulting to the <a>default rule set</a> of the <a>shapes graph</a>)
+				and is capable of producing <a>triples</a> that are not in the <a>base graph</a>.
 				The new <a>triples</a> that are produced by a rules engine are called the <dfn data-lt="inferring|infer">inferred</dfn> triples.
-			</p>
-			<p>
-				Note that, from a logical perspective, the <a>data graph</a> will be <em>modified</em> if <a>triples</a> get inferred.
-				This means that rules can trigger after other triples have been inferred.
-				However, in cases where the original data should not be modified, implementations may construct a logical <a>data graph</a>
-				that has the original data as one subgraph and a dedicated inferences graph as another subgraph, and where
-				the inferred triples get added to the inferences graph only.
+				The <dfn>inference graph</dfn> consists of these <a>inferred</a> triples.
+				The <dfn>evaluation graph</dfn> is the union of the <a>base graph</a> and the <a>inference graph</a>.
 			</p>
 			<p>
 				An <dfn>execution</dfn> of a <a>rule</a> is the process that produces <a>inferred</a> triples from the <a>rule</a>
@@ -1131,6 +1127,7 @@ ex:SetYoungestOffspringsRule
 				then the rule is executed for each <a>target node</a> of each of the linked and <a data-cite="shacl12-core#deactivated">non-deactivated</a>
 				<a>shapes</a> that <a>conform</a> to all <a data-cite="shacl12-core#deactivated">non-deactivated</a> <a href="#condition">conditions</a> of the <a>rule</a>.
 				These <a>target nodes</a> become the <a>focus nodes</a> of the executing <a>shape rule</a>.
+				During execution, the <a>evaluation graph</a> is used as the active query graph, and only the <a>inference graph</a> is updated.
 			</p>
 			<p>
 				For a given <a>rule set</a> in the <a>shapes graph</a>


### PR DESCRIPTION
These SHOULD now have the same interpretation as in SRL (unless I made mistakes). The intention was always that, but the old wording from SHACL-AF wasn't clear.

<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

Closes #1212

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-1212/shacl12-inference-rules/index.html#rules-execution)

CC (with thanks for raising this): @afs 
