### PR TITLE
Add section for SRL-based rules

### DIFF
--- a/shacl12-inference-rules/index.html
+++ b/shacl12-inference-rules/index.html
@@ -565,10 +565,10 @@ ex:RectangleRulesShape
 		<section id="syntax">
 			<h2>Syntax of SHACL Rules</h2>
 			<p>
-				The <a>SHACL instances</a> of <code>sh:Rule</code>, including its subclasses <code>sh:SPARQLRule</code> and <code>sh:TripleRule</code>,
+				The <a>SHACL instances</a> of <code>sh:Rule</code>, including its subclasses <code>sh:SPARQLRule</code>, <code>sh:TripleRule</code> and <code>sh:SRL</code>,
 				are called <dfn data-lt="rule|rules|SHACL rule">SHACL rules</dfn>.
 				SHACL has a flexible, extensible design in which multiple types of rules can be supported,
-				but this document only defines two of them: <a>SPARQL rules</a> and <a>triple rules</a>.
+				but this document only defines three of them: <a>SPARQL rules</a>, <a>triple rules</a> and <a>SRL rules</a>.
 			</p>
 			<p>
 				Each <dfn>rule type</dfn> is identified by an <a>IRI</a> that is used as
@@ -1237,10 +1237,10 @@ _:id sh:sourceRule ex:SymmetricPropertyRule .</pre>
 			<h2>Built-in Rule Types</h2>
 			<p>
 				The SHACL inference rules framework defines a general syntax of rules and their execution algorithm.
-				This document defines the two <a>rule types</a> from the following two subsections.
+				This document defines the three <a>rule types</a> from the following subsections.
 			</p>
 			<p>
-				Note that not all implementations are required to implement both of these types for conformance.
+				Note that not all implementations are required to implement all of these types for conformance.
 				A <a>rules engine</a> that encounters a rule for which it does not implement any
 				<a>rule type</a> reports a <a>failure</a>, as defined in <a href="#rules-execution"></a>.
 			</p>
@@ -1456,6 +1456,59 @@ ex:Dad
 						</div>
 					</div>
 				</aside>
+			</section>
+			<section id="SRLRules">
+				<h3>SPARQL-RL Rules</h3>
+				<p>
+					This section defines a <a>rule type</a> called <dfn data-lt="SRL rules">SPARQL-RL</dfn>, often just "SRL",
+					identified by the <a>IRI</a> <code>sh:SRL</code>.
+					<a>SRL rules</a> have the following properties:
+				</p>
+				<table class="term-table">
+					<tr>
+						<th>Property</th>
+						<th>Summary and Syntax Rules</th>
+					</tr>
+					<tr>
+						<td><code>sh:srlProgram</code></td>
+						<td>
+							The SPARQL-RL program: a <a data-cite="SPARQL12-RL#dfn-rule-set">SPARQL-RL rule set</a>.
+							<span data-syntax-rule="srlProgram-count"><a>SRL rules</a> must have exactly one
+							<a>value</a> for the property <code>sh:srlProgram</code>.</span>
+							<span data-syntax-rule="srlProgram-datatype">The values of <code>sh:srlProgram</code>
+							are <a>literals</a> with datatype <code>xsd:string</code>.</span>
+						</td>
+					</tr>
+					<tr>
+						<td><code>sh:prefixes</code></td>
+						<td>
+							The prefixes to use to turn the <code>sh:srlProgram</code> into a SPARQL-RL program.
+							<a>SRL rules</a> may use the property <code>sh:prefixes</code> to declare a dependency on prefixes based on the
+							mechanism defined in <a data-cite="shacl12-sparql#sparql-prefixes">Prefix Declarations for SPARQL Queries</a>.
+							This mechanism allows users to abbreviate URIs in the <code>sh:srlProgram</code> strings.
+						</td>
+					</tr>
+				</table>
+				<div class="def def-text">
+					<div class="def-header">EXECUTION OF SPARQL-RL RULES</div>
+					<div class="def-text-body">
+						Let <code>PGM</code> be the SPARQL-RL program derived from the values of the properties
+						<code>sh:srlProgram</code> and <code>sh:prefixes</code> of the <a>SRL rule</a> in the <a>shapes graph</a>.
+						<ul>
+							<li>
+								If the rule is a <a>shape rule</a>:
+								For each <a>focus node</a>, execute the program <code>PGM</code>,
+								<a>pre-binding</a> by variable substitution of the variable <code>$this</code>
+								with the <a>focus node</a>, and <a>infer</a> the <a>triples</a> it produces.
+							</li>
+							<li>
+								If the rule is a <a>global rule</a>:
+								Execute the program <code>PGM</code> without any <a>pre-binding</a>,
+								and <a>infer</a> the <a>triples</a> it produces.
+							</li>
+						</ul>
+					</div>
+				</div>
 			</section>
 		</section>
 

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -2048,6 +2048,28 @@ sh:object
 	rdfs:domain sh:TripleRule ;
 	rdfs:isDefinedBy sh: .
 
+## sh:SRL is a sh:SPARQLExecutable so that it can carry sh:prefixes, whose
+## rdfs:domain is sh:SPARQLExecutable. sh:SPARQLExprExpression is declared the
+## same way for the same reason. A separate executable class (in the style of
+## sh:SPARQLConstructExecutable) is not needed here because sh:srlProgram has no
+## user other than sh:SRL.
+
+sh:SRL
+	a rdfs:Class ;
+	rdfs:label "SPARQL-RL rule"@en ;
+	rdfs:comment "The class of SHACL rules based on SPARQL-RL programs."@en ;
+	rdfs:subClassOf sh:Rule ;
+	rdfs:subClassOf sh:SPARQLExecutable ;
+	rdfs:isDefinedBy sh: .
+
+sh:srlProgram
+	a rdf:Property ;
+	rdfs:label "SRL program"@en ;
+	rdfs:comment "The SPARQL-RL program to execute."@en ;
+	rdfs:domain sh:SRL ;
+	rdfs:range xsd:string ;
+	rdfs:isDefinedBy sh: .
+
 
 # -----------------------------------------------------------------------------
 # SHACL ADVANCED FEATURES (will likely be marked deprecated with 1.2)


### PR DESCRIPTION
This PR adds a rule type to the SHACL Inference Rules framework as another sub-section in section 11.

The rule type is based on SPARQL-RL.

SPARQL-RL has unique properties and guarantees not offered by SHACL SPARQL Rules.
SHACL SPARQL Rules has unique properties not offered by SPARQL-RL.

This PR uses "program" because SHACL Inf Rules added the same terminology "rule set" after SPARQL-RL.
Other names would be possible.

See also #1228 for discussion of creating a general concept of linking SHACL shapes to SHACL Rule step evaluations necessary for any SHACL Rule rule type.

This PR uses variable binding for `$this`.

Closes #1229

* [See the section rendered online here](https://raw.githack.com/w3c/data-shapes/inf-rules-srl/shacl12-inference-rules/index.html#SRLRules)
