### PR TITLE
[UI] Add SHACL UI logical constraints section

### DIFF
--- a/shacl12-ui/index.html
+++ b/shacl12-ui/index.html
@@ -1827,10 +1827,13 @@ ex:PersonShapeName
       </section>
     </section>
 
-    <section id="core-constraints">
-      <h2>Core Constraints</h2>
+    <section>
+      <h2>Logical Constraints</h2>
 
-      <p class="ednote">TODO: This section may not be needed if we decide to fold in the use of different constraints for common form scenarios under the Patterns section.</p>
+      <p class="ednote">
+        Add support for at least `sh:or` use with `sh:datatype` and `sh:class` constraints, as described in
+        <a href="https://datashapes.org/forms.html#multi" target="_blank" rel="noopener">Form Generation using SHACL and DASH 3.1 Multiple Datatypes or Classes</a>.
+      </p>
     </section>
 
     <section id="property-paths">


### PR DESCRIPTION
Initial placeholder section.

At a minimum, this PR will include at least support for `sh:or` with `sh:datatype` and `sh:class`, as described in [Form Generation using SHACL and DASH 3.1 Multiple Datatypes or Classes](https://datashapes.org/forms.html#multi).

Closes #533 

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/ui/logical-constraints/shacl12-ui/index.html)
