### PR TITLE
GH-1156: Mention run-once in dependency graph section

### DIFF
--- a/sparql12-rl/index.html
+++ b/sparql12-rl/index.html
@@ -556,11 +556,10 @@ in the negation element have been completed. The rule containing the negation is
           their [=rule head=] are [=run-once rules=].
           Such rules are run after all the rules that could produce data that they depend on,
           and before any rules that depend on the data they produce. 
-          Rules that involve blank nodes in the [=rule head=] also create new
-          RDF terms and are run-once rules.
         </p>
         <p>
-This condition ensures that such rules do not loop back to themselves and cause an unbounded number of RDF terms.
+          This condition ensures that such rules do not loop back to themselves
+          and cause an unbounded number of RDF terms.
         </p>
         <p>
           If evaluating the expression in an [=assignment=] causes an error,
@@ -1249,10 +1248,9 @@ This condition ensures that such rules do not loop back to themselves and cause 
                 matches a [=triple template=] in the [=rule head=] of `R2`.
               </li>
               <li>Rule `R1` [=depends on=] rule `R2`  
-                and `R1` has an [=assignment element=].
-              </li>
-              <li>Rule `R1` [=depends on=] rule `R2`
-                and the [=rule head=] of `R1` has a blank node.
+                and `R1` is a [=run-once rule=], that is
+                rule `R1` has an [=assignment element=] or
+                the [=rule head=] of `R1` has a blank node.
               </li>
             </ul>
           </dd>


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

`run-once` is already in the abstract syntax. This PR uses the terminology in the dependency graph section.

Closes #1156

* [See this section rendered online here](https://raw.githack.com/w3c/data-shapes/gh1156-srl-run-once/sparql12-rl/index.html#rule-dependency)
