### PR TITLE
GH#1234: Allow `sh:name` and `sh:description` on node shapes

### DIFF
--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5960,7 +5960,7 @@ ex:PersonShape
 				</aside>
 
 				<p class="note">
-					<code>sh:name</code> and other label properties (<code>rdfs:label</code>, <code>skosprefLabel</code>, etc.) are complementary.
+					<code>sh:name</code> and other label properties (<code>rdfs:label</code>, <code>skos:prefLabel</code>, etc.) are complementary.
 					Other label properties name the shape resource itself.
 					<code>sh:name</code> is not intended to name the shape resource, but rather
 					the shape's defining characteristic, as described above.
@@ -5987,10 +5987,6 @@ ex:SocialNetworkParticipantShape
 				</aside>
 
 				<p>
-					If present, tools should prefer such locally specified names
-					over globally specified labels at the <code>rdf:Property</code> or the <code>rdfs:Class</code> itself.
-					For example, if a form displays a node that is in the target of a given property shape
-					with an <code>sh:name</code>, then the tool should use the provided name.
 					The <a>values</a> of <code>sh:name</code> must be <a>literals</a> with <a>datatype</a>
 					<code>xsd:string</code>, <code>rdf:dirLangString</code>, or <code>rdf:langString</code>.
 				</p>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5982,7 +5982,7 @@ ex:TargetSubjectsOfExampleShape
 				</p>
 				<p>
 					Similarly, shapes may have values for <code id="description">sh:description</code>
-					to provide descriptions of the property or node in the given context.
+					to provide descriptions of the property or target in the given context.
 					The <a>values</a> of <code>sh:description</code> must be <a>literals</a> with <a>datatype</a>
 					<code>xsd:string</code>, <code>rdf:dirLangString</code>, <code>rdf:langString</code>, or <code>rdf:HTML</code>.
 				</p>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5936,11 +5936,14 @@ ex:Concept2
 				<h3>sh:name and sh:description</h3>
 				<p>
 					Shapes may have one or more <a>values</a> for <code>sh:name</code>
-					to provide human-readable labels:
+					to provide a human-readable name for the shape's defining characteristic,
+					i.e. the property path in the case of a property shape,
+					or the kind of resource targeted by a node shape:
 				</p>
 				<ul>
-					<li>For property shapes, it is the label of the property path in the target where it appears.</li>
-					<li>For node shapes, it is the label of the shape's target nodes.</li>
+					<li>For property shapes, <code>sh:name</code> names the property path.</li>
+					<li>For node shapes, <code>sh:name</code> names what the shape's targets have in common,
+						i.e. the kind of resource described by the shape's constraints.</li>
 				</ul>
 
 
@@ -5958,10 +5961,12 @@ ex:PersonShape
 
 				<p class="note">
 					<code>sh:name</code> and <code>rdfs:label</code> are complementary.
-					<code>rdfs:label</code> specifies a label for the shape. <code>sh:name</code> does not.
+					<code>rdfs:label</code> names the shape resource itself.
+					<code>sh:name</code> is not intended to name the shape resource, but rather
+					the shape's defining characteristic, as described above.
 				</p>
 
-				<aside class="example" title="An example distinguishing labels for the shape from labels for its targets">
+				<aside class="example" title="An example distinguishing rdfs:label for the shape from sh:name for what it characterizes">
 					<div class="shapes-graph">
 						<div class="turtle">
 ex:SocialNetworkParticipantShape
@@ -5970,11 +5975,11 @@ ex:SocialNetworkParticipantShape
 	sh:targetSubjectsOf ex:knows ;
 	sh:targetObjectsOf ex:knows ;
 
-	# The following describe the shape itself
+	# The following name and describe the shape resource itself
 	rdfs:label "Social Network Participant Shape" ;
 	rdfs:comment "The constraints to apply to all participants in a social network." ;
 
-	# The following describe the shape's targets
+	# The following name and describe the kind of resource the shape's constraints characterize
 	sh:name "Social Network Participant" ;
 	sh:description "A participant in a social network." .
 						</div>
@@ -5982,7 +5987,7 @@ ex:SocialNetworkParticipantShape
 				</aside>
 
 				<p>
-					If present, tools should prefer such locally specified labels
+					If present, tools should prefer such locally specified names
 					over globally specified labels at the <code>rdf:Property</code> or the <code>rdfs:Class</code> itself.
 					For example, if a form displays a node that is in the target of a given property shape
 					with an <code>sh:name</code>, then the tool should use the provided name.
@@ -5991,11 +5996,11 @@ ex:SocialNetworkParticipantShape
 				</p>
 				<p>
 					Similarly, shapes may have values for <code id="description">sh:description</code>
-					to provide descriptions:
+					to provide a human-readable description of the same defining characteristic:
 				</p>
 				<ul>
-					<li>For property shapes, it is the description of the property path in the given context.</li>
-					<li>For node shapes, it is the description of the shape's target nodes.</li>
+					<li>For property shapes, a description of the property path in the given context.</li>
+					<li>For node shapes, a description of the kind of resource described by the shape's constraints.</li>
 				</ul>
 				<p>
 					The <a>values</a> of <code>sh:description</code> must be <a>literals</a> with <a>datatype</a>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5935,29 +5935,60 @@ ex:Concept2
 			<section id="name">
 				<h3>sh:name and sh:description</h3>
 				<p>
-					Property shapes may have one or more <a>values</a> for <code>sh:name</code>
-					to provide human-readable labels for the property in the target where it appears.
+					Shapes may have one or more <a>values</a> for <code>sh:name</code>
+					to provide human-readable labels.
+					In case of property shapes it is the label of the property in the target where it appears.
+					In case of node shapes, it is the label of the shape's target.
+				</p>
+
+
+				<aside class="example" title="A simple example of sh:name">
+					<div class="shapes-graph">
+						<div class="turtle">
+ex:PersonShape
+	a sh:NodeShape ;
+	sh:name "Person" ;
+	rdfs:label "Person shape v3.2" ;
+	sh:targetClass ex:Person .
+						</div>
+					</div>
+				</aside>
+
+				<aside class="example" title="An example of a subjects-of target with sh:name">
+					<div class="shapes-graph">
+						<div class="turtle">
+ex:TargetSubjectsOfExampleShape
+	a sh:NodeShape ;
+	sh:name "Subjects that know someone" ;
+	rdfs:label "Subjects that know someone shape v3.2" ;
+	sh:targetSubjectsOf ex:knows .
+						</div>
+					</div>
+				</aside>
+
+				<p class="note">
+					<code>sh:name</code> and <code>rdfs:label</code> are complementary.
+					<code>rdfs:label</code> specifies a label for the shape. <code>sh:name</code> does not.
+				</p>
+
+
+				<p>
 					If present, tools should prefer such locally specified labels
-					over globally specified labels at the <code>rdf:Property</code> itself.
+					over globally specified labels at the <code>rdf:Property</code> or the <code>rdfs:Class</code> itself.
 					For example, if a form displays a node that is in the target of a given property shape
 					with an <code>sh:name</code>, then the tool should use the provided name.
 					The <a>values</a> of <code>sh:name</code> must be <a>literals</a> with <a>datatype</a>
 					<code>xsd:string</code>, <code>rdf:dirLangString</code>, or <code>rdf:langString</code>.
 				</p>
 				<p>
-					Similarly, property shapes may have values for <code id="description">sh:description</code>
-					to provide descriptions of the property in the given context.
+					Similarly, shapes may have values for <code id="description">sh:description</code>
+					to provide descriptions of the property or node in the given context.
 					The <a>values</a> of <code>sh:description</code> must be <a>literals</a> with <a>datatype</a>
 					<code>xsd:string</code>, <code>rdf:dirLangString</code>, <code>rdf:langString</code>, or <code>rdf:HTML</code>.
 				</p>
 				<p>
 					Both <code>sh:name</code> and <code>sh:description</code> may have
 					multiple <a>values</a>, but should only have one <a>value</a> per language tag.
-				</p>
-				<p>
-					Note that <code>sh:name</code> and <code>sh:description</code> should NOT be used for <a>node shapes</a>.
-					For those, the properties <code>rdfs:label</code> and <code>rdfs:comment</code> are well-established
-					and already used for class definitions.
 				</p>
 			</section>
 			<section id="intent">

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5936,10 +5936,12 @@ ex:Concept2
 				<h3>sh:name and sh:description</h3>
 				<p>
 					Shapes may have one or more <a>values</a> for <code>sh:name</code>
-					to provide human-readable labels.
-					In case of property shapes it is the label of the property in the target where it appears.
-					In case of node shapes, it is the label of the shape's target.
+					to provide human-readable labels:
 				</p>
+				<ul>
+					<li>For property shapes, it is the label of the property path in the target where it appears.</li>
+					<li>For node shapes, it is the label of the shape's target nodes.</li>
+				</ul>
 
 
 				<aside class="example" title="A simple example of sh:name">
@@ -5954,23 +5956,30 @@ ex:PersonShape
 					</div>
 				</aside>
 
-				<aside class="example" title="An example of a subjects-of target with sh:name">
-					<div class="shapes-graph">
-						<div class="turtle">
-ex:TargetSubjectsOfExampleShape
-	a sh:NodeShape ;
-	sh:name "Subjects that know someone" ;
-	rdfs:label "Subjects that know someone shape v3.2" ;
-	sh:targetSubjectsOf ex:knows .
-						</div>
-					</div>
-				</aside>
-
 				<p class="note">
 					<code>sh:name</code> and <code>rdfs:label</code> are complementary.
 					<code>rdfs:label</code> specifies a label for the shape. <code>sh:name</code> does not.
 				</p>
 
+				<aside class="example" title="An example distinguishing labels for the shape from labels for its targets">
+					<div class="shapes-graph">
+						<div class="turtle">
+ex:SocialNetworkParticipantShape
+	a sh:NodeShape ;
+	sh:targetClass ex:Person ;
+	sh:targetSubjectsOf ex:knows ;
+	sh:targetObjectsOf ex:knows ;
+
+	# The following describe the shape itself
+	rdfs:label "Social Network Participant Shape" ;
+	rdfs:comment "The constraints to apply to all participants in a social network." ;
+
+	# The following describe the shape's targets
+	sh:name "Social Network Participant" ;
+	sh:description "A participant in a social network." .
+						</div>
+					</div>
+				</aside>
 
 				<p>
 					If present, tools should prefer such locally specified labels
@@ -5982,7 +5991,13 @@ ex:TargetSubjectsOfExampleShape
 				</p>
 				<p>
 					Similarly, shapes may have values for <code id="description">sh:description</code>
-					to provide descriptions of the property or target in the given context.
+					to provide descriptions:
+				</p>
+				<ul>
+					<li>For property shapes, it is the description of the property path in the given context.</li>
+					<li>For node shapes, it is the description of the shape's target nodes.</li>
+				</ul>
+				<p>
 					The <a>values</a> of <code>sh:description</code> must be <a>literals</a> with <a>datatype</a>
 					<code>xsd:string</code>, <code>rdf:dirLangString</code>, <code>rdf:langString</code>, or <code>rdf:HTML</code>.
 				</p>

--- a/shacl12-core/index.html
+++ b/shacl12-core/index.html
@@ -5960,8 +5960,8 @@ ex:PersonShape
 				</aside>
 
 				<p class="note">
-					<code>sh:name</code> and <code>rdfs:label</code> are complementary.
-					<code>rdfs:label</code> names the shape resource itself.
+					<code>sh:name</code> and other label properties (<code>rdfs:label</code>, <code>skosprefLabel</code>, etc.) are complementary.
+					Other label properties name the shape resource itself.
 					<code>sh:name</code> is not intended to name the shape resource, but rather
 					the shape's defining characteristic, as described above.
 				</p>

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1863,8 +1863,8 @@ sh:defaultValue
 sh:description
 	a rdf:Property ;
 	rdfs:label "description"@en ;
-	rdfs:comment "Human-readable descriptions for the property in the context of the surrounding shape."@en ;
-	rdfs:domain sh:PropertyShape ;
+	rdfs:comment "Human-readable descriptions for the property or the target in the context of the surrounding shape."@en ;
+	rdfs:domain sh:Shape ;
 	# range: xsd:string or rdf:dirLangString or rdf:langString or rdf:HTML
 	rdfs:isDefinedBy sh: .
 
@@ -1893,8 +1893,8 @@ sh:intent
 sh:name
 	a rdf:Property ;
 	rdfs:label "name"@en ;
-	rdfs:comment "Human-readable labels for the property in the context of the surrounding shape."@en ;
-	rdfs:domain sh:PropertyShape ;
+	rdfs:comment "Human-readable labels for the property or the target in the context of the surrounding shape."@en ;
+	rdfs:domain sh:Shape ;
 	# range: xsd:string or rdf:dirLangString or rdf:langString
 	rdfs:isDefinedBy sh: .
 

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1863,7 +1863,7 @@ sh:defaultValue
 sh:description
 	a rdf:Property ;
 	rdfs:label "description"@en ;
-	rdfs:comment "Human-readable descriptions for the property path (for property shapes) or the target nodes (for node shapes). Not to be used as description of the shape itself."@en ;
+	rdfs:comment "A human-readable description of a shape's defining characteristic: the property path for property shapes, or the kind of resource described by its constraints for node shapes. Not intended as a description of the shape resource itself; use rdfs:comment for that."@en ;
 	rdfs:domain sh:Shape ;
 	# range: xsd:string or rdf:dirLangString or rdf:langString or rdf:HTML
 	rdfs:isDefinedBy sh: .
@@ -1893,7 +1893,7 @@ sh:intent
 sh:name
 	a rdf:Property ;
 	rdfs:label "name"@en ;
-	rdfs:comment "Human-readable labels for the property path (for property shapes) or the target nodes (for node shapes). Not to be used as labels for the shape itself."@en ;
+	rdfs:comment "A human-readable name for a shape's defining characteristic: the property path for property shapes, or the kind of resource described by its constraints for node shapes. Not intended as a label for the shape resource itself; use rdfs:label for that."@en ;
 	rdfs:domain sh:Shape ;
 	# range: xsd:string or rdf:dirLangString or rdf:langString
 	rdfs:isDefinedBy sh: .

--- a/shacl12-vocabularies/shacl.ttl
+++ b/shacl12-vocabularies/shacl.ttl
@@ -1863,7 +1863,7 @@ sh:defaultValue
 sh:description
 	a rdf:Property ;
 	rdfs:label "description"@en ;
-	rdfs:comment "Human-readable descriptions for the property or the target in the context of the surrounding shape."@en ;
+	rdfs:comment "Human-readable descriptions for the property path (for property shapes) or the target nodes (for node shapes). Not to be used as description of the shape itself."@en ;
 	rdfs:domain sh:Shape ;
 	# range: xsd:string or rdf:dirLangString or rdf:langString or rdf:HTML
 	rdfs:isDefinedBy sh: .
@@ -1893,7 +1893,7 @@ sh:intent
 sh:name
 	a rdf:Property ;
 	rdfs:label "name"@en ;
-	rdfs:comment "Human-readable labels for the property or the target in the context of the surrounding shape."@en ;
+	rdfs:comment "Human-readable labels for the property path (for property shapes) or the target nodes (for node shapes). Not to be used as labels for the shape itself."@en ;
 	rdfs:domain sh:Shape ;
 	# range: xsd:string or rdf:dirLangString or rdf:langString
 	rdfs:isDefinedBy sh: .


### PR DESCRIPTION
<!--
# Pull request instructions
(Note that text between the HTML comments will be recorded in this pull request's source for future editing, but will not render on Github.  Text is suggested with portions needing substitution enclosed in curly braces.  The curly braces also need to be removed when substituting.)

Please use "Closing keywords" for the associated Issue if this PR should close the Issue once merged.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

If this PR edits a document, please consider including a "Live render."  The non-comment template text suggests one mechanism.  If including the link line(s), please test-load the link(s) while drafting the PR.
-->

- Broadens the domain of sh:name and sh:description to sh:Shape
- Clears up confusion between rdfs:label and sh:name
- Broadens prose about sh:name and sh:description to include node shapes
- Added basic example containing sh:name and rdfs:label
- Added example of sh:name in case of different targeting mechanism than sh:targetClass

Closes #1234

* [See this document rendered online here](https://raw.githack.com/w3c/data-shapes/allow-sh-name-description-on-node-shapes/shacl12-core/index.html#name)
