### PR TITLE
#1227: Replaced "reifier" with "triple annotations" in a few places

### DIFF
--- a/shacl12-inference-rules/index.html
+++ b/shacl12-inference-rules/index.html
@@ -211,6 +211,7 @@
 						<dfn data-cite="rdf12-concepts#dfn-rdf-node" data-lt="node|nodes">node</dfn> of an RDF graph,
 						<dfn data-cite="rdf12-concepts#dfn-datatype" data-lt="datatype|datatypes">datatype</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-reifier">reifier</dfn>,
+						<dfn data-cite="rdf12-concepts#dfn-triple-annotation">triple annotation</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-rdf-term" data-lt="term|terms">RDF term</dfn>, and
 						<dfn data-cite="rdf12-concepts#dfn-subject" data-lt="subject|subjects">subject</dfn>,
 						<dfn data-cite="rdf12-concepts#dfn-predicate" data-lt="predicate|predicates">predicate</dfn>, and
@@ -1046,7 +1047,7 @@ ex:RuleSet2
 				of other rules but do not end up in the final inferences.
 				A <dfn>temporary triple</dfn> is an inferred <a>triple</a> for which the <a>inference graph</a> contains a
 				<a>reifier</a> with the <a>value</a> <code>sh:tempTriple true</code>.
-				<a>Temporary triples</a> and their <a>reifiers</a> are visible to executing rules.
+				<a>Temporary triples</a> and their <a>triple annotations</a> are visible to executing rules.
 				Rules can produce such triples as illustrated in the following example:
 			</p>
 			<aside class="example" title="An example rule that produces temporary triples" id="tempTriple-example">
@@ -1147,9 +1148,9 @@ ex:SetYoungestOffspringsRule
 							Execute one <a>iteration</a> over all <a>iterating rules</a> in the layer
 						while the iteration has produced newly inferred triples
 						Delete the <a>derived triples</a> (except those that were also inferred by rules)
-							and their <a>reifiers</a>
+							and their <a>triple annotations</a>
 
-					Delete the <a>temporary triples</a> and their <a>reifiers</a>
+					Delete the <a>temporary triples</a> and their <a>triple annotations</a>
 				</pre>
 			</div>
 			<p>


### PR DESCRIPTION
Closes #1227

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-1227/shacl12-inference-rules/index.html)
