### PR TITLE
#1226: Added test case and changed contract for rules with same order

### DIFF
--- a/shacl12-inference-rules/index.html
+++ b/shacl12-inference-rules/index.html
@@ -695,6 +695,7 @@ ex:SymmetricPropertyRule
 				<p>
 					If unspecified, then the default <a>execution order</a> is <code>0</code>.
 					When the <a>rules</a> are executed, within the same <a>layer</a>, <a>rules</a> with larger order values will be executed after those with smaller values.
+					Rules with the same order are executed concurrently and must not see each other's inferences before they have all completed.
 				</p>
 				<aside class="example" title="Rule order example">
 					<div class="shapes-graph">
@@ -1133,7 +1134,10 @@ ex:SetYoungestOffspringsRule
 				For a given <a>rule set</a> in the <a>shapes graph</a>
 				an <dfn data-lt="iterate">iteration</dfn> is a single <a>execution</a> of each individual rule in the order as
 				specified by <a href="#rule-order"></a>, skipping the rules that are <a href="#deactivated-rules">deactivated</a>.
-				Within an iteration, the inferred triples of one rule become immediately visible to the next rule.
+				Within an iteration, the inferred triples of one rule (or group of same-order rules) become immediately
+				visible to the following rule (or group of same-order rules).
+				When rules have the same order, they must be executed concurrently and must not see each other's inferences before they
+				have all completed.
 			</p>
 			<p>
 				The <dfn>execution of a rule set</dfn> is defined as follows:

--- a/shacl12-inference-rules/index.html
+++ b/shacl12-inference-rules/index.html
@@ -694,8 +694,8 @@ ex:SymmetricPropertyRule
 				</p>
 				<p>
 					If unspecified, then the default <a>execution order</a> is <code>0</code>.
-					When the <a>rules</a> are executed, within the same <a>layer</a>, <a>rules</a> with larger order values will be executed after those with smaller values.
-					Rules with the same order are executed concurrently and must not see each other's inferences before they have all completed.
+					When the <a>rules</a> are executed, within the same <a>layer</a>, <a>rules</a> with larger order values will be executed after those with smaller values. The inferred triples of one rule (or group of same-order rules) become immediately visible to the subsequent rule (or group of same-order rules) in the order.
+					Rules with the same order are executed concurrently and must not see each other's inferences before they have all completed. The sets of triples individually inferred by these rules are then _unioned_ to produce the inferred graph.
 				</p>
 				<aside class="example" title="Rule order example">
 					<div class="shapes-graph">
@@ -1134,10 +1134,6 @@ ex:SetYoungestOffspringsRule
 				For a given <a>rule set</a> in the <a>shapes graph</a>
 				an <dfn data-lt="iterate">iteration</dfn> is a single <a>execution</a> of each individual rule in the order as
 				specified by <a href="#rule-order"></a>, skipping the rules that are <a href="#deactivated-rules">deactivated</a>.
-				Within an iteration, the inferred triples of one rule (or group of same-order rules) become immediately
-				visible to the following rule (or group of same-order rules).
-				When rules have the same order, they must be executed concurrently and must not see each other's inferences before they
-				have all completed.
 			</p>
 			<p>
 				The <dfn>execution of a rule set</dfn> is defined as follows:

--- a/shacl12-inference-rules/index.html
+++ b/shacl12-inference-rules/index.html
@@ -694,8 +694,10 @@ ex:SymmetricPropertyRule
 				</p>
 				<p>
 					If unspecified, then the default <a>execution order</a> is <code>0</code>.
-					When the <a>rules</a> are executed, within the same <a>layer</a>, <a>rules</a> with larger order values will be executed after those with smaller values. The inferred triples of one rule (or group of same-order rules) become immediately visible to the subsequent rule (or group of same-order rules) in the order.
-					Rules with the same order are executed concurrently and must not see each other's inferences before they have all completed. The sets of triples individually inferred by these rules are then _unioned_ to produce the inferred graph.
+					When the <a>rules</a> are executed, within the same <a>layer</a>, <a>rules</a> with larger order values will be executed after those with smaller values.
+					The inferred triples of one rule (or group of same-order rules) become immediately visible to the subsequent rule (or group of same-order rules) in the order.
+					Rules with the same order are executed concurrently and must not see each other's inferences before they have all completed.
+					The sets of triples individually inferred by these rules are merged into the inference graph.
 				</p>
 				<aside class="example" title="Rule order example">
 					<div class="shapes-graph">

--- a/shacl12-test-suite/tests/inference-rules/manifest.ttl
+++ b/shacl12-test-suite/tests/inference-rules/manifest.ttl
@@ -13,6 +13,7 @@
 	mf:include <rectangle-prefixes.ttl> ;
 	mf:include <rectangle-simple.ttl> ;
 	mf:include <run-once-example.ttl> ;
+	mf:include <same-order.ttl> ;
 	mf:include <temp-triples-example.ttl> ;
 	mf:include <TripleRule-example-childCount.ttl> ;
 	mf:include <TripleRule-example-squares.ttl> ;

--- a/shacl12-test-suite/tests/inference-rules/same-order.ttl
+++ b/shacl12-test-suite/tests/inference-rules/same-order.ttl
@@ -1,0 +1,52 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:
+  a sh:RulesGraph ;
+  sh:declare [
+      sh:namespace "http://example.com/ns#" ;
+      sh:prefix "ex" ;
+    ] .
+
+ex:RuleP
+    a sh:SPARQLRule ;
+    sh:construct """
+        CONSTRUCT { ?this ex:p true }
+        WHERE { ?this a ex:Node . FILTER NOT EXISTS { ?this ex:q true } }
+        """ .
+
+ex:RuleQ
+    a sh:SPARQLRule ;
+    sh:construct """
+        CONSTRUCT { ?this ex:q true }
+        WHERE { ?this a ex:Node . FILTER NOT EXISTS { ?this ex:p true } }
+        """ .
+
+ex:SomeNode
+    a ex:Node .
+
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <same-order>
+    ) .
+
+<same-order>
+  rdf:type sht:Infer ;
+  rdfs:label "Test of two rules that have the same order (and layer), making sure they don't see each other's triples" ;
+  rdfs:seeAlso <https://github.com/w3c/data-shapes/issues/1226#issue-5313787732> ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result (
+    ( ex:SomeNode ex:p true )
+    ( ex:SomeNode ex:q true )
+  ) ;
+  mf:status sht:approved .


### PR DESCRIPTION
As a starting point for a reworking of same-order logic, I have added a test case that is using Oggy's example. Both triples will always be inferred.

Could someone else extend this PR to update the text or are there already parallel branches for that? In the latter case, I suggest we merge this here into them.