### PR TITLE
First draft of report extension for infos on matched nodes

### DIFF
--- a/shacl/shacl.ttl
+++ b/shacl/shacl.ttl
@@ -171,12 +171,28 @@ sh:conforms
 	rdfs:range xsd:boolean ;
 	rdfs:isDefinedBy sh: .
 
+sh:nodeAssignmentCount
+	a rdf:Property ;
+	rdfs:label "Node assignment count"@en ;
+	rdfs:comment "The total number of shape assignments of shapes to focus nodes."@en ;
+	rdfs:domain sh:ValidationReport ;
+	rdfs:range xsd:integer ;
+	rdfs:isDefinedBy sh: .
+
 sh:result
 	a rdf:Property ;
 	rdfs:label "result"@en ;
 	rdfs:comment "The validation results contained in a validation report."@en ;
 	rdfs:domain sh:ValidationReport ;
 	rdfs:range sh:ValidationResult ;
+	rdfs:isDefinedBy sh: .
+
+sh:assignment
+	a rdf:Property ;
+	rdfs:label "assignment"@en ;
+	rdfs:comment "The shape assignments that the validation was processed on."@en ;
+	rdfs:domain sh:ValidationReport ;
+	rdfs:range sh:ShapeAssignment ;
 	rdfs:isDefinedBy sh: .
 
 sh:shapesGraphWellFormed
@@ -198,6 +214,13 @@ sh:ValidationResult
 	a rdfs:Class ;
 	rdfs:label "Validation result"@en ;
 	rdfs:comment "The class of validation results."@en ;
+	rdfs:subClassOf sh:AbstractResult ;
+	rdfs:isDefinedBy sh: .
+
+sh:ShapeAssignment
+	a rdfs:Class ;
+	rdfs:label "Shape assignment"@en ;
+	rdfs:comment "The class of assignments of shapes to nodes."@en ;
 	rdfs:subClassOf sh:AbstractResult ;
 	rdfs:isDefinedBy sh: .
 

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2619,6 +2619,26 @@ ex:CompanyShape
 							maximum recursion depth, or other runtime parameters.
 						</p>
 					</section>
+					<section id="nodeAssignmentCount"><!-- ISSUE-1221 -->
+						<h5>Node Assignment Count (sh:nodeAssignmentCount)</h5>
+						<p>
+							A valdiation report MAY contain one value for the property <code>sh:nodeAssignmentCount</code>.
+							The value MUST be equal to the total number of shape assignments of a <a>focus node</a> to a <a>shape</a>.
+							It MUST include focus nodes of target declarations other than <a href="#targetNode"><code>sh:targetNode</code></a>, which are determined by grounding the target nodes based on the specific target declaration.
+							<span class="todo">TODO: provide a concrete definition of grounding.</span>
+
+						</p>
+					</section>
+					<section id="assignment"><!-- ISSUE-1221 -->
+						<h5>Assignment (sh:assignment)</h5>
+						<p>
+							A valdiation report MAY containt values for the property <code>sh:assignment</code>.
+							If it does, it MUST provide one value for every pair of <a>focus node</a> to a <a>shape</a>. 
+							If the target declaration is other than <a href="#targetNode"><code>sh:targetNode</code></a>, the pairs are determined by grounding the target nodes based on the specific target declaration.
+							Each value of <code>sh:assignment</code> is a <a>SHACL instance</a> of the class <code>sh:ShapeAssignment</code>.
+							<span class="todo">TODO: provide a concrete definition of grounding.</span>
+						</p>
+					</section>
 				</section>
 
 				<section id="results-validation-result">
@@ -2710,6 +2730,15 @@ ex:CompanyShape
 							<li>defaulting to <code>sh:Violation</code> if no <code>sh:severity</code> has been specified for the shape or constraint.</li>
 						</ol>
 					</section>
+				</section>
+				<section id="results-shape-assignment"><!-- ISSUE-1221 -->
+					<h4>Validation Details (sh:ShapeAssignment)</h4>
+					<p>
+						SHACL defines <code>sh:ShapeAssignment</code> to report individual assigmments of a <a>focus node</a> to a <a>shape</a>.
+						Each instance of <code>sh:ShapeAssignment</code> MUST have exactly one value for the property <code>sh:focusNode</code>
+						and exactly one value for the property <code>sh:sourceShape</code>. 
+						It MAY provide exactly one value for the property <code>sh:conforms</code> to indicate an individual conformance of a <a>focus node</a> to a <a>shape</a>. 
+					</p>
 				</section>
 			</section>
 

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -2623,7 +2623,7 @@ ex:CompanyShape
 						<h5>Node Assignment Count (sh:nodeAssignmentCount)</h5>
 						<p>
 							A valdiation report MAY contain one value for the property <code>sh:nodeAssignmentCount</code>.
-							The value MUST be equal to the total number of shape assignments of a <a>focus node</a> to a <a>shape</a>.
+							The value MUST be equal to the total number of shape assignments of a <a>shape</a> to a <a>focus node</a>.
 							It MUST include focus nodes of target declarations other than <a href="#targetNode"><code>sh:targetNode</code></a>, which are determined by grounding the target nodes based on the specific target declaration.
 							<span class="todo">TODO: provide a concrete definition of grounding.</span>
 
@@ -2633,7 +2633,7 @@ ex:CompanyShape
 						<h5>Assignment (sh:assignment)</h5>
 						<p>
 							A valdiation report MAY containt values for the property <code>sh:assignment</code>.
-							If it does, it MUST provide one value for every pair of <a>focus node</a> to a <a>shape</a>. 
+							If it does, it MUST provide one value for every pair of <a>shape</a> and <a>focus node</a>. 
 							If the target declaration is other than <a href="#targetNode"><code>sh:targetNode</code></a>, the pairs are determined by grounding the target nodes based on the specific target declaration.
 							Each value of <code>sh:assignment</code> is a <a>SHACL instance</a> of the class <code>sh:ShapeAssignment</code>.
 							<span class="todo">TODO: provide a concrete definition of grounding.</span>


### PR DESCRIPTION
This pull request provides a first draft to extend the validation report with infos on targeted nodes.
The extensions are designed to not break backwards compatibility with SHACL 1.0.
It provides the following extensions:
- Node Assignment Count (sh:nodeAssignmentCount) - total number of pairs of targeted nodes and shapes
- Assignment (sh:assignment) - a property to link a concrete assignment (instance of sh:ShapeAssignment)
- Validation Details (sh:ShapeAssignment) - the actual assignment reporting on focus node, shape and optionally on conformance

Closes #1221 

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-1221-report-extension/shacl12-core/index.html)
