### PR TITLE
Updated Custom Rule Processors section introducing sh:ruleProcessor property

### DIFF
--- a/shacl12-inference-rules/index.html
+++ b/shacl12-inference-rules/index.html
@@ -664,7 +664,7 @@ ex:SymmetricPropertyRule
 				<h3>Grouping of Rules into Layers (sh:layer)</h3>
 				<p>
 					Rules may be grouped into <dfn data-lt="layer">layers</dfn>, identified by a numeric value.
-					During execution, a SHACL rules engine will iterate over all rules in the same layer
+					During execution, a SHACL rules engine will iterate over all rules with the same numeric layer value
 					before moving to the next layer.
 					Layers with a smaller numeric value will be executed before those with a larger number.
 				</p>
@@ -672,7 +672,7 @@ ex:SymmetricPropertyRule
 					<span data-syntax-rule="rule-layer-maxCount">Each <a>rule</a> may have at most one <a>value</a> for the
 					property <code>sh:layer</code>.</span>
 					<span data-syntax-rule="rule-layer-datatype">The values of <code>sh:layer</code> at <a>rules</a>
-					are <a>literals</a> with datatype <code>xsd:integer</code>.</span>
+					are <a>literals</a> with datatype <code>xsd:integer</code> or <code>xsd:decimal</code>.</span>
 				</p>
 				<p>
 					If unspecified and unless it has been computed by a <a href="#ruleProcessor">custom rule processor</a>, the default <a>layer</a> of a rule is <code>0</code>.

--- a/shacl12-inference-rules/index.html
+++ b/shacl12-inference-rules/index.html
@@ -675,7 +675,7 @@ ex:SymmetricPropertyRule
 					are <a>literals</a> with datatype <code>xsd:integer</code>.</span>
 				</p>
 				<p>
-					If unspecified, then the default <a>layer</a> of a rule is <code>0</code>.
+					If unspecified and unless it has been computed by a <a href="#ruleProcessor">custom rule processor</a>, the default <a>layer</a> of a rule is <code>0</code>.
 				</p>
 				<p>
 					An example of <code>sh:layer</code> to control the execution order of rules is provided in <a href="#example-rules-before-after"></a>.
@@ -693,7 +693,7 @@ ex:SymmetricPropertyRule
 					are <a>literals</a> with datatype <code>xsd:decimal</code> or <code>xsd:integer</code>.</span>
 				</p>
 				<p>
-					If unspecified, then the default <a>execution order</a> is <code>0</code>.
+					If unspecified and unless it has been computed by a <a href="#ruleProcessor">custom rule processor</a>, the default <a>execution order</a> is <code>0</code>.
 					When the <a>rules</a> are executed, within the same <a>layer</a>, <a>rules</a> with larger order values will be executed after those with smaller values.
 				</p>
 				<aside class="example" title="Rule order example">
@@ -756,6 +756,7 @@ ex:RuleOrderExampleShape
 					A <dfn>run-once rule</dfn> is a <a>rule</a> for which at most one <a>iteration</a> is performed (per <a>shape</a>, if it is a <a>shape rule</a>), i.e. it is executed at most once per <a>focus node</a>.
 					All other rules are called <dfn>iterating rules</dfn>.
 					A <a>rule</a> that has <code>true</code> as its <a>value</a> for <code>sh:runOnce</code> is a <a>run-once rule</a>.
+					<a href="#ruleProcessor">Custom rule processors</a> may compute additional run-once rules when <code>sh:runOnce</code> is absent.
 				</p>
 				<aside class="example" title="Example of run-once rules and layers" id="example-rules-before-after">
 					<div class="shapes-graph">
@@ -1198,8 +1199,8 @@ _:id sh:sourceRule ex:SymmetricPropertyRule .</pre>
 			</p>
 		</section>
 
-		<section id="rule-variations">
-			<h2>Variations of SHACL Rule Implementations</h2>
+		<section id="ruleProcessor">
+			<h2>Custom Rule Processors (sh:ruleProcessor)</h2>
 			<p>
 				The <a href="#rules-execution">general execution algorithm</a> described above is intentionally
 				kept generic and offers a lot of flexibility to specific implementations.
@@ -1210,24 +1211,40 @@ _:id sh:sourceRule ex:SymmetricPropertyRule .</pre>
 				In this document, the responsibility of producing a predictable ordering and layering/grouping of
 				rules is left to the rule author.
 			</p>
+			<p class="issue" data-number="1226">
+				The motivating sentences above would no longer apply if we make rules with the same order
+				independent from each other, as then the general algorithm is deterministic again
+				(except where rules use features like RAND()).
+			</p>
 			<p>
-				Some SHACL rule implementations MAY implement different algorithms to determine
-				the <a>run-once rules</a> (ignoring <code>sh:runOnce</code>),
-				the <a href="#rule-order">rule order</a> (ignoring <code>sh:order</code>), and
-				the <a href="#rule-layers">layers</a> (ignoring <code>sh:layer</code>).
+				Some SHACL rule implementations MAY implement different algorithms to determine:
+			</p>
+			<ul>
+				<li>the <a>run-once rules</a> (where <code>sh:runOnce</code> is not specified)</li>
+				<li>the <a href="#rule-order">rule order</a> (where <code>sh:order</code> is not specified)</li>
+				<li>the <a href="#rule-layers">layers</a> (where <code>sh:layer</code> is not specified)</li>
+			</ul>
+			<p>
 				This can, for example, be used by engines that support controlled subsets of SHACL rules
 				for which it is possible to compute rule dependencies automatically.
 				Another example is a rule engine that automatically prevents infinite loops because rules
 				generate blank nodes.
-				These implementation MAY produce different results from those that only rely on the
-				explicitly given <code>sh:order</code>, <code>sh:runOnce</code> and <code>sh:layer</code> values.
 			</p>
 			<p>
 				Some SHACL rule implementations MAY also report additional <a>failures</a> that are not reported
 				by the default algorithm.
 			</p>
-			<p class="issue" data-number="1073">
-				This would be a good place to cross-reference the ongoing SRL work, if this becomes a SHACL Rules variation.
+			<p>
+				The property <code>sh:ruleProcessor</code> can be used at <a>rule sets</a> or <a>rules</a>
+				to instruct a <a>rules engine</a> that non-standard processing is required for the given rules.
+				<span data-syntax-rule="ruleProcessor">The <a>values</a> of <code>sh:ruleProcessor</code> are <a>IRIs</a>,
+				or <a>literals</a> with <a>datatype</a> <code>xsd:string</code></span>.
+				A <a>rules engine</a> that encounters <a>rules</a> or <a>rule sets</a> with a value for <code>sh:ruleProcessor</code>
+				that they are unable to handle MUST report a <a>failure</a>.
+			</p>
+			<p class="issue" data-number="1202">
+				This would be a good place to cross-reference the ongoing SPARQL-RL work, if this integrates naturally with SHACL Inference Rules.
+				For example we could add an example with <code>sh:ruleProcessor "SRL 1.2"</code>.
 			</p>
 		</section>
 

--- a/shacl12-inference-rules/index.html
+++ b/shacl12-inference-rules/index.html
@@ -1204,19 +1204,9 @@ _:id sh:sourceRule ex:SymmetricPropertyRule .</pre>
 		<section id="ruleProcessor">
 			<h2>Custom Rule Processors (sh:ruleProcessor)</h2>
 			<p>
-				The <a href="#rules-execution">general execution algorithm</a> described above is intentionally
-				kept generic and offers a lot of flexibility to specific implementations.
-				In particular, the algorithm is non-deterministic in the sense that unless the order of rules
-				is specified explicitly, the results may differ across executions.
-				This is, for example, the case when rules draw conclusions from the number of certain triples
-				yet those triples may be produced by other rules.
-				In this document, the responsibility of producing a predictable ordering and layering/grouping of
-				rules is left to the rule author.
-			</p>
-			<p class="issue" data-number="1226">
-				The motivating sentences above would no longer apply if we make rules with the same order
-				independent from each other, as then the general algorithm is deterministic again
-				(except where rules use features like RAND()).
+				The <a href="#rules-execution">general execution algorithm</a> described above assumes that
+				the author of the rules is responsible for selecting a suitable ordering and layering/grouping
+				of rules to achieve the desired outcome.
 			</p>
 			<p>
 				Some SHACL rule implementations MAY implement different algorithms to determine:

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1998,6 +1998,12 @@ sh:hasRule
 	rdfs:range sh:Rule ;
 	rdfs:isDefinedBy sh: .
 
+sh:ruleProcessor
+	a rdf:Property ;
+	rdfs:label "rule processor"@en ;
+	rdfs:comment "Instructions to a SHACL rules engine on how to process the provided rule or rule set with a custom algorithm."@en ;
+	rdfs:isDefinedBy sh: .
+
 sh:sourceRule
 	a rdf:Property ;
 	rdfs:label "source rule"@en ;

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1964,7 +1964,6 @@ sh:layer
 	rdfs:label "layer"@en ;
 	rdfs:comment "The (numeric) layer of a rule, defaulting to 0."@en ;
 	rdfs:domain sh:Rule ;
-	rdfs:range xsd:integer ;
 	rdfs:isDefinedBy sh: .
 
 sh:runOnce


### PR DESCRIPTION
This clarifies that custom rule processors (such as a SPARQL-RL stratification algorithm) can only compute sh:layer, order, runOnce when no values are explicitly given. This means that authors can leave those values out when they know that SRL will handle them, and "fix" other rules by giving them explicit layers.

The property sh:ruleProcessor can be used to enforce expectations, e.g. that stratification MUST be applied beforehand. See examples of this in my comment https://github.com/w3c/data-shapes/pull/1230#discussion_r3964203449

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/issue-1202-ruleProcessor/shacl12-inference-rules/index.html#ruleProcessor)

CC: @afs @robert-david @recalcitrantsupplant 
